### PR TITLE
Fix seqfault in emission of NVPTX due to missing DIsubprogram

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5259,9 +5259,9 @@ function create_abi_wrapper(enzymefn::LLVM.Function, F, argtypes, rettype, actua
     FT = LLVM.FunctionType(T_ret, T_wrapperargs)
     llvm_f = LLVM.Function(mod, safe_name(LLVM.name(enzymefn)*"wrap"), FT)
     sfn = LLVM.get_subprogram(enzymefn)
-    # if sfn !== nothing
-    #     LLVM.set_subprogram!(llvm_f, sfn)
-    # end
+    if sfn !== nothing
+        LLVM.set_subprogram!(llvm_f, sfn)
+    end
     dl = datalayout(mod)
 
     params = [parameters(llvm_f)...]


### PR DESCRIPTION
Fixes #576

@wsmoses now the only question is: Why is CI passing.
