### PR TITLE
Add Aqua to tests

### DIFF
--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -1,5 +1,5 @@
 
-function get_function!(mod::LLVM.Module, name, FT::LLVM.FunctionType, attrs=[])
+function get_function!(mod::LLVM.Module, name::AbstractString, FT::LLVM.FunctionType, attrs=[])
     if haskey(functions(mod), name)
         F = functions(mod)[name]
         PT = LLVM.PointerType(FT)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Enzyme_jll = "7cc45869-7501-5eee-bdea-0790c847d4ef"
@@ -15,4 +16,5 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.6"
 CUDA = "4.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Enzyme
 using Test
 using FiniteDifferences
 using ForwardDiff
+using Aqua
 using Statistics
 using LinearAlgebra
 
@@ -60,6 +61,8 @@ function test_matrix_to_number(f, x; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1)
     end
     @test isapprox(dx_fwd, dx_fd; rtol=rtol, atol=atol, kwargs...)
 end
+
+Aqua.test_all(Enzyme, unbound_args=false, piracy=false)
 
 include("abi.jl")
 include("typetree.jl")


### PR DESCRIPTION
[Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) is a nice little package that runs automated checks for Julia packages. This PR adds it to the Enzyme tests.

Most checks currently pass, with one method ambiguity fixed by annotating an argument. The skipped checks currently fail but I think that is okay. The unbound type parameter checks fail due to `Vararg` possibly being empty and the piracy checks fail due to piracy of EnzymeCore.