### PR TITLE
Fix thunk/deferred_codegen getting incorrect world age and segfaulting

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -178,13 +178,12 @@ Enzyme.autodiff(ReverseWithPrimal, x->x*x, Active(3.0))
     ModifiedBetween = Val(falses_from_args(Val(1), args...))
 
     tt    = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f.val), tt)
-    
+
     if A <: Active
         tt    = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
         rt = Core.Compiler.return_type(f.val, tt)
         if !allocatedinline(rt) || rt isa Union
-            forward, adjoint = Enzyme.Compiler.thunk(Val(world), FA, Duplicated{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal), #=ShadowInit=#Val(true))
+            forward, adjoint = Enzyme.Compiler.thunk(FA, Duplicated{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal), #=ShadowInit=#Val(true))
             res = forward(f, args′...)
             tape = res[1]
             if ReturnPrimal
@@ -196,7 +195,7 @@ Enzyme.autodiff(ReverseWithPrimal, x->x*x, Active(3.0))
     elseif A <: Duplicated || A<: DuplicatedNoNeed || A <: BatchDuplicated || A<: BatchDuplicatedNoNeed
         throw(ErrorException("Duplicated Returns not yet handled"))
     end
-    thunk = Enzyme.Compiler.thunk(Val(world), FA, A, tt′, #=Split=# Val(API.DEM_ReverseModeCombined), Val(width), ModifiedBetween, Val(ReturnPrimal))
+    thunk = Enzyme.Compiler.thunk(FA, A, tt′, #=Split=# Val(API.DEM_ReverseModeCombined), Val(width), ModifiedBetween, Val(ReturnPrimal))
     if A <: Active
         tt    = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
         rt = Core.Compiler.return_type(f.val, tt)
@@ -315,9 +314,8 @@ f(x) = x*x
     ModifiedBetween = Val(falses_from_args(Val(1), args...))
     
     tt    = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f.val), tt)
 
-    thunk = Enzyme.Compiler.thunk(Val(world), FA, RT, tt′, #=Mode=# Val(API.DEM_ForwardMode), Val(width),
+    thunk = Enzyme.Compiler.thunk(FA, RT, tt′, #=Mode=# Val(API.DEM_ForwardMode), Val(width),
                                      ModifiedBetween, ReturnPrimal)
     thunk(f, args′...)
 end
@@ -337,8 +335,6 @@ code, as well as high-order differentiation.
     end
     tt = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
         
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f.val), tt)
-    
     if A isa UnionAll
         rt = Core.Compiler.return_type(f.val, tt)
         rt = A{rt}
@@ -353,7 +349,7 @@ code, as well as high-order differentiation.
 
     ModifiedBetween = Val(falses_from_args(Val(1), args...))
     
-    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(Val(world), FA, Val(tt′), Val(rt), Val(API.DEM_ReverseModeCombined), Val(width), ModifiedBetween, Val(ReturnPrimal))
+    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(FA, Val(tt′), Val(rt), Val(API.DEM_ReverseModeCombined), Val(width), ModifiedBetween, Val(ReturnPrimal))
     @assert primal_ptr === nothing
     thunk = Compiler.CombinedAdjointThunk{FA, rt, tt′, typeof(Val(width)), Val(ReturnPrimal)}(adjoint_ptr)
     if rt <: Active
@@ -397,8 +393,6 @@ code, as well as high-order differentiation.
     end
     tt = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
     
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f.val), tt)
-    
     if RT isa UnionAll
         rt = Core.Compiler.return_type(f.val, tt)
         rt = RT{rt}
@@ -419,7 +413,7 @@ code, as well as high-order differentiation.
     ModifiedBetween = Val(falses_from_args(Val(1), args...))
 
     
-    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(Val(world), FA, Val(tt′), Val(rt), Val(API.DEM_ForwardMode), Val(width), ModifiedBetween, ReturnPrimal)
+    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(FA, Val(tt′), Val(rt), Val(API.DEM_ForwardMode), Val(width), ModifiedBetween, ReturnPrimal)
     @assert primal_ptr === nothing
     thunk = Compiler.ForwardModeThunk{FA, rt, tt′, typeof(Val(width)), ReturnPrimal}(adjoint_ptr)
     thunk(f, args′...)
