### PR TITLE
Change `::Int64` to `::Int`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -869,7 +869,7 @@ struct Return3
     ret2::Any
     ret3::Any
 end
-AnyArray(Length::Int64) = NamedTuple{ntuple(i->Symbol(i), Val(Length)),NTuple{Length,Any}}
+AnyArray(Length::Int) = NamedTuple{ntuple(i->Symbol(i), Val(Length)),NTuple{Length,Any}}
 
 function permit_inlining!(f::LLVM.Function)
     for bb in blocks(f), inst in instructions(bb)
@@ -949,7 +949,7 @@ struct Tape{TapeTy,ShadowTy,ResT}
     shadow_return::ShadowTy
 end
 
-function setup_macro_wraps(forwardMode::Bool, N::Int64, Width::Int64, base=nothing)
+function setup_macro_wraps(forwardMode::Bool, N::Int, Width::Int, base=nothing)
     primargs = Union{Symbol,Expr}[]
     shadowargs = Union{Symbol,Expr}[]
     primtypes = Union{Symbol,Expr}[]
@@ -6012,7 +6012,7 @@ abstract type AbstractEnzymeCompilerParams <: AbstractCompilerParams end
 struct EnzymeCompilerParams <: AbstractEnzymeCompilerParams
     TT::Type{<:Tuple}
     mode::API.CDerivativeMode
-    width::Int64
+    width::Int
     rt::Type{<:Annotation{T} where T}
     run_enzyme::Bool
     abiwrap::Bool

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -1,5 +1,5 @@
 function get_job(@nospecialize(func), @nospecialize(A), @nospecialize(types);
-        run_enzyme::Bool=true, mode::API.CDerivativeMode=API.DEM_ReverseModeCombined, dupClosure::Bool=false, argwrap::Bool=true, width::Int64=1, modifiedBetween=nothing, returnPrimal::Bool=false, augmentedInit=false, world=nothing, kwargs...)
+        run_enzyme::Bool=true, mode::API.CDerivativeMode=API.DEM_ReverseModeCombined, dupClosure::Bool=false, argwrap::Bool=true, width::Int=1, modifiedBetween=nothing, returnPrimal::Bool=false, augmentedInit=false, world=nothing, kwargs...)
 
     tt    = Tuple{map(eltype, types.parameters)...}
     if world === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -808,7 +808,7 @@ end
 @testset "No speculation" begin
 	mutable struct SpecFoo
 
-		iters::Int64
+		iters::Int
 		a::Float64
 		b::Vector{Float64}
 
@@ -1199,7 +1199,7 @@ typeunknownvec = Float64[]
 
     struct AGriddedInterpolation{K<:Tuple{Vararg{AbstractVector}}} <: AbstractArray{Float64, 1}
         knots::K
-        v::Int64
+        v::Int
     end
 
     function AGriddedInterpolation(A::AbstractArray{Float64, 1})


### PR DESCRIPTION
This PR is a simple find-replace of `::Int64` with `::Int`.

The restriction to `::Int64` breaks support for 32bit systems: https://github.com/TuringLang/Turing.jl/actions/runs/4687453137/jobs/8306774283?pr=1887#step:6:478