### PR TITLE
Only lock cache for writing

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -9739,16 +9739,18 @@ const cache_lock = ReentrantLock()
 @inline function cached_compilation(@nospecialize(job::CompilerJob))::CompileResult
     key = hash(job)
 
+    haskey(cache, key) && return cache[key]
     # NOTE: no use of lock(::Function)/@lock/get! to keep stack traces clean
     lock(cache_lock)
     try
-        obj = get(cache, key, nothing)
-        if obj === nothing
+        if haskey(cache, key)
+            cache[key]
+        else
             asm = _thunk(job)
             obj = _link(job, asm)
             cache[key] = obj
+            obj
         end
-        obj
     finally
         unlock(cache_lock)
     end


### PR DESCRIPTION
Currently the `cached_compilation` method locks the cache for both reads and writes.

Since the compilation cache is not modified once written-to, it only needs to be locked for writes. This PR implements the change.

It also switches to `haskey(cache, key)` from `get(cache, key, nothing) === nothing` which improves type stability.