### PR TITLE
vc/fix 1.9

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -530,7 +530,7 @@ end
     end
     return args
 end
-@inline function wrap_annotated_args(forwardMode, start, arg_ptr, shadow_ptr::Ptr{Any}, activity_ptr::Ptr{UInt8}, ::Val{width}) where {width,AddrSpace}
+@inline function wrap_annotated_args(forwardMode, start, arg_ptr, shadow_ptr::Ptr{Any}, activity_ptr::Ptr{UInt8}, ::Val{width}) where {width}
     # Note: We shall not unsafe_wrap any of the Ptr{Any}, since these are stack allocations
     #       As an example, if the Array created by unsafe_wrap get's moved to the remset it
     #       will constitute a leak of the stack allocation, and GC will find delicous garbage.
@@ -3433,7 +3433,7 @@ from_tape_type(::Type{T}, ctx) where T<:Integer = convert(LLVMType, T; ctx)
 from_tape_type(::Type{NTuple{Size, T}}, ctx) where {Size, T} = LLVM.ArrayType(from_tape_type(T, ctx), Size)
 from_tape_type(::Type{Core.LLVMPtr{T, Addr}}, ctx) where {T, Addr} = LLVM.PointerType(from_tape_type(UInt8, ctx), Addr)
 # from_tape_type(::Type{Core.LLVMPtr{T, Addr}}, ctx) where {T, Addr} = LLVM.PointerType(from_tape_type(T, ctx), Addr)
-from_tape_type(::Type{Any}, ctx) where {T, Addr} = LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[]; ctx), 10)
+from_tape_type(::Type{Any}, ctx) = LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[]; ctx), 10)
 function from_tape_type(::Type{NamedTuple{A,B}}, ctx) where {A,B}
     if length(B.parameters) >= 1 && all(B.parameters[1] == b for b in B.parameters)
         return LLVM.ArrayType(from_tape_type(B.parameters[1], ctx), length(B.parameters))

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3444,7 +3444,11 @@ end
 const Tracked = 10
 
 # TODO: Calculate that constant... see get_current_task
-current_task_offset() = -12
+if VERSION >= v"1.9.0-"
+  current_task_offset() = -13
+else
+  current_task_offset() = -12
+end
 current_ptls_offset() = 14
 
 function julia_post_cache_store(SI::LLVM.API.LLVMValueRef, B::LLVM.API.LLVMBuilderRef, R2)::Ptr{LLVM.API.LLVMValueRef}


### PR DESCRIPTION
- Fix current_task_offset on 1.9
- Remove unecessary type args
