### PR TITLE
Allow external packages to influence global load inlining

### DIFF
--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -134,6 +134,8 @@ const Forward = ForwardMode()
 function autodiff end
 function autodiff_deferred end
 
+const GlobalInlinedLoads = Set{Any}(())
+
 include("rules.jl")
 
 end # module EnzymeCore

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7550,6 +7550,7 @@ end
     if process_module
         GPUCompiler.optimize_module!(parent_job, mod)
     end
+    cleanup_global_loads!(mod)
 
     TapeType::Type = Cvoid
 


### PR DESCRIPTION
E.g. the following is required to get past the ref inside MPI.SUM.

Similar analogues may be needed for cuda/etc API's, if handled within Enzyme rather than a high-level rule.

```julia
using MPI
using Enzyme
using EnzymeCore

Enzyme.API.printall!(true)
push!(EnzymeCore.GlobalInlinedLoads, MPI.SUM, MPI.DOUBLE)

function foo(x::Vector{Float64})
    MPI.Reduce!(x, MPI.SUM, 0, MPI.COMM_WORLD)
    return nothing
end

MPI.Init()

x = ones(10)
foo(x)
x = ones(10)
dx = zeros(10)
autodiff(Reverse, foo, Duplicated(x, dx))

MPI.Finalize()
```

see: https://github.com/EnzymeAD/Enzyme/pull/1025/files