### PR TITLE
Fix type analysis on 1.8

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -201,6 +201,8 @@ EnzymeGradientUtilsIsConstantValue(gutils, val) = ccall((:EnzymeGradientUtilsIsC
 EnzymeGradientUtilsIsConstantInstruction(gutils, val) = ccall((:EnzymeGradientUtilsIsConstantInstruction, libEnzyme), UInt8, (EnzymeGradientUtilsRef, LLVMValueRef), gutils, val)
 EnzymeGradientUtilsAllocationBlock(gutils) = ccall((:EnzymeGradientUtilsAllocationBlock, libEnzyme), LLVM.API.LLVMBasicBlockRef, (EnzymeGradientUtilsRef,), gutils)
 
+EnzymeGradientUtilsTypeAnalyzer(gutils) = ccall((:EnzymeGradientUtilsTypeAnalyzer, libEnzyme), EnzymeTypeAnalyzerRef, (EnzymeGradientUtilsRef,), gutils)
+
 EnzymeGradientUtilsAllocAndGetTypeTree(gutils, val) = ccall((:EnzymeGradientUtilsAllocAndGetTypeTree, libEnzyme), CTypeTreeRef, (EnzymeGradientUtilsRef,LLVMValueRef), gutils, val)
 
 EnzymeGradientUtilsSubTransferHelper(gutils, mode, secretty, intrinsic, dstAlign, srcAlign, offset, dstConstant, origdst, srcConstant, origsrc, length, isVolatile, MTI, allowForward, shadowsLookedUp) = ccall((:EnzymeGradientUtilsSubTransferHelper, libEnzyme),

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1792,7 +1792,14 @@ function arraycopy_common(fwd, B, orig, origArg, gutils, shadowdst)
     ct = API.EnzymeTypeTreeInner0(tt)
 
     if ct == API.DT_Unknown
-        GPUCompiler.@safe_warn "Unknown concrete type" tt=string(tt)
+        analyzer = API.EnzymeGradientUtilsTypeAnalyzer(gutils)
+        ip = API.EnzymeTypeAnalyzerToString(analyzer)
+        sval = Base.unsafe_string(ip)
+        API.EnzymeStringFree(ip)
+        @show LLVM.parent(LLVM.parent(orig))
+        @show orig
+        println(sval)
+        GPUCompiler.@safe_warn "Unknown concrete type" tt=string(tt) orig=string(orig) sval=string(sval)
         emit_error(B, "Enzyme: Unknown concrete type in arraycopy_common")
         return nothing
     end
@@ -3129,28 +3136,40 @@ function enzyme!(job, mod, primalf, adjoint, mode, width, parallel, actualRetTyp
         "jl_box_float32" => @cfunction(f32_box_rule,
                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "ijl_box_float32" => @cfunction(f32_box_rule,
+                                           UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                   Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "jl_box_int64" => @cfunction(i64_box_rule,
+                                           UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                   Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "ijl_box_int64" => @cfunction(i64_box_rule,
                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "jl_box_uint64" => @cfunction(i64_box_rule,
                                             UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "ijl_box_uint64" => @cfunction(i64_box_rule,
+                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "jl_array_copy" => @cfunction(inout_rule,
+                                           UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                   Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "ijl_array_copy" => @cfunction(inout_rule,
                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "jl_alloc_array_1d" => @cfunction(alloc_rule,
                                             UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
-        "jl_alloc_array_2d" => @cfunction(alloc_rule,
-                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
-                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
-        "jl_alloc_array_3d" => @cfunction(alloc_rule,
-                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
-                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "ijl_alloc_array_1d" => @cfunction(alloc_rule,
                                             UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "jl_alloc_array_2d" => @cfunction(alloc_rule,
+                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "ijl_alloc_array_2d" => @cfunction(alloc_rule,
+                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "jl_alloc_array_3d" => @cfunction(alloc_rule,
                                             UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "ijl_alloc_array_3d" => @cfunction(alloc_rule,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1431,6 +1431,7 @@ end
 
     ops = collect(operands(orig))[1:end-1]
 
+	vals = LLVM.Value[]
     if !GPUCompiler.isghosttype(funcT) && !Core.Compiler.isconstType(funcT)
 		for real in [ LLVM.Value(API.EnzymeGradientUtilsNewFromOriginal(gutils, ops[1])), LLVM.Value(API.EnzymeGradientUtilsInvertPointer(gutils, ops[1], B))]
 			push!(vals, real)
@@ -1792,14 +1793,11 @@ function arraycopy_common(fwd, B, orig, origArg, gutils, shadowdst)
     ct = API.EnzymeTypeTreeInner0(tt)
 
     if ct == API.DT_Unknown
-        analyzer = API.EnzymeGradientUtilsTypeAnalyzer(gutils)
-        ip = API.EnzymeTypeAnalyzerToString(analyzer)
-        sval = Base.unsafe_string(ip)
-        API.EnzymeStringFree(ip)
-        @show LLVM.parent(LLVM.parent(orig))
-        @show orig
-        println(sval)
-        GPUCompiler.@safe_warn "Unknown concrete type" tt=string(tt) orig=string(orig) sval=string(sval)
+        # analyzer = API.EnzymeGradientUtilsTypeAnalyzer(gutils)
+        # ip = API.EnzymeTypeAnalyzerToString(analyzer)
+        # sval = Base.unsafe_string(ip)
+        # API.EnzymeStringFree(ip)
+        GPUCompiler.@safe_warn "Unknown concrete type" tt=string(tt) orig=string(orig)
         emit_error(B, "Enzyme: Unknown concrete type in arraycopy_common")
         return nothing
     end


### PR DESCRIPTION
Requires https://github.com/EnzymeAD/Enzyme/pull/673 for the nicer method

Fixes issue from https://github.com/EnzymeAD/Enzyme.jl/pull/331

@vchuravy I've also now added the infra to get a better error message (namely the type dump of what's missing). Currently there's a compile time warning and a runtime error. We now have enough info to create the thrown error from the other PR. Probably the best thing is to throw that error at runtime (with full trace, etc). I'm not very opinionated on the best way to do this, so take a look?