### PR TITLE
Add simple CUDA test

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Enzyme_jll = "7cc45869-7501-5eee-bdea-0790c847d4ef"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
@@ -6,4 +8,3 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Enzyme_jll = "7cc45869-7501-5eee-bdea-0790c847d4ef"

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,0 +1,25 @@
+using CUDA
+using Enzyme
+using Test
+
+function mul_kernel(A)
+    i = threadIdx().x
+    if i <= length(A)
+        A[i] *= A[i]
+    end
+    return nothing
+end
+
+function grad_mul_kernel(A, dA)
+    Enzyme.autodiff_deferred(mul_kernel, Const, Duplicated(A, dA))
+    return nothing
+end
+
+@testset "mul_kernel" begin
+    A = CUDA.ones(64,)
+    @cuda threads=length(A) mul_kernel(A)
+    dA = similar(A)
+    dA .= 1
+    @cuda threads=length(A) grad_mul_kernel(A, dA)
+    @test all(dA .== 2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -835,3 +835,8 @@ end
     @test x ≈ [2.3, 2.0]
     @test dx ≈ [1.0]
 end
+
+using CUDA
+if CUDA.functional()
+    include("cuda.jl")
+end


### PR DESCRIPTION
Currently fails with :
```
julia> @cuda threads=length(A) grad_mul_kernel(A, dA)
ERROR: BoundsError: attempt to access 0-element LLVM.FunctionParameterSet at index [1]
Stacktrace:
  [1] getindex
    @ ~/.julia/packages/LLVM/tVv0H/src/core/function.jl:97 [inlined]
  [2] (::GPUCompiler.var"#74#75"{LLVM.Function, LLVM.Function, DataType, LLVM.Context})(builder::LLVM.Builder)
    @ GPUCompiler ~/.julia/packages/GPUCompiler/1FdJy/src/irgen.jl:784
  [3] LLVM.Builder(f::GPUCompiler.var"#74#75"{LLVM.Function, LLVM.Function, DataType, LLVM.Context}, args::LLVM.Context; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ LLVM ~/.julia/packages/LLVM/tVv0H/src/irbuilder.jl:21
  [4] Builder
    @ ~/.julia/packages/LLVM/tVv0H/src/irbuilder.jl:19 [inlined]
  [5] lower_kernel_state!(fun::LLVM.Function)
    @ GPUCompiler ~/.julia/packages/GPUCompiler/1FdJy/src/irgen.jl:770
  [6] function_pass_callback(ptr::Ptr{Nothing}, data::Ptr{Nothing})
    @ LLVM ~/.julia/packages/LLVM/tVv0H/src/pass.jl:49
  [7] LLVMRunPassManager
    @ ~/.julia/packages/LLVM/tVv0H/lib/12/libLLVM_h.jl:4741 [inlined]
  [8] run!
    @ ~/.julia/packages/LLVM/tVv0H/src/passmanager.jl:39 [inlined]
  [9] (::GPUCompiler.var"#81#84"{GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams, GPUCompiler.FunctionSpec{typeof(grad_mul_kernel), Tuple{CuDeviceVector{Float32, 1}, CuDeviceVector{Float32, 1}}}}, LLVM.Module, LLVM.TargetMachine, String})(pm::LLVM.ModulePassManager)
    @ GPUCompiler ~/.julia/packages/GPUCompiler/1FdJy/src/optim.jl:239
 [10] LLVM.ModulePassManager(::GPUCompiler.var"#81#84"{GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams, GPUCompiler.FunctionSpec{typeof(grad_mul_kernel), Tuple{CuDeviceVector{Float32, 1}, CuDeviceVector{Float32, 1}}}}, LLVM.Module, LLVM.TargetMachine, String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ LLVM ~/.julia/packages/LLVM/tVv0H/src/passmanager.jl:33
```