@@ -442,7 +436,6 @@ Like [`autodiff_deferred`](@ref) but will try to guess the activity of the retur
 @inline function autodiff_deferred(mode::M, f::FA, args...) where {FA<:Annotation, M<:Mode}
     args′ = annotate(args...)
     tt    = Tuple{map(T->eltype(Core.Typeof(T)), args′)...}
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f.val), tt)
     rt    = Core.Compiler.return_type(f.val, tt)
     if rt === Union{}
         error("return type is Union{}, giving up.")
@@ -514,10 +507,8 @@ result, ∂v, ∂A
 
     tt    = Tuple{map(eltype, args)...}
         
-    world = GPUCompiler.codegen_world_age(eltype(FA), tt)
-    
     @assert ReturnShadow
-    Enzyme.Compiler.thunk(Val(world), FA, A, Tuple{args...}, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal), #=ShadowInit=#Val(false))
+    Enzyme.Compiler.thunk(FA, A, Tuple{args...}, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal), #=ShadowInit=#Val(false))
 end
 
 """
@@ -578,9 +569,7 @@ forward = autodiff_thunk(Forward, Const{typeof(f)}, DuplicatedNoNeed, Duplicated
 
     tt    = Tuple{map(eltype, args)...}
         
-    world = GPUCompiler.codegen_world_age(eltype(FA), tt)
-    
-    Enzyme.Compiler.thunk(Val(world), FA, A, Tuple{args...}, #=Mode=# Val(API.DEM_ForwardMode), Val(width), ModifiedBetween, ReturnPrimal, #=ShadowInit=#Val(false))
+    Enzyme.Compiler.thunk(FA, A, Tuple{args...}, #=Mode=# Val(API.DEM_ForwardMode), Val(width), ModifiedBetween, ReturnPrimal, #=ShadowInit=#Val(false))
 end
 
 """
@@ -648,14 +637,13 @@ result, ∂v, ∂A
     TT = Tuple{args...}
    
     primal_tt = Tuple{map(eltype, args)...}
-    world = GPUCompiler.codegen_world_age(eltype(FA), primal_tt)
 
     # TODO this assumes that the thunk here has the correct parent/etc things for getting the right cuda instructions -> same caching behavior
