### PR TITLE
Rename Config -> ReverseConfig

### DIFF
--- a/examples/custom_rule.jl
+++ b/examples/custom_rule.jl
@@ -159,7 +159,7 @@ g(y, x) = f(y, x)^2 # function to differentiate
 # Let's look at how to write a simple reverse-mode rule! 
 # First, we write a method for [`EnzymeRules.augmented_primal`](@ref):
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f)}, ::Type{<:Active},
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f)}, ::Type{<:Active},
                           y::Duplicated, x::Duplicated)
     println("In custom augmented primal rule.")
     ## Compute primal
@@ -180,7 +180,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f)}, ::Type
 end
 
 # Let's unpack our signature for `augmented_primal` :
-# * We accepted a [`EnzymeRules.Config`](@ref) object with a specified width of 1, which means that our rule does not support batched reverse mode.
+# * We accepted a [`EnzymeRules.ReverseConfig`](@ref) object with a specified width of 1, which means that our rule does not support batched reverse mode.
 # * We annotated `f` with [`Const`](@ref) as usual.
 # * We dispatched on an [`Active`](@ref) annotation for the return value. This is a special annotation for scalar values, such as our return value,
 #   that indicates that that we care about the value's derivative but we need not explicitly allocate a mutable shadow since it is a scalar value.
@@ -188,13 +188,13 @@ end
 
 # Now, let's unpack the body of our `augmented_primal` rule:
 # * We checked if the `config` requires the primal. If not, we need not compute the return value, but we make sure to mutate `y` in all cases.
-# * We checked if `x` could possibly be overwritten using the `Overwritten` attribute of [`EnzymeRules.Config`](@ref). 
+# * We checked if `x` could possibly be overwritten using the `Overwritten` attribute of [`EnzymeRules.ReverseConfig`](@ref). 
 #   If so, we save the elements of `x` on the `tape` of the returned [`EnzymeRules.AugmentedReturn`](@ref) object.
 # * We return a shadow of `nothing` since the return value is [`Active`](@ref) and hence does not need a shadow.
 
 # Now, we write a method for [`EnzymeRules.reverse`](@ref):
 
