### PR TITLE
Cleanup deferred

### DIFF
--- a/docs/src/pullbacks.md
+++ b/docs/src/pullbacks.md
@@ -33,7 +33,7 @@ R = zeros(size(A,1), size(B,2))
 ∂z_∂A = zero(A)
 ∂z_∂B = zero(B)
 
-Enzyme.autodiff(mymul!, Const, Duplicated(R, ∂z_∂R), Duplicated(A, ∂z_∂A), Duplicated(B, ∂z_∂B))
+Enzyme.autodiff(Reverse, mymul!, Const, Duplicated(R, ∂z_∂R), Duplicated(A, ∂z_∂A), Duplicated(B, ∂z_∂B))
 ```
 
 Now we have:

--- a/examples/autodiff.jl
+++ b/examples/autodiff.jl
@@ -98,7 +98,7 @@ dby = [0.0]
 
 Enzyme.autodiff(
     Forward,
-    (x,y) -> Enzyme.autodiff_deferred(f, x, y),
+    (x,y) -> Enzyme.autodiff_deferred(Reverse, f, x, y),
     Duplicated(Duplicated(x, bx), Duplicated(dx, dbx)),
     Duplicated(Duplicated(y, by), Duplicated(dy, dby)),
 )
@@ -129,7 +129,7 @@ vdby = ([0.0], [0.0]);
 # on our tuples of `Duplicated` for the tangents.
 Enzyme.autodiff(
     Forward,
-    (x,y) -> Enzyme.autodiff_deferred(f, x, y),
+    (x,y) -> Enzyme.autodiff_deferred(Reverse, f, x, y),
     BatchDuplicated(Duplicated(x, bx), Duplicated.(vdx, vdbx)),
     BatchDuplicated(Duplicated(y, by), Duplicated.(vdy, vdby)),
 );

--- a/examples/autodiff.jl
+++ b/examples/autodiff.jl
@@ -41,7 +41,7 @@ by = [1.0];
 # `Duplicated` where the first element represent the value and the second the
 # adjoint. Evaluating the reverse model using Enzyme is done via the following
 # call.
-Enzyme.autodiff(f, Duplicated(x, bx), Duplicated(y, by));
+Enzyme.autodiff(Reverse, f, Duplicated(x, bx), Duplicated(y, by));
 # This yields the gradient of `f` in `bx` at point `x = [2.0, 2.0]`. `by` is called the seed and has
 # to be set to ``1.0`` in order to compute the gradient. Let's save the gradient for later.
 g = copy(bx)

--- a/examples/box.jl
+++ b/examples/box.jl
@@ -274,7 +274,7 @@ din_now = zeros(6)
 din_old = zeros(6)
 out_now = zeros(6); dout_now = ones(6)
 out_old = zeros(6); dout_old = ones(6)
-autodiff(forward_func_4_AD, Duplicated([Tbar; Sbar], din_now), Duplicated([Tbar; Sbar], din_old), 
+autodiff(Reverse, forward_func_4_AD, Duplicated([Tbar; Sbar], din_now), Duplicated([Tbar; Sbar], din_old), 
                     Duplicated(out_now, dout_now), Duplicated(out_old, dout_old));
 
 # In order to run Enzyme on `forward_func_4_AD`, we've needed to provide quite a few 
@@ -310,7 +310,7 @@ din_now_new = zeros(6)
 din_old_new = zeros(6)
 out_now = zeros(6); dout_now = 2*ones(6)
 out_old = zeros(6); dout_old = 2*ones(6)
-autodiff(forward_func_4_AD, Duplicated([Tbar; Sbar], din_now_new), Duplicated([Tbar; Sbar], din_old_new), 
+autodiff(Reverse, forward_func_4_AD, Duplicated([Tbar; Sbar], din_now_new), Duplicated([Tbar; Sbar], din_old_new), 
                     Duplicated(out_now, dout_now), Duplicated(out_old, dout_old));
 
 # Now checking din_now_new and din_old_new we see
@@ -367,7 +367,7 @@ for j = M:-1:1
     din_now = zeros(6)
     din_old = zeros(6)
 
-    autodiff(forward_func_4_AD, Duplicated(in_now[j], din_now), 
+    autodiff(Reverse, forward_func_4_AD, Duplicated(in_now[j], din_now), 
             Duplicated(in_old[j], din_old), Duplicated(zeros(6), dout_old), 
             Duplicated(zeros(6), dout_now))
     

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -11,7 +11,7 @@ function mul_kernel(A)
 end
 
 function grad_mul_kernel(A, dA)
-    Enzyme.autodiff_deferred(mul_kernel, Const, Duplicated(A, dA))
+    autodiff_deferred(Reverse, mul_kernel, Const, Duplicated(A, dA))
     return nothing
 end
 
@@ -34,7 +34,7 @@ function exp_kernel(A)
 end
 
 function grad_exp_kernel(A, dA)
-    Enzyme.autodiff_deferred(exp_kernel, Const, Duplicated(A, dA))
+    autodiff_deferred(Reverse, exp_kernel, Const, Duplicated(A, dA))
     return nothing
 end
 
@@ -57,7 +57,7 @@ function cos_kernel(A)
 end
 
 function grad_cos_kernel(A, dA)
-    Enzyme.autodiff_deferred(cos_kernel, Const, Duplicated(A, dA))
+    autodiff_deferred(Reverse, cos_kernel, Const, Duplicated(A, dA))
     return nothing
 end
 
@@ -76,7 +76,7 @@ function val_kernel!(_, ::Val{N}) where N
 end
 
 function dval_kernel!(du, ::Val{N}) where N
-    Enzyme.autodiff_deferred(val_kernel!, Const, du, Val(N))
+    autodiff_deferred(Reverse, val_kernel!, Const, du, Val(N))
     return nothing
 end
 
@@ -121,7 +121,8 @@ function ddense!(
   ::Val{nfeat_out}, ::Val{nfeat_in}, ::Val{ndof}
 ) where {nfeat_out, nfeat_in, ndof}
 
-  Enzyme.autodiff_deferred(
+  autodiff_deferred(
+    Reverse,
     dense!,
     Const,
     dfeats_out, dfeats_in, dW, db,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -307,7 +307,7 @@ end
 @testset "Struct return" begin
     x = [2.0]
     dx = [0.0]
-    @test Enzyme.autodiff(invsin, Active, Duplicated(x, dx)) == ((nothing,),)
+    @test Enzyme.autodiff(Reverse, invsin, Active, Duplicated(x, dx)) == ((nothing,),)
     @test dx[1] == -0.4161468365471424
 end
 
@@ -339,7 +339,7 @@ end
     end
     inp = Float64[1.0, 2.0]
     dinp = Float64[0.0, 0.0]
-    autodiff(arsumsq, Active, Duplicated(inp, dinp))
+    autodiff(Reverse, arsumsq, Active, Duplicated(inp, dinp))
     @test inp ≈ Float64[1.0, 2.0]
     @test dinp ≈ Float64[6.0, 6.0]
 end
@@ -424,7 +424,7 @@ end
     end
 
     test_f(f::Foo2) = f.x^2
-    res = autodiff(test_f, Active(Foo2(3.0, :two)))[1][1]
+    res = autodiff(Reverse, test_f, Active(Foo2(3.0, :two)))[1][1]
     @test res.x ≈ 6.0
     @test res.y == nothing
 end
@@ -636,7 +636,7 @@ function dxdt_pred(x)
 end
 
 @testset "AbstractType calling convention" begin
-    @test 1.0 ≈ Enzyme.autodiff(dxdt_pred, Active(1.0))[1][1]
+    @test 1.0 ≈ Enzyme.autodiff(Reverse, dxdt_pred, Active(1.0))[1][1]
 end
 
 ## https://github.com/JuliaDiff/ChainRules.jl/tree/master/test/rulesets
@@ -796,7 +796,7 @@ end
 
 	# should not throw a domain error, which
 	# will occur if the pow is mistakenly speculated
-	Enzyme.autodiff(f, Duplicated(foo, dfoo))
+	Enzyme.autodiff(Reverse, f, Duplicated(foo, dfoo))
 end
 
 genlatestsin(x)::Float64 = Base.invokelatest(sin, x)
@@ -943,7 +943,7 @@ end
     dyn_f(::Val{D}) where D = prod(D)
     dyn_mwe(x, t) = x / dyn_f(Val(t))
 
-    @test 0.5 ≈ Enzyme.autodiff(dyn_mwe, Active, Active(1.0), Const((1, 2)))[1][1]
+    @test 0.5 ≈ Enzyme.autodiff(Reverse, dyn_mwe, Active, Active(1.0), Const((1, 2)))[1][1]
 end
 
 @testset "broadcast" begin
@@ -1000,7 +1000,7 @@ end
     u_v_eta = [0.0]
     ad_struct = [1.0]
 
-    autodiff(advance, Active, Duplicated(u_v_eta, ad_struct))
+    autodiff(Reverse, advance, Active, Duplicated(u_v_eta, ad_struct))
     @test ad_struct[1] ≈ 2.0 
     
     function advance2(u_v_eta)
@@ -1011,7 +1011,7 @@ end
     u_v_eta = [Ref(0.0)]
     ad_struct = [Ref(1.0)]
 
-    autodiff(advance2, Active, Duplicated(u_v_eta, ad_struct))
+    autodiff(Reverse, advance2, Active, Duplicated(u_v_eta, ad_struct))
     @test ad_struct[1][] ≈ 2.0 
 end
 
@@ -1128,7 +1128,7 @@ end
     x = randn(10)
     dx = zero(x)
 
-    Enzyme.autodiff(gcloss, Duplicated(x, dx))
+    Enzyme.autodiff(Reverse, gcloss, Duplicated(x, dx))
 end
 
 typeunknownvec = Float64[]
@@ -1234,7 +1234,7 @@ end
 
     a = rand(5)
     da = zero(a)
-    autodiff(modf!, Duplicated(a, da))
+    autodiff(Reverse, modf!, Duplicated(a, da))
 end
 
 @testset "Type-instable capture" begin
@@ -1313,7 +1313,7 @@ end
     end
 
     GC.@preserve x y dx dy begin
-      autodiff(foo,
+      autodiff(Reverse, foo,
                 Duplicated(Base.unsafe_convert(Ptr{Cvoid}, x), Base.unsafe_convert(Ptr{Cvoid}, dx)), 
                 Duplicated(Base.unsafe_convert(Ptr{Cvoid}, y), Base.unsafe_convert(Ptr{Cvoid}, dy)))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1683,8 +1683,8 @@ using Random
 @testset "Random" begin
 	f_rand(x) = x*rand()
 	f_randn(x, N) = x*sum(randn(N))
-    autodiff(f_rand, Active, Active(1.0))
-    autodiff(f_randn, Active, Active(1.0), Const(64))
+    autodiff(Reverse, f_rand, Active, Active(1.0))
+    autodiff(Reverse, f_randn, Active, Active(1.0), Const(64))
 end
 
 @testset "Reshape" begin
@@ -1699,7 +1699,7 @@ end
     data = Float64[1.,2.,3.,4.]
 	ddata = ones(4)
 
-	autodiff(rs, Duplicated(data, ddata))
+	autodiff(Reverse, rs, Duplicated(data, ddata))
 	@test ddata ≈ [3.0, 5.0, 2.0, 2.0]
 	
     data = Float64[1.,2.,3.,4.]
@@ -1720,7 +1720,7 @@ end
 	  @inbounds w[1] * x[1]
 	end
 
-	Enzyme.autodiff(inactiveArg, Active, Duplicated(w, dw), Const(x), Const(false))
+	Enzyme.autodiff(Reverse, inactiveArg, Active, Duplicated(w, dw), Const(x), Const(false))
 
     @test x ≈ [3.0]
     @test w ≈ [1.0]
@@ -1736,7 +1736,7 @@ end
       res
     end
 
-    dw = Enzyme.autodiff(loss, Active, Active(1.0), Const(x), Const(false))[1]
+    dw = Enzyme.autodiff(Reverse, loss, Active, Active(1.0), Const(x), Const(false))[1]
     
     @test x ≈ [3.0]
     @test dw[1] ≈ 3.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1445,7 +1445,7 @@ end
 
     out = Ref(0.0)
     dout = Ref(1.0)
-    @test 2.0 ≈ Enzyme.autodiff(unionret, Active, Active(2.0), Duplicated(out, dout), true)[1][1]
+    @test 2.0 ≈ Enzyme.autodiff(Reverse, unionret, Active, Active(2.0), Duplicated(out, dout), true)[1][1]
 end
 
 @testset "Array push" begin
@@ -1467,7 +1467,7 @@ end
         push!(a, 1.0)
         return x
     end
-    y, = Enzyme.autodiff(double_push,Active(1.0))[1]
+    y, = Enzyme.autodiff(Reverse, double_push,Active(1.0))[1]
     @test y == 1.0
     
     function aloss(a, arr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,7 +209,7 @@ end
 @testset "Nested AD" begin
     tonest(x,y) = (x + y)^2
 
-    @test Enzyme.autodiff(Forward, (x,y) -> Enzyme.fwddiff_deferred(tonest, Duplicated(x, 1.0), Const(y))[1], Const(1.0), Duplicated(2.0, 1.0))[1] ≈ 2.0
+    @test autodiff(Forward, (x,y) -> autodiff_deferred(Forward, tonest, Duplicated(x, 1.0), Const(y))[1], Const(1.0), Duplicated(2.0, 1.0))[1] ≈ 2.0
 end
 
 @testset "Array tests" begin
@@ -1665,7 +1665,7 @@ end
     dry = zeros(2)
 
     function foo(y, dy, x, dx)
-        Enzyme.autodiff_deferred(speelpenning, Const, Duplicated(y, dy), Duplicated(x, dx))
+        autodiff_deferred(Reverse, speelpenning, Const, Duplicated(y, dy), Duplicated(x, dx))
         return nothing
     end
 


### PR DESCRIPTION
A first step in cleaning up the deferred ABI.

This PR specifically simplifies the internals and changes the interface to match the nondeferred. This PR also removes the default of autodiff to be Reverse and explicitly requires the user to specify Forward, Reverse, ReverseWithPrimal, etc.

This will enable a later PR can unify the two interfaces.