### PR TITLE
Use LLVM.@dispose instead of do-block resource handling

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5429,7 +5429,7 @@ function lower_convention(
         LLVM.run!(pb, mod)
     end
 
-    ModulePassManager() do pm
+    @dispose pm = ModulePassManager() begin
         LLVM.run!(pm, mod)
     end
     if haskey(globals(mod), "llvm.used")
@@ -7231,7 +7231,7 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
         primal_name = nothing
     end
 
-    LLVM.ModulePassManager() do pm
+    LLVM.@dispose pm = LLVM.ModulePassManager() begin
         add!(pm, FunctionPass("ReinsertGCMarker", reinsert_gcmarker_pass!))
         LLVM.run!(pm, mod)
     end

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -149,7 +149,7 @@ function move_to_threadsafe(ir)
     buf = convert(MemoryBuffer, ir)
 
     # 2. deserialize and wrap by a ThreadSafeModule
-    return ThreadSafeContext() do ctx
+    return @dispose ctx = ThreadSafeContext() begin
         mod = parse(LLVM.Module, buf)
         ThreadSafeModule(mod)
     end


### PR DESCRIPTION
Replaces the remaining `ModulePassManager() do` and `ThreadSafeContext() do` blocks with `LLVM.@dispose`, which does the same acquire/release via `try`/`finally` without allocating a closure per call.

The `GPUCompiler.JuliaContext() do` sites are deliberately left as-is: the do-form hands the body the inner `LLVM.Context` and activates it, while the no-arg constructor returns an unactivated `ThreadSafeContext`, so the two are not interchangeable.

(Rebase of a stale 2022 PR; most of the original diff targeted the legacy pass manager and no longer applies.)