-function reverse(config::ConfigWidth{1}, func::Const{typeof(f)}, dret::Active, tape,
+function reverse(config::ReverseConfigWidth{1}, func::Const{typeof(f)}, dret::Active, tape,
                  y::Duplicated, x::Duplicated)
     println("In custom reverse rule.")
     ## retrieve x value, either from original x or from tape if x may have been overwritten.

--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -1,7 +1,7 @@
 module EnzymeRules
 
 import EnzymeCore: Annotation, Const, Duplicated
-export Config, ConfigWidth, AugmentedReturn
+export ReverseConfig, ReverseConfigWidth, AugmentedReturn
 export needs_primal, needs_shadow, width, overwritten
 export primal_type, shadow_type, tape_type
 
@@ -19,8 +19,8 @@ the annotated function arguments.
 function forward end
 
 """
-    Config{NeedsPrimal, NeedsShadow, Width, Overwritten}
-    ConfigWidth{Width} = Config{<:Any,<:Any, Width}
+    ReverseConfig{NeedsPrimal, NeedsShadow, Width, Overwritten}
+    ReverseConfigWidth{Width} = ReverseConfig{<:Any,<:Any, Width}
 
 Configuration type to dispatch on in custom reverse rules (see [`augmented_primal`](@ref) and [`reverse`](@ref)).
 * `NeedsPrimal` and `NeedsShadow`: boolean values specifying whether the primal and shadow (resp.) should be returned. 
@@ -30,13 +30,13 @@ Configuration type to dispatch on in custom reverse rules (see [`augmented_prima
 
 Getters for the four type parameters are provided by `needs_primal`, `needs_shadow`, `width`, and `overwritten`.
 """
-struct Config{NeedsPrimal, NeedsShadow, Width, Overwritten} end
-const ConfigWidth{Width} = Config{<:Any,<:Any, Width}
+struct ReverseConfig{NeedsPrimal, NeedsShadow, Width, Overwritten} end
+const ReverseConfigWidth{Width} = ReverseConfig{<:Any,<:Any, Width}
 
-@inline needs_primal(::Config{NeedsPrimal}) where NeedsPrimal = NeedsPrimal
-@inline needs_shadow(::Config{<:Any, NeedsShadow}) where NeedsShadow = NeedsShadow
-@inline width(::Config{<:Any, <:Any, Width}) where Width = Width
-@inline overwritten(::Config{<:Any, <:Any, <:Any, Overwritten}) where Overwritten = Overwritten
+@inline needs_primal(::ReverseConfig{NeedsPrimal}) where NeedsPrimal = NeedsPrimal
+@inline needs_shadow(::ReverseConfig{<:Any, NeedsShadow}) where NeedsShadow = NeedsShadow
+@inline width(::ReverseConfig{<:Any, <:Any, Width}) where Width = Width
+@inline overwritten(::ReverseConfig{<:Any, <:Any, <:Any, Overwritten}) where Overwritten = Overwritten
 
 """
     AugmentedReturn(primal, shadow, tape)
@@ -67,7 +67,7 @@ end
 @inline shadow_type(::Type{AugmentedReturnFlexShadow{PrimalType,ShadowType,TapeType}}) where {PrimalType,ShadowType,TapeType} = ShadowType
 @inline tape_type(::Type{AugmentedReturnFlexShadow{PrimalType,ShadowType,TapeType}}) where {PrimalType,ShadowType,TapeType} = TapeType
 """
-    augmented_primal(::Config, func::Annotation{typeof(f)}, RT::Type{<:Annotation}, args::Annotation...)
+    augmented_primal(::ReverseConfig, func::Annotation{typeof(f)}, RT::Type{<:Annotation}, args::Annotation...)
 
 Must return an [`AugmentedReturn`](@ref) type.
 * The primal must be the same type of the original return if `needs_primal(config)`, otherwise nothing.
@@ -78,8 +78,8 @@ Must return an [`AugmentedReturn`](@ref) type.
 function augmented_primal end
 
 """
-    reverse(::Config, func::Annotation{typeof(f)}, dret::Active, tape, args::Annotation...)
-    reverse(::Config, func::Annotation{typeof(f)}, ::Type{<:Annotation), tape, args::Annotation...)
+    reverse(::ReverseConfig, func::Annotation{typeof(f)}, dret::Active, tape, args::Annotation...)
+    reverse(::ReverseConfig, func::Annotation{typeof(f)}, ::Type{<:Annotation), tape, args::Annotation...)
 
 Takes gradient of derivative, activity annotation, and tape. If there is an active return dret is passed
 as Active{T} with the derivative of the active return val. Otherwise dret is passed as Type{Duplicated{T}}, etc.
@@ -120,7 +120,7 @@ function has_rrule_from_sig(@nospecialize(TT);
                             method_table::Union{Nothing,Core.Compiler.MethodTableView}=nothing,
                             caller::Union{Nothing,Core.MethodInstance}=nothing)
     ft, tt = _annotate_tt(TT)
-    TT = Tuple{<:Config, <:Annotation{ft}, Type{<:Annotation}, tt...}
+    TT = Tuple{<:ReverseConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}
     return isapplicable(augmented_primal, TT; world, method_table, caller)
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3803,7 +3803,7 @@ function enzyme_custom_common_rev(forward::Bool, B::LLVM.API.LLVMBuilderRef, Ori
     fn = LLVM.parent(curent_bb)
     world = enzyme_extract_world(fn)
 
-    C = EnzymeRules.Config{Bool(needsPrimal), Bool(needsShadow), Int(width), overwritten}
+    C = EnzymeRules.ReverseConfig{Bool(needsPrimal), Bool(needsShadow), Int(width), overwritten}
 
     augprimal_tt = copy(activity)
     if isKWCall

--- a/test/kwrrules.jl
+++ b/test/kwrrules.jl
@@ -11,7 +11,7 @@ end
 import .EnzymeRules: augmented_primal, reverse
 using .EnzymeRules
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw)}, ::Type{<:Active}, x::Active; kwargs...)
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f_kw)}, ::Type{<:Active}, x::Active; kwargs...)
     @show kwargs
     if needs_primal(config)
         return AugmentedReturn(func.val(x.val), nothing, nothing)
@@ -20,7 +20,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw)}, ::T
     end
 end
 
-function reverse(config::ConfigWidth{1}, ::Const{typeof(f_kw)}, dret::Active, tape, x::Active; kwargs...)
+function reverse(config::ReverseConfigWidth{1}, ::Const{typeof(f_kw)}, dret::Active, tape, x::Active; kwargs...)
     @show kwargs # TODO do we want them here?
     if needs_primal(config)
         return (10+2*x.val*dret.val,)
@@ -41,7 +41,7 @@ function f_kw2(x; kwargs...)
     x^2
 end
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw2)}, ::Type{<:Active}, x::Active)
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f_kw2)}, ::Type{<:Active}, x::Active)
     if needs_primal(config)
         return AugmentedReturn(func.val(x.val), nothing, nothing)
     else
@@ -49,7 +49,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw2)}, ::
     end
 end
 
-function reverse(config::ConfigWidth{1}, ::Const{typeof(f_kw2)}, dret::Active, tape, x::Active)
+function reverse(config::ReverseConfigWidth{1}, ::Const{typeof(f_kw2)}, dret::Active, tape, x::Active)
     if needs_primal(config)
         return (10+2*x.val*dret.val,)
     else
@@ -66,7 +66,7 @@ function f_kw3(x; val=nothing)
     x^2
 end
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw3)}, ::Type{<:Active}, x::Active; dval=nothing)
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f_kw3)}, ::Type{<:Active}, x::Active; dval=nothing)
     if needs_primal(config)
         return AugmentedReturn(func.val(x.val), nothing, nothing)
     else
@@ -74,7 +74,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw3)}, ::
     end
 end
 
-function reverse(config::ConfigWidth{1}, ::Const{typeof(f_kw3)}, dret::Active, tape, x::Active; dval=nothing)
+function reverse(config::ReverseConfigWidth{1}, ::Const{typeof(f_kw3)}, dret::Active, tape, x::Active; dval=nothing)
     if needs_primal(config)
         return (10+2*x.val*dret.val,)
     else
@@ -90,7 +90,7 @@ function f_kw4(x; y=2.0)
     x*y
 end
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw4)}, ::Type{<:Active}, x::Active; y)
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f_kw4)}, ::Type{<:Active}, x::Active; y)
     if needs_primal(config)
         return AugmentedReturn(func.val(x.val), nothing, nothing)
     else
@@ -98,7 +98,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f_kw4)}, ::
     end
 end
 
-function reverse(config::ConfigWidth{1}, ::Const{typeof(f_kw4)}, dret::Active, tape, x::Active; y)
+function reverse(config::ReverseConfigWidth{1}, ::Const{typeof(f_kw4)}, dret::Active, tape, x::Active; y)
     return (1000*y+2*x.val*dret.val,)
 end
 

--- a/test/rrules.jl
+++ b/test/rrules.jl
@@ -14,7 +14,7 @@ end
 import .EnzymeRules: augmented_primal, reverse, Annotation, has_rrule_from_sig
 using .EnzymeRules
 
-function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f)}, ::Type{<:Active}, x::Active)
+function augmented_primal(config::ReverseConfigWidth{1}, func::Const{typeof(f)}, ::Type{<:Active}, x::Active)
     if needs_primal(config)
         return AugmentedReturn(func.val(x.val), nothing, nothing)
     else
@@ -22,7 +22,7 @@ function augmented_primal(config::ConfigWidth{1}, func::Const{typeof(f)}, ::Type
     end
 end
 
-function reverse(config::ConfigWidth{1}, ::Const{typeof(f)}, dret::Active, tape, x::Active)
+function reverse(config::ReverseConfigWidth{1}, ::Const{typeof(f)}, dret::Active, tape, x::Active)
     if needs_primal(config)
         return (10+2*x.val*dret.val,)
     else
@@ -30,13 +30,13 @@ function reverse(config::ConfigWidth{1}, ::Const{typeof(f)}, dret::Active, tape,
     end
 end
 
-function augmented_primal(::Config{false, false, 1}, func::Const{typeof(f_ip)}, ::Type{<:Const}, x::Duplicated)
+function augmented_primal(::ReverseConfig{false, false, 1}, func::Const{typeof(f_ip)}, ::Type{<:Const}, x::Duplicated)
     v = x.val[1]
     x.val[1] *= v
     return AugmentedReturn(nothing, nothing, v)
 end
 
-function reverse(::Config{false, false, 1}, ::Const{typeof(f_ip)}, ::Type{<:Const}, tape, x::Duplicated)
+function reverse(::ReverseConfig{false, false, 1}, ::Const{typeof(f_ip)}, ::Type{<:Const}, tape, x::Duplicated)
     x.dval[1] = 100 + x.dval[1] * tape
     return ()
 end


### PR DESCRIPTION
Pros:

- Makes it more clear from the name that `Config` is for reverse mode

Cons:

- More typing
- Does this make it inconsistent with terminology in enzyme proper? If that's somewhat ingrained the change might not be worth it