### PR TITLE
Make Adapt a weak dependency of EnzymeCore on Julia >= 1.9

### DIFF
--- a/lib/EnzymeCore/Project.toml
+++ b/lib/EnzymeCore/Project.toml
@@ -1,10 +1,16 @@
 name = "EnzymeCore"
 uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[weakdeps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[extensions]
+EnzymeCoreAdaptExt = "Adapt"
 
 [compat]
 Adapt = "3.3"

--- a/lib/EnzymeCore/ext/EnzymeCoreAdaptExt.jl
+++ b/lib/EnzymeCore/ext/EnzymeCoreAdaptExt.jl
@@ -1,0 +1,13 @@
+module EnzymeCoreAdaptExt
+
+using EnzymeCore
+using Adapt
+
+Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
+Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
+Adapt.adapt_structure(to, x::Duplicated) = Duplicated(adapt(to, x.val), adapt(to, x.dval))
+Adapt.adapt_structure(to, x::DuplicatedNoNeed) = DuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+Adapt.adapt_structure(to, x::BatchDuplicated) = BatchDuplicated(adapt(to, x.val), adapt(to, x.dval))
+Adapt.adapt_structure(to, x::BatchDuplicatedNoNeed) = BatchDuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+
+end # module EnzymeCoreAdaptExt

--- a/lib/EnzymeCore/test/Project.toml
+++ b/lib/EnzymeCore/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/EnzymeCore/test/runtests.jl
+++ b/lib/EnzymeCore/test/runtests.jl
@@ -17,3 +17,26 @@ function forward(::Const{typeof(f)}, ::Type{<:Const}; kwargs...)
 end
 
 @test has_frule_from_sig(Base.signature_type(f, Tuple{}))
+
+# Check loading of extension
+if isdefined(Base, :get_extension)
+    @test Base.get_extension(EnzymeCore, :EnzymeCoreAdaptExt) === nothing
+end
+using Adapt
+EnzymeCoreAdaptExt = if isdefined(Base, :get_extension)
+    Base.get_extension(EnzymeCore, :EnzymeCoreAdaptExt)
+else
+    EnzymeCore.EnzymeCoreAdaptExt
+end
+@test EnzymeCoreAdaptExt isa Module
+
+# Test `adapt` with example from Adapt docs
+struct IntegerLessAdaptor end
+Adapt.adapt_storage(::IntegerLessAdaptor, x::Int) = Float64(x)
+
+@test adapt(IntegerLessAdaptor(), Const(1)) === Const(1.0)
+@test adapt(IntegerLessAdaptor(), Active(2)) === Active(2.0)
+@test adapt(IntegerLessAdaptor(), Duplicated(3, 4)) === Duplicated(3.0, 4.0)
+@test adapt(IntegerLessAdaptor(), DuplicatedNoNeed(5, 6)) === DuplicatedNoNeed(5.0, 6.0)
+@test adapt(IntegerLessAdaptor(), BatchDuplicated(7, (8, 9))) === BatchDuplicated(7.0, (8.0, 9.0))
+@test adapt(IntegerLessAdaptor(), BatchDuplicatedNoNeed(10, (11, 12))) === BatchDuplicatedNoNeed(10.0, (11.0, 12.0))


### PR DESCRIPTION
This PR is a suggestion to make Adapt a weak dependency of EnzymeCore on Julia >= 1.9. This would make EnzymeCore even more lightweight and mean that downstream packages that only need e.g. the modes defined in EnzymeCore do not have to pull in a transitive dependency on Adapt or, indirectly, Requires.