### PR TITLE
Throw descriptive AsssertionError instead of `@show` + `@assert` inside of `create_abi_wrapper`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3252,7 +3252,7 @@ function create_abi_wrapper(enzymefn::LLVM.Function, TT, rettype, actualRetType,
     if is_adjoint && rettype <: Active
         @assert !sret_union
         if allocatedinline(actualRetType) != allocatedinline(literal_rt)
-            @show actualRetType, literal_rt, rettype
+            @safe_show actualRetType, literal_rt, rettype
         end
         @assert allocatedinline(actualRetType) == allocatedinline(literal_rt)
         if !allocatedinline(actualRetType)


### PR DESCRIPTION
I just ran into
```julia
(actualRetType, literal_rt, rettype) = (actualRetType, literal_rt, rettype) = (actualRetType, literal_rt, rettype) = Gradient - enzyme: Error During Test at REPL[5]:1
  Got exception outside of a @test
  task switch not allowed from inside staged nor pure functions
  Stacktrace:
    [1] try_yieldto(undo::typeof(Base.ensure_rescheduled))
      @ Base ./task.jl:910
    [2] wait()
      @ Base ./task.jl:984
    [3] uv_write(s::Base.TTY, p::Ptr{UInt8}, n::UInt64)
      @ Base ./stream.jl:1048
    [4] unsafe_write(s::Base.TTY, p::Ptr{UInt8}, n::UInt64)
      @ Base ./stream.jl:1120
    [5] write
      @ ./strings/io.jl:244 [inlined]
    [6] print
      @ ./strings/io.jl:246 [inlined]
    [7] print(::Base.TTY, ::String, ::String, ::Vararg{String})
      @ Base ./strings/io.jl:46
    [8] println(::Base.TTY, ::String, ::Vararg{String})
      @ Base ./strings/io.jl:75
    [9] println(::String, ::String)
      @ Base ./coreio.jl:4
   [10] create_abi_wrapper(enzymefn::LLVM.Function, TT::Type, rettype::Type, actualRetType::Type, Mode::Enzyme.API.CDerivativeMode, augmented::Nothing, width::Int64, returnPrimal::Bool, shadow_init::Bool, world::UInt64, interp::Enzyme.Compiler.Interpreter.EnzymeInterpreter)
      @ Enzyme.Compiler ~/.julia/packages/Enzyme/KJgKj/src/compiler.jl:3255
...
```
Based on the stacktrace I assume that the problem is the use of `@show` instead of `@safe_show` (as a few lines below) in the `create_abi_wrapper` function.

By the way, is there any typical problem (or error on my side) when hitting this branch?
