### PR TITLE
Avoid recursive warning on recursive types

### DIFF
--- a/src/typetree.jl
+++ b/src/typetree.jl
@@ -143,27 +143,12 @@ else
     ismutabletype(T) = isa(T, DataType) && T.mutable
 end
 
-const AlreadyWarned = Dict{Symbol,Bool}()
-const AlreadyWarnedLock = Threads.SpinLock()
-
-function recursive_type_warning(@nospecialize(T))
-    haskey(AlreadyWarned, Symbol(T)) && return nothing
-    lock(AlreadyWarnedLock) do
-        haskey(AlreadyWarned, Symbol(T)) && return nothing
-        GPUCompiler.@safe_warn "Recursive type" T
-        AlreadyWarned[Symbol(T)] = true
-        return nothing
-    end
-    return nothing
-end
-
 function typetree(@nospecialize(T), ctx, dl, seen=nothing)
     if T isa UnionAll || T isa Union || T == Union{} || Base.isabstracttype(T)
         return TypeTree()
     end
 
     if seen !== nothing && T ∈ seen
-        recursive_type_warning(T)
         return TypeTree()
     end
     if seen === nothing


### PR DESCRIPTION
Right now when you perform autodiff on a recursive type, you see a warning about it. However, this warning is printed recursively at each node in the type hierarchy, so you can get thousands of warning messages about the same type.

This implements a simple fix to only warn about a recursive type *once*. Later warnings are skipped.

Fixes part 1 of #810