### PR TITLE
[EnzymeCore] Move adapt to extension

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@ steps:
     matrix:
       setup:
         version:
-          - "1.8"
           - "1.9"
           - "1.10"
     plugins:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Enzyme"
 uuid = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.11.12"
+version = "0.11.13"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 CEnum = "0.4, 0.5"
-EnzymeCore = "0.6.4"
+EnzymeCore = "0.6.4, 0.6.5"
 Enzyme_jll = "0.0.98"
 GPUCompiler = "0.21, 0.22, 0.23, 0.24, 0.25"
 LLVM = "6.1"

--- a/lib/EnzymeCore/Project.toml
+++ b/lib/EnzymeCore/Project.toml
@@ -1,11 +1,17 @@
 name = "EnzymeCore"
 uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.6.4"
-
-[deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "0.6.5"
 
 [compat]
-Adapt = "3.3"
+Adapt = "3, 4"
 julia = "1.6"
+
+[extensions]
+AdaptExt = "Adapt"
+
+[extras]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[weakdeps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/EnzymeCore/ext/AdaptExt.jl
+++ b/lib/EnzymeCore/ext/AdaptExt.jl
@@ -1,0 +1,11 @@
+module AdaptExt
+    using Adapt
+    using EnzymeCore
+
+	Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
+	Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
+	Adapt.adapt_structure(to, x::Duplicated) = Duplicated(adapt(to, x.val), adapt(to, x.dval))
+	Adapt.adapt_structure(to, x::DuplicatedNoNeed) = DuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+	Adapt.adapt_structure(to, x::BatchDuplicated) = BatchDuplicated(adapt(to, x.val), adapt(to, x.dval))
+	Adapt.adapt_structure(to, x::BatchDuplicatedNoNeed) = BatchDuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+end

--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -1,7 +1,5 @@
 module EnzymeCore
 
-using Adapt
-
 export Forward, Reverse, ReverseWithPrimal, ReverseSplitNoPrimal, ReverseSplitWithPrimal
 export ReverseSplitModified, ReverseSplitWidth
 export Const, Active, Duplicated, DuplicatedNoNeed, BatchDuplicated, BatchDuplicatedNoNeed
@@ -28,7 +26,6 @@ Enzyme will not auto-differentiate in respect `Const` arguments.
 struct Const{T} <: Annotation{T}
     val::T
 end
-Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
 
 # To deal with Const(Int) and prevent it to go to `Const{DataType}(T)`
 Const(::Type{T}) where T = Const{Type{T}}(T)
@@ -50,7 +47,6 @@ struct Active{T} <: Annotation{T}
     @inline Active(x::T1) where {T1} = new{T1}(x)
     @inline Active(x::T1) where {T1 <: Array} = error("Unsupported Active{"*string(T1)*"}, consider Duplicated or Const")
 end
-Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
 
 Active(i::Integer) = Active(float(i))
 
@@ -75,7 +71,6 @@ struct Duplicated{T} <: Annotation{T}
         new{T1}(x, dx)
     end
 end
-Adapt.adapt_structure(to, x::Duplicated) = Duplicated(adapt(to, x.val), adapt(to, x.dval))
 
 """
     DuplicatedNoNeed(x, ∂f_∂x)
@@ -96,7 +91,6 @@ struct DuplicatedNoNeed{T} <: Annotation{T}
         new{T1}(x, dx)
     end
 end
-Adapt.adapt_structure(to, x::DuplicatedNoNeed) = DuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
 
 """
     BatchDuplicated(x, ∂f_∂xs)
@@ -119,7 +113,6 @@ struct BatchDuplicated{T,N} <: Annotation{T}
         new{T1, N}(x, dx)
     end
 end
-Adapt.adapt_structure(to, x::BatchDuplicated) = BatchDuplicated(adapt(to, x.val), adapt(to, x.dval))
 
 struct BatchDuplicatedFunc{T,N,Func} <: Annotation{T}
     val::T
@@ -154,7 +147,6 @@ end
 @inline batch_size(::Type{BatchDuplicated{T,N}}) where {T,N} = N
 @inline batch_size(::Type{BatchDuplicatedFunc{T,N}}) where {T,N} = N
 @inline batch_size(::Type{BatchDuplicatedNoNeed{T,N}}) where {T,N} = N
-Adapt.adapt_structure(to, x::BatchDuplicatedNoNeed) = BatchDuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
 
 
 """


### PR DESCRIPTION
CUDA CI is presently broken since CUDA requires Adapt 4, and this wasn't allowed by compat.

Let's make this an extension while we're bumping versions.