### PR TITLE
Import EnzymeCore into Enzyme

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -1,5 +1,7 @@
 module Enzyme
 
+import EnzymeCore
+
 import EnzymeCore: Forward, Reverse, ReverseWithPrimal, ReverseSplitNoPrimal, ReverseSplitWithPrimal, ReverseSplitModified, ReverseSplitWidth, ReverseMode, ForwardMode
 export Forward, Reverse, ReverseWithPrimal, ReverseSplitNoPrimal, ReverseSplitWithPrimal, ReverseSplitModified, ReverseSplitWidth, ReverseMode, ForwardMode
 


### PR DESCRIPTION
I believe this change is needed so that we can access `EnzymeCore` via something like

```julia
using Enzyme: EnzymeCore
```

which currently isn't possible.

cc @jlk9 @wsmoses 