### PR TITLE
Test that exceptions are thrown

### DIFF
--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -62,7 +62,7 @@ module FFI
             "jl_in_threaded_region", "jl_enter_threaded_region", "jl_exit_threaded_region", "jl_set_task_tid", "jl_new_task",
             "malloc", "memmove", "memcpy", "jl_array_grow_beg", "jl_array_grow_end", "jl_array_grow_at", "jl_array_del_beg",
             "jl_array_del_end", "jl_array_del_at", "jl_array_ptr", "jl_value_ptr", "jl_get_ptls_states", "jl_gc_add_finalizer_th",
-            "jl_symbol_n"
+            "jl_symbol_n", "jl_"
         )
         for name in known_names
             sym = LLVM.find_symbol(name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,6 +99,14 @@ end
     @test autodiff((x)->log(x), Active(2.0)) == (0.5,)
 end
 
+@testset "Simple Exception" begin
+    f_simple_exc(x, i) = ccall(:jl_, Cvoid, (Any,), x[i])
+    y = [1.0, 2.0]
+    f_x = zero.(y)
+    @test_throws BoundsError autodiff(f_simple_exc, Duplicated(y, f_x), 0)
+end
+
+
 @testset "Duplicated" begin
     x = Ref(1.0)
     y = Ref(2.0)


### PR DESCRIPTION
@wsmoses you assume to much.

```
julia> Enzyme.Compiler.enzyme_code_llvm(f_simple_exc, Const, Tuple{Duplicated{Vector{Float64}}, Const{Int}})
; Function Attrs: alwaysinline
define void @diffejulia_f_simple_exc_2215.inner.5wrap({}* %0, {}* %1, i64 %2) #5 {
entry:
  %gcframe2 = alloca [3 x {}*], align 16
  %gcframe2.sub = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe2, i64 0, i64 0
  %3 = bitcast [3 x {}*]* %gcframe2 to i8*
  call void @llvm.memset.p0i8.i32(i8* nonnull align 16 dereferenceable(24) %3, i8 0, i32 24, i1 false)
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #7
  %ppgcstack_i8 = getelementptr i8, i8* %thread_ptr, i64 -8
  %ppgcstack = bitcast i8* %ppgcstack_i8 to {}****
  %pgcstack = load {}***, {}**** %ppgcstack, align 8
;  @ REPL[2] within `f_simple_exc` @ REPL[2]:1
; ┌ @ array.jl:861 within `getindex`
   %4 = bitcast [3 x {}*]* %gcframe2 to i64*
   store i64 4, i64* %4, align 16
   %5 = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe2, i64 0, i64 1
   %6 = bitcast {}** %5 to {}***
   %7 = load {}**, {}*** %pgcstack, align 8
   store {}** %7, {}*** %6, align 8
   %8 = bitcast {}*** %pgcstack to {}***
   store {}** %gcframe2.sub, {}*** %8, align 8
   %9 = add i64 %2, -1
   %10 = bitcast {}* %0 to { i8*, i64, i16, i16, i32 }*
   %11 = getelementptr inbounds { i8*, i64, i16, i16, i32 }, { i8*, i64, i16, i16, i32 }* %10, i64 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = icmp ult i64 %9, %12
   call void @llvm.assume(i1 %13)
   %14 = bitcast {}* %0 to double**
   %15 = load double*, double** %14, align 16
   %16 = getelementptr inbounds double, double* %15, i64 %9
   %17 = load double, double* %16, align 8
; └
  %ptls_field.i3.i = getelementptr inbounds {}**, {}*** %pgcstack, i64 2305843009213693954
  %18 = bitcast {}*** %ptls_field.i3.i to i8**
  %ptls_load.i45.i = load i8*, i8** %18, align 8
  %19 = call noalias nonnull {}* @jl_gc_pool_alloc(i8* %ptls_load.i45.i, i32 1392, i32 16) #8
  %20 = bitcast {}* %19 to i64*
  %21 = getelementptr inbounds i64, i64* %20, i64 -1
  store atomic i64 140178320221600, i64* %21 unordered, align 8
  %22 = bitcast {}* %19 to double*
  store double %17, double* %22, align 8
  %23 = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe2, i64 0, i64 2
  store {}* %19, {}** %23, align 16
  call void inttoptr (i64 140178635388480 to void ({}*)*)({}* nonnull %19) #9
  call void inttoptr (i64 140178635388480 to void ({}*)*)({}* nonnull %19)
  %24 = load {}*, {}** %5, align 8
  %25 = bitcast {}*** %pgcstack to {}**
  store {}* %24, {}** %25, align 8
  ret void
}
```
