### PR TITLE
correct some formatting, variable names, and math in box example

### DIFF
--- a/examples/autodiff.jl
+++ b/examples/autodiff.jl
@@ -51,7 +51,7 @@ g = copy(bx)
 # ```math
 # \begin{aligned}
 # y &= f(x) \\
-# \dot{y} &= \nabla f(x) \cdot x
+# \dot{y} &= \nabla f(x) \cdot \dot{x}
 # \end{aligned}
 # ```
 # To obtain the first element of the gradient using the forward model we have to

--- a/examples/box.jl
+++ b/examples/box.jl
@@ -338,7 +338,7 @@ autodiff(Reverse,
 # are vectors, not scalars. Let's go through and see what Enzyme did with all 
 # of those placeholders. 
 
-# First we can look at what happened to the zero vectors out_now and out_old:
+# First we can look at what happened to the zero vectors `out_now` and `out_old`:
 
 @show out_now, out_old
 
@@ -352,11 +352,12 @@ autodiff(Reverse,
 @show dstate_now 
 
 # Just a few numbers, but this is what makes AD so nice: Enzyme has exactly computed
-# the derivative of all outputs with respect to the input in_now, evaluated at
-# in_now, and acted with this gradient on what we gave as dout_now (in our case, 
-# all ones). In math language, this is just
+# the derivative of all outputs with respect to the input `state_now`, evaluated at
+# `state_now`, and acted with this gradient on what we gave as `dout_now` (in our case,
+# all ones). Using AD notation for reverse mode, this is
+
 # ```math 
-# \text{dstate now} = (\frac{\partial \text{out now}(\text{state now})}{\partial \text{state now}} + \frac{\partial \text{out old}(\text{state now})}{\partial \text{state now}}) \text{dout now} 
+# \overline{\text{state\_now}} = \frac{\partial \text{out\_now}}{\partial \text{state\_now}}\right|_\text{state\_now} \overline{\text{out\_now} + \frac{\partial \text{out\_old}}{\partial \text{state\_now}}\right|_\text{state\_now} \overline{\text{out\_old}
 # ```
 
 # We note here that had we initialized `dstate_now` and `dstate_old` as something else, our results 


### PR DESCRIPTION
 - formatting of variables out_now and out_old is corrected
 - variable name in_now replaced with state_now
 - math equation describing reverse mode dstate_now:
   - correct to reflect multiple seeds
   - change notation for adjoint to use overline