### PR TITLE
Attempt to provide a better error for undef sret

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -4960,9 +4960,15 @@ end
 # Box
 ##
 
+zeroof(::Type{T}) where T = Base.zero(T)
+zeroof(::Type{<:NamedTuple{names, TT}}) where {names, TT} = NamedTuple{names}(zeroof(TT))
+zeroof(::Type{TT}) where TT<:Tuple = (map(T->zeroof(T), TT.parameters)...,)
+zeroof(::Type{Symbol}) = Symbol("")
+zeroof(::Type{String}) = ""
+
 mutable struct Box{T} <: Base.Ref{T}
     x::T
-    Box{T}() where {T} = new()
+    Box{T}() where {T} = new(zeroof(T))
     Box{T}(x) where {T} = new(x)
 end
 


### PR DESCRIPTION
I was thinking if we can find which values weren't initalized by Enzyme for the shadow
sret we could fix them up with fictious values instead of Julia throwing an error, but
I haven't found a solution yet since for some values we can't take a pointer `Symbol`...

x-ref: #347
