### PR TITLE
Fix typo "appliable"

### DIFF
--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -316,7 +316,7 @@ function enzyme_custom_fwd(B, orig, gutils, normalR, shadowR)
 
     if llvmf === nothing
         @safe_debug "No custom forward rule is applicable for" TT
-        emit_error(B, orig, "Enzyme: No custom rule was appliable for " * string(TT))
+        emit_error(B, orig, "Enzyme: No custom rule was applicable for " * string(TT))
         return false
     end
     
@@ -540,7 +540,7 @@ function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils,
         aug_RT = something(Core.Compiler.typeinf_type(interp, ami.def, ami.specTypes, ami.sparam_vals), Any)
     else
         @safe_debug "No custom augmented_primal rule is applicable for" augprimal_TT
-        emit_error(B, orig, "Enzyme: No custom augmented_primal rule was appliable for " * string(augprimal_TT))
+        emit_error(B, orig, "Enzyme: No custom augmented_primal rule was applicable for " * string(augprimal_TT))
         return C_NULL
     end
 
@@ -601,7 +601,7 @@ function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils,
 
         if llvmf == nothing
             @safe_debug "No custom reverse rule is applicable for" rev_TT
-            emit_error(B, orig, "Enzyme: No custom reverse rule was appliable for " * string(rev_TT))
+            emit_error(B, orig, "Enzyme: No custom reverse rule was applicable for " * string(rev_TT))
             return C_NULL
         end
     end


### PR DESCRIPTION
This PR fixes a small typo ("appliable" instead of "applicable") in some error messages.