### PR TITLE
Fix `UndefVarError: ST not defined`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -2613,9 +2613,11 @@ function common_apply_iterate_fwd(offset, B, orig, gutils, normalR, shadowR)
     emit_error(B, orig, "Enzyme: Not yet implemented, forward for jl_f__apply_iterate")
     if shadowR != C_NULL
         cal =  new_from_original(gutils, orig)
+        width = get_width(gutils)
         if width == 1
             shadow = cal
         else
+            ST = LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig)))
             shadow = LLVM.UndefValue(ST)
             for i in 1:width
                 shadow = insert_value!(B, shadow, cal, i-1)
@@ -2634,9 +2636,11 @@ function common_apply_iterate_augfwd(offset, B, orig, gutils, normalR, shadowR, 
 
     if shadowR != C_NULL
         cal =  new_from_original(gutils, orig)
+        width = get_width(gutils)
         if width == 1
             shadow = cal
         else
+            ST = LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig)))
             shadow = LLVM.UndefValue(ST)
             for i in 1:width
                 shadow = insert_value!(B, shadow, cal, i-1)


### PR DESCRIPTION
A large number of errors in https://github.com/TuringLang/DistributionsAD.jl/pull/254 are caused by an `UndefVarError: ST not defined`. The logs (see, e.g., https://github.com/TuringLang/DistributionsAD.jl/actions/runs/5872312798/job/16026479059#step:6:47460 https://github.com/TuringLang/DistributionsAD.jl/actions/runs/5872312798/job/16026479059#step:6:47460) point to line 2619 in src/compiler.jl.

This PR ensures that variable `ST` is defined by copying definitions from other functions in `src/compiler.jl` - since I don't know what they are doing, I don't know if this suggestion is correct.

While looking at `src/compiler.jl`, I noticed that the same problem should be present in line 2640, and hence I applied the same suggestions there as well.

I don't have a simple MWE, so no test is added.