### PR TITLE
Fix GitHub action configuration – `continue-on-error`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,6 +117,7 @@ jobs:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: Build libEnzyme
         if: ${{ matrix.libEnzyme == 'local' && matrix.os != 'macOS-latest'}}
+        continue-on-error: ${{ matrix.version == 'nightly' }}
         id: build_libenzyme
         run: |
           julia --project=deps -e 'using Pkg; Pkg.instantiate()'
@@ -124,6 +125,7 @@ jobs:
           cp LocalPreferences.toml test/
       - name: Build libEnzyme MacOS
         if: ${{ matrix.libEnzyme == 'local' && matrix.os == 'macOS-latest'}}
+        continue-on-error: ${{ matrix.version == 'nightly' }}
         id: build_libenzyme_mac
         run: |
           julia --project=deps -e 'using Pkg; Pkg.instantiate()'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,21 +132,21 @@ jobs:
           SDKROOT=`xcrun --show-sdk-path` julia --project=deps deps/build_local.jl
           cp LocalPreferences.toml test/
       - uses: julia-actions/julia-buildpkg@v1
-        if: steps.build_libenzyme.outcome == 'success' || steps.build_libenzyme_mac.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.build_libenzyme.outcome == 'success' || steps.build_libenzyme_mac.outcome == 'success'
         continue-on-error: ${{ matrix.version == 'nightly' }}
         id: buildpkg
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-runtest@v1
-        if: steps.buildpkg.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.buildpkg.outcome == 'success'
         continue-on-error: ${{ matrix.version == 'nightly' }}
         id: run_tests
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-processcoverage@v1
-        if: steps.run_tests.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
       - uses: codecov/codecov-action@v1
-        if: steps.run_tests.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
         with:
           file: lcov.info
   enzymetestutils:
@@ -186,6 +186,7 @@ jobs:
       - name: setup EnzymeTestUtils
         shell: julia --color=yes {0}
         id: setup_testutils
+        continue-on-error: ${{ matrix.version == 'nightly' }}
         run: |
           using Pkg
           Pkg.develop([PackageSpec(; path) for path in (".", "lib/EnzymeCore")])
@@ -193,7 +194,7 @@ jobs:
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: Run the tests
-        if: steps.setup_testutils.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.setup_testutils.outcome == 'success'
         continue-on-error: ${{ matrix.version == 'nightly' }}
         id: run_tests
         shell: julia --color=yes {0}
@@ -201,11 +202,11 @@ jobs:
           using Pkg
           Pkg.test("EnzymeTestUtils"; coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
-        if: steps.run_tests.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
         with:
           directories: lib/EnzymeTestUtils/src
       - uses: codecov/codecov-action@v2
-        if: steps.run_tests.outcome == 'success'
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
         with:
           files: lcov.info
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.libEnzyme }} libEnzyme - assertions=${{ matrix.assertions }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -132,10 +131,14 @@ jobs:
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        id: run_tests
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-processcoverage@v1
+        if: steps.run_tests.outcome == 'success'
       - uses: codecov/codecov-action@v1
+        if: steps.run_tests.outcome == 'success'
         with:
           file: lcov.info
   enzymetestutils:
@@ -181,14 +184,18 @@ jobs:
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: Run the tests
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        id: run_tests
         shell: julia --color=yes {0}
         run: |
           using Pkg
           Pkg.test("EnzymeTestUtils"; coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
+        if: steps.run_tests.outcome == 'success'
         with:
           directories: lib/EnzymeTestUtils/src
       - uses: codecov/codecov-action@v2
+        if: steps.run_tests.outcome == 'success'
         with:
           files: lcov.info
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,20 +117,26 @@ jobs:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: Build libEnzyme
         if: ${{ matrix.libEnzyme == 'local' && matrix.os != 'macOS-latest'}}
+        id: build_libenzyme
         run: |
           julia --project=deps -e 'using Pkg; Pkg.instantiate()'
           julia --project=deps deps/build_local.jl
           cp LocalPreferences.toml test/
       - name: Build libEnzyme MacOS
         if: ${{ matrix.libEnzyme == 'local' && matrix.os == 'macOS-latest'}}
+        id: build_libenzyme_mac
         run: |
           julia --project=deps -e 'using Pkg; Pkg.instantiate()'
           SDKROOT=`xcrun --show-sdk-path` julia --project=deps deps/build_local.jl
           cp LocalPreferences.toml test/
       - uses: julia-actions/julia-buildpkg@v1
+        if: steps.build_libenzyme.outcome == 'success' || steps.build_libenzyme_mac.outcome == 'success'
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        id: buildpkg
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-runtest@v1
+        if: steps.buildpkg.outcome == 'success'
         continue-on-error: ${{ matrix.version == 'nightly' }}
         id: run_tests
         env:
@@ -177,6 +183,7 @@ jobs:
             ${{ runner.os }}-
       - name: setup EnzymeTestUtils
         shell: julia --color=yes {0}
+        id: setup_testutils
         run: |
           using Pkg
           Pkg.develop([PackageSpec(; path) for path in (".", "lib/EnzymeCore")])
@@ -184,6 +191,7 @@ jobs:
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: Run the tests
+        if: steps.setup_testutils.outcome == 'success'
         continue-on-error: ${{ matrix.version == 'nightly' }}
         id: run_tests
         shell: julia --color=yes {0}


### PR DESCRIPTION
Second version of #1030.

The appearance of the  ❌  everywhere in this repo makes it look poorly maintained (which it is not!). Right now a new user curious about Enzyme will land on the GitHub repo, and see everything broken:

<img width="400" alt="Screenshot 2024-01-13 at 23 01 40" src="https://github.com/EnzymeAD/Enzyme.jl/assets/7593028/3841b0ba-43f2-4173-98da-c1127df3dc36">

including all of the pull requests:

<img width="400" alt="Screenshot 2024-01-13 at 23 01 57" src="https://github.com/EnzymeAD/Enzyme.jl/assets/7593028/f1b5117c-dd59-46be-b6df-6ffca970d81d">

and even the commit history (with many more than just 1 failing job) –

<img width="614" alt="Screenshot 2024-01-13 at 23 07 23" src="https://github.com/EnzymeAD/Enzyme.jl/assets/7593028/b33a4980-800b-4d57-97c8-d209dbf80b98">

The issue is that julia nightly is always a bit sketchy to test on, and so one should configure CI to not fail if the nightly builds fail – they should simply be warnings. GitHub doesn't have a proper way to do this, the only way is the `continue-on-error` parameter.

`continue-on-error` is actually used in the current CI configuration file but it seems to not actually being applied (#72). This PR implements a fix for that and also for the `enzymetestutils` job.

Relevant docs:
- https://docs.github.com/en/actions/learn-github-actions/contexts
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error