### PR TITLE
Restrict `ldiv!` rules to `Cholesky`

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -622,7 +622,7 @@ function EnzymeRules.forward(
         func::Const{typeof(ldiv!)},
         RT::Type,
         fact::Annotation{<:Cholesky},
-        B::Union{Const{<:AbstractVecOrMat}, DuplicatedNoNeed{<:AbstractVecOrMat}, Duplicated{<:AbstractVecOrMat}, BatchDuplicatedNoNeed{<:AbstractVecOrMat}, BatchDuplicated{<:AbstractVecOrMat}};
+        B;
         kwargs...
 )
     if isa(B, Const)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -627,14 +627,14 @@ function EnzymeRules.forward(
 )
     if isa(B, Const)
         @assert (RT <: Const)
-        return ldiv!(fact.val, B.val; kwargs...)
+        return func.val(fact.val, B.val; kwargs...)
     else
         N = width(B)
 
         @assert !isa(B, Const)
 
         retval = if !isa(fact, Const) || (RT <: Const) || (RT <: Duplicated) || (RT <: BatchDuplicated)
-            ldiv!(fact.val, B.val; kwargs...)
+            func.val(fact.val, B.val; kwargs...)
         else
             nothing
         end
@@ -660,7 +660,7 @@ function EnzymeRules.forward(
                 mul!(dB, dfact.L, tmp, -1, 1)
             end
 
-            ldiv!(fact.val, dB; kwargs...)
+            func.val(fact.val, dB; kwargs...)
         end
 
         if RT <: Const
@@ -746,7 +746,7 @@ function EnzymeRules.augmented_primal(
         B::Union{Const{<:AbstractVecOrMat}, DuplicatedNoNeed{<:AbstractVecOrMat}, Duplicated{<:AbstractVecOrMat}, BatchDuplicatedNoNeed{<:AbstractVecOrMat}, BatchDuplicated{<:AbstractVecOrMat}};
         kwargs...
 )
-    ldiv!(A.val, B.val; kwargs...)
+    func.val(A.val, B.val; kwargs...)
 
     cache_Bout = if !isa(A, Const) && !isa(B, Const)
         if EnzymeRules.overwritten(config)[3]
@@ -803,7 +803,7 @@ function EnzymeRules.reverse(
             #   dB = z, where  z = inv(A^T) dB
             #   dA −= z B(out)^T
 
-            ldiv!(cache_A, dB; kwargs...)
+            func.val(cache_A, dB; kwargs...)
             if !isa(A, Const)
                 dA = EnzymeRules.width(config) == 1 ? A.dval : A.dval[b]
                 mul!(dA.factors, dB, transpose(cache_Bout), -1, 1)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -743,7 +743,7 @@ function EnzymeRules.augmented_primal(
         RT::Type{<:Union{Const, DuplicatedNoNeed, Duplicated, BatchDuplicatedNoNeed, BatchDuplicated}},
 
         A::Annotation{<:Cholesky},
-        B::Union{Const{<:AbstractVecOrMat}, DuplicatedNoNeed{<:AbstractVecOrMat}, Duplicated{<:AbstractVecOrMat}, BatchDuplicatedNoNeed{<:AbstractVecOrMat}, BatchDuplicated{<:AbstractVecOrMat}};
+        B::Union{Const, DuplicatedNoNeed, Duplicated, BatchDuplicatedNoNeed, BatchDuplicated};
         kwargs...
 )
     func.val(A.val, B.val; kwargs...)
@@ -789,7 +789,7 @@ function EnzymeRules.reverse(
     dret,
     cache,
     A::Annotation{<:Cholesky},
-    B::Union{Const{<:AbstractVecOrMat}, DuplicatedNoNeed{<:AbstractVecOrMat}, Duplicated{<:AbstractVecOrMat}, BatchDuplicatedNoNeed{<:AbstractVecOrMat}, BatchDuplicated{<:AbstractVecOrMat}};
+    B::Union{Const, DuplicatedNoNeed, Duplicated, BatchDuplicatedNoNeed, BatchDuplicated};
     kwargs...
 )
     if !isa(B, Const)


### PR DESCRIPTION
I noticed that the `ldiv!` rules added in #1220 also support `Array` arguments (or `Const` etc. of `Array`s). However, no such primal methods exist in LinearAlgebra:
```julia
julia> using LinearAlgebra

julia> methods(ldiv!, Tuple{Array, Any})
# 0 methods for generic function "ldiv!" from LinearAlgebra
```
There exist a few methods for `AbstractMatrix` subtypes such as `Diagonal` but I think it might be best to just restrict the rule to `Cholesky` for now (also in line with the docstring of `ldiv!` which tells users that "The argument A should not be a matrix. Rather, instead of matrices it should be a factorization object").

Additionally, the PR fixes a call to the primal in the `reverse` rule which did not forward the `kwargs...` correctly.