### PR TITLE
Activate gradient tests

### DIFF
--- a/test/DiffTests.jl
+++ b/test/DiffTests.jl
@@ -115,8 +115,9 @@ end
 
 self_weighted_logit(x) = inv(1.0 + exp(-dot(x, x)))
 
+# vec2num_6 fails due to #708
 const VECTOR_TO_NUMBER_FUNCS = (vec2num_1, vec2num_2,  vec2num_3, vec2num_4, vec2num_5,
-                                vec2num_6, vec2num_7, rosenbrock_1, rosenbrock_2,
+                                #=vec2num_6,=# vec2num_7, rosenbrock_1, rosenbrock_2,
                                 rosenbrock_3, rosenbrock_4, ackley, self_weighted_logit,
                                 first)
 
@@ -143,7 +144,8 @@ mat2num_4(x) = mean(sum(sin.(x) * x, dims=2))
 
 softmax(x) = sum(exp.(x) ./ sum(exp.(x), dims=2))
 
-const MATRIX_TO_NUMBER_FUNCS = (det, mat2num_1, mat2num_2, mat2num_3, mat2num_4, softmax)
+# det and mat2num_1 fail due to #709
+const MATRIX_TO_NUMBER_FUNCS = (#=det, mat2num_1,=# mat2num_2, mat2num_3, mat2num_4, softmax)
 
 ####################
 # binary broadcast #

--- a/test/DiffTests.jl
+++ b/test/DiffTests.jl
@@ -29,7 +29,7 @@ num2num_3(x) = 10.31^(x + x) - x
 num2num_4(x) = 1.0
 num2num_5(x) = 1. / (1. + exp(-x))
 
-const NUMBER_TO_NUMBER_FUNCS = (num2num_1, #=num2num_2,=# num2num_3,
+const NUMBER_TO_NUMBER_FUNCS = (num2num_1, num2num_2, num2num_3,
                                 num2num_4, num2num_5, identity)
 
 #######################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -691,7 +691,7 @@ end
     include("DiffTests.jl")
 
     n = rand()
-    x, y = rand(5, 5), rand(26)
+    x, y = rand(5, 5), rand(5)
     A, B = rand(5, 5), rand(5, 5)
 
     # f returns Number
@@ -699,15 +699,15 @@ end
         test_scalar(f, n)
     end
 
+    @testset "Vector to Number" for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
+        test_matrix_to_number(f, y)
+    end
+
+    @testset "Matrix to Number" for f in DiffTests.MATRIX_TO_NUMBER_FUNCS
+        test_matrix_to_number(f, x)
+    end
+
     # TODO(vchuravy/wsmoses): Enable these tests
-    # for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
-    #     @test isa(f(y), Number)
-    # end
-
-    # for f in DiffTests.MATRIX_TO_NUMBER_FUNCS
-    #     @test isa(f(x), Number)
-    # end
-
     # for f in DiffTests.TERNARY_MATRIX_TO_NUMBER_FUNCS
     #     @test isa(f(A, B, x), Number)
     # end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -691,8 +691,8 @@ end
     include("DiffTests.jl")
 
     n = rand()
-    x, y = rand(5, 5), rand(5)
-    A, B = rand(5, 5), rand(5, 5)
+    x, y = 1 .+ rand(5, 5), 1 .+ rand(5)
+    A, B = 1 .+ rand(5, 5), 1 .+ rand(5, 5)
 
     # f returns Number
     @testset "Number to Number" for f in DiffTests.NUMBER_TO_NUMBER_FUNCS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,28 @@ function test_scalar(f, x; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), kwargs..
     end
 end
 
+function test_matrix_to_number(f, x; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), kwargs...)
+    dx_fd = map(eachindex(x)) do i
+        fdm(x[i]) do xi
+            x2 = copy(x)
+            x2[i] = xi
+            f(x2)
+        end
+    end
+
+    dx = zero(x)
+    autodiff(Reverse, f, Active, Duplicated(x, dx))
+    @test isapprox(reshape(dx, length(dx)), dx_fd; rtol=rtol, atol=atol, kwargs...)
+
+    dx_fwd = map(eachindex(x)) do i
+        dx = zero(x)
+        dx[i] = 1
+        ∂x = autodiff(Forward, f, Duplicated(x, dx))
+        isempty(∂x) ? zero(eltype(dx)) : ∂x[1]
+    end
+    @test isapprox(dx_fwd, dx_fd; rtol=rtol, atol=atol, kwargs...)
+end
+
 include("abi.jl")
 include("typetree.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -690,7 +690,7 @@ end
 @testset "DiffTest" begin
     include("DiffTests.jl")
 
-    n = rand()
+    n = 1 + rand()
     x, y = 1 .+ rand(5, 5), 1 .+ rand(5)
     A, B = 1 .+ rand(5, 5), 1 .+ rand(5, 5)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -700,11 +700,11 @@ end
     end
 
     @testset "Vector to Number" for f in DiffTests.VECTOR_TO_NUMBER_FUNCS
-        test_matrix_to_number(f, y)
+        test_matrix_to_number(f, y; rtol=1e-6, atol=1e-6)
     end
 
     @testset "Matrix to Number" for f in DiffTests.MATRIX_TO_NUMBER_FUNCS
-        test_matrix_to_number(f, x)
+        test_matrix_to_number(f, x; rtol=1e-6, atol=1e-6)
     end
 
     # TODO(vchuravy/wsmoses): Enable these tests


### PR DESCRIPTION
I went to write some tests for Enzyme.jl and noticed that there are useful tests in DiffTests.jl which are currently disabled. This PR writes a testing function for vector/matrix to number functions and turns on those tests. It also turns on a number to number test that now works.

A couple of possible issues were uncovered and have been opened (#708 and #709). Those tests are turned off for now.

Tests pass on my machine. I did notice one stochastic failure due to the `1e-9` tolerance but I couldn't reproduce.

If turning these tests on sounds like a good strategy I can proceed with more.