### PR TITLE
Fix UndefVarError

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5207,7 +5207,7 @@ function jl_array_ptr_copy_fwd(B, orig, gutils, normalR, shadowR)
 
     if width == 1
         vargs = args
-        cal = call_samefunc_with_inverted_bundles!(b, gutils, orig, vargs, valTys, #=lookup=#false)
+        cal = call_samefunc_with_inverted_bundles!(B, gutils, orig, vargs, valTys, #=lookup=#false)
         debug_from_orig!(gutils, cal, orig)
         callconv!(cal, callconv(orig))
     else


### PR DESCRIPTION
`b` is not defined: https://github.com/EnzymeAD/Enzyme.jl/issues/650#issuecomment-1625288275

I'm not familiar with this part of the code but I assume possibly `B` should be used instead.