### PR TITLE
Unmark reverse mutating test as broken

### DIFF
--- a/lib/EnzymeTestUtils/test/test_reverse.jl
+++ b/lib/EnzymeTestUtils/test/test_reverse.jl
@@ -101,12 +101,7 @@ end
                 a = randn(T)
 
                 atol = rtol = sqrt(eps(real(T)))
-                @test !fails() do
-                    test_reverse(f_mut_rev!, Tret, (y, Ty), (x, Tx), (a, Ta); atol, rtol)
-                    # https://github.com/EnzymeAD/Enzyme.jl/issues/1028
-                end broken = (
-                    VERSION > v"1.8" && Tx <: Const && Ta <: Const && !(Ty <: Const)
-                )
+                test_reverse(f_mut_rev!, Tret, (y, Ty), (x, Tx), (a, Ta); atol, rtol)
             end
         end
 


### PR DESCRIPTION
Now that #1028 is fixed, this test in EnzymeTestUtils is no longer broken.