-    nondef = Enzyme.Compiler.thunk(Val(world), FA, A, TT, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal))
+    nondef = Enzyme.Compiler.thunk(FA, A, TT, #=Split=# Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, #=ReturnPrimal=#Val(ReturnPrimal))
     TapeType = Compiler.get_tape_type(typeof(nondef[1]))
     A2 = Compiler.return_type(typeof(nondef[1]))
 
-    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(Val(world), FA, Val(TT), Val(A2), Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, Val(ReturnPrimal), #=ShadowInit=#Val(false), TapeType)
+    adjoint_ptr, primal_ptr = Compiler.deferred_codegen(FA, Val(TT), Val(A2), Val(API.DEM_ReverseModeGradient), Val(width), ModifiedBetween, Val(ReturnPrimal), #=ShadowInit=#Val(false), TapeType)
     AugT = Compiler.AugmentedForwardThunk{FA, A2, TT, Val{width}, Val(ReturnPrimal), TapeType}
     @assert AugT == typeof(nondef[1])
     AdjT = Compiler.AdjointThunk{FA, A2, TT, Val{width}, TapeType}
@@ -933,12 +921,11 @@ grad = jacobian(Reverse, f, [2.0, 3.0], Val(2))
 
     tt′   = Tuple{BatchDuplicated{Core.Typeof(x), chunk}}
     tt    = Tuple{Core.Typeof(x)}
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f), tt)
     rt = Core.Compiler.return_type(f, tt)
     ModifiedBetween = Val((false, false))
     FA = Const{Core.Typeof(f)}
     World = Val(nothing)
-    primal, adjoint = Enzyme.Compiler.thunk(Val(world), FA, BatchDuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(chunk), ModifiedBetween)
+    primal, adjoint = Enzyme.Compiler.thunk(FA, BatchDuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(chunk), ModifiedBetween)
     
     if num * chunk == n_out_val
         last_size = chunk
@@ -946,7 +933,7 @@ grad = jacobian(Reverse, f, [2.0, 3.0], Val(2))
     else
         last_size = n_out_val - (num-1)*chunk
         tt′ = Tuple{BatchDuplicated{Core.Typeof(x), last_size}}
-        primal2, adjoint2 = Enzyme.Compiler.thunk(Val(world), FA, BatchDuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(last_size), ModifiedBetween)
+        primal2, adjoint2 = Enzyme.Compiler.thunk(FA, BatchDuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(last_size), ModifiedBetween)
     end
 
     tmp = ntuple(num) do i
@@ -972,11 +959,10 @@ end
 @inline function jacobian(::ReverseMode, f::F, x::X, n_outs::Val{n_out_val}, ::Val{1} = Val(1)) where {F, X, n_out_val}
     tt′   = Tuple{Duplicated{Core.Typeof(x)}}
     tt    = Tuple{Core.Typeof(x)}
-    world = GPUCompiler.codegen_world_age(Core.Typeof(f), tt)
     rt = Core.Compiler.return_type(f, tt)
     ModifiedBetween = Val((false, false))
     FA = Const{Core.Typeof(f)}
-    primal, adjoint = Enzyme.Compiler.thunk(Val(world), FA, DuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(1), ModifiedBetween)
+    primal, adjoint = Enzyme.Compiler.thunk(FA, DuplicatedNoNeed{rt}, tt′, #=Split=# Val(API.DEM_ReverseModeGradient), #=width=#Val(1), ModifiedBetween)
     rows = ntuple(n_outs) do i
         Base.@_inline_meta
         dx = zero(x)


### PR DESCRIPTION
Bug Found:

The following script will error out with a segfault in the current Enzyme implementation. This occurs because the generated functions for thunk and deferred_codegen do no retrigger GPUCompiler and instead use stale values. Simply dropping the generated tag fixes the segfault but we are no longer able to look up unique method instances as the returned world ages are incorrect. Instead we should switch to using GPUCompiler.methodinstance directly dropping the need to filter on world ages.

```
module EnzymeTest                                                               
using Enzyme                                                                    
                                                                                
rosenbrock(x, y) = (1.0 - x)^2 + 100.0 * (y - x^2)^2                            
autodiff(Reverse, rosenbrock, Active, Active(1.0), Active(2.0))                 
                                                                                
function __init__()                                                             
    autodiff(Reverse, rosenbrock, Active, Active(1.0), Active(2.0))             
end                                                                             
                                                                                
end # module EnzymeTest   
```

With the following segfault:


```
julia> using EnzymeTest                                                                                                                            
[ Info: Precompiling EnzymeTest [87ed9522-ec2b-4441-9f14-f86404eed9ba]
                                                                                                                                                                                                                         
[1273377] signal (11.1): Segmentation fault                                                                                                        
in expression starting at REPL[1]:1                                                                                                                
unknown function (ip: 0x7f6f218d4050)                                                                                                              
macro expansion at /home/collinw/.julia/dev/Enzyme/src/compiler.jl:8971 [inlined]                                                                  
enzyme_call at /home/collinw/.julia/dev/Enzyme/src/compiler.jl:8663 [inlined]                                                                      
CombinedAdjointThunk at /home/collinw/.julia/dev/Enzyme/src/compiler.jl:8626 [inlined]                                                             
autodiff at /home/collinw/.julia/dev/Enzyme/src/Enzyme.jl:205 [inlined]                                                                            
autodiff at /home/collinw/.julia/dev/Enzyme/src/Enzyme.jl:214 [inlined]                                                                            
runGradients at /home/collinw/julia_master/EnzymeTest/src/EnzymeTest.jl:9 [inlined]                                                                
__init__ at /home/collinw/julia_master/EnzymeTest/src/EnzymeTest.jl:30                                                                             
Allocations: 7890557 (Pool: 7878530; Big: 12027); GC: 11                                                                                           
Segmentation fault (core dumped)                              
```

