### PR TITLE
Add rule for triangular solves

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -531,14 +531,14 @@ function EnzymeRules.reverse(
     end
 
     for (dA, db, dy) in zip(dAs, dbs, dys)
-        z = transpose(cache_A) \ dy
+        z = adjoint(cache_A) \ dy
         if !(typeof(A) <: Const)
-            dA.data .-= _zero_unused_elements!(AT(z * transpose(y)))
+            dA.data .-= _zero_unused_elements!(AT(z * adjoint(y)))
         end
         if !(typeof(b) <: Const)
             db .+= z
         end
-        dy .= eltype(dy)(0)
+        dy .= zero(eltype(dy))
     end
 
     return (nothing,nothing)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -462,13 +462,13 @@ function EnzymeRules.augmented_primal(
     A::Annotation{AT},
     B::Annotation{BT}
 ) where {RT, YT <: Array, AT <: EnzymeTriangulars, BT <: Array}
-    func.val(Y.val, A.val, B.val)
     cache_Y = EnzymeRules.overwritten(config)[1] ? copy(Y.val) : Y.val
     cache_A = EnzymeRules.overwritten(config)[2] ? copy(A.val) : A.val
     cache_A = compute_lu_cache(cache_A, B.val)
     cache_B = EnzymeRules.overwritten(config)[3] ? copy(B.val) : nothing
     primal = EnzymeRules.needs_primal(config) ? Y.val : nothing
     shadow = EnzymeRules.needs_shadow(config) ? Y.dval : nothing
+    func.val(Y.val, A.val, B.val)
     return EnzymeRules.AugmentedReturn{typeof(primal), typeof(shadow), Any}(
         primal, shadow, (cache_Y, cache_A, cache_B))
 end

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -533,7 +533,7 @@ function EnzymeRules.reverse(
     for (dA, db, dy) in zip(dAs, dbs, dys)
         z = transpose(cache_A) \ dy
         if !(typeof(A) <: Const)
-            dA.data .-= _zero_unused_elements(AT(z * transpose(y)))
+            dA.data .-= _zero_unused_elements!(AT(z * transpose(y)))
         end
         if !(typeof(b) <: Const)
             db .+= z
@@ -544,10 +544,10 @@ function EnzymeRules.reverse(
     return (nothing,nothing)
 end
 
-_zero_unused_elements(A::UpperTriangular) = triu!(A.data)
-_zero_unused_elements(A::LowerTriangular) = tril!(A.data)
-_zero_unused_elements(A::UnitUpperTriangular) = triu!(A.data, 1)
-_zero_unused_elements(A::UnitLowerTriangular) = tril!(A.data, -1)
+_zero_unused_elements!(A::UpperTriangular) = triu!(A.data)
+_zero_unused_elements!(A::LowerTriangular) = tril!(A.data)
+_zero_unused_elements!(A::UnitUpperTriangular) = triu!(A.data, 1)
+_zero_unused_elements!(A::UnitLowerTriangular) = tril!(A.data, -1)
 
 @static if VERSION >= v"1.7-"
 # Force a rule around hvcat_fill as it is type unstable if the tuple is not of the same type (e.g., int, float, int, float)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -462,6 +462,7 @@ function EnzymeRules.augmented_primal(
     A::Annotation{AT},
     B::Annotation{BT}
 ) where {RT, YT <: Array, AT <: EnzymeTriangulars, BT <: Array}
+    func.val(Y.val, A.val, B.val)
     cache_Y = EnzymeRules.overwritten(config)[1] ? copy(Y.val) : Y.val
     cache_A = EnzymeRules.overwritten(config)[2] ? copy(A.val) : A.val
     cache_A = compute_lu_cache(cache_A, B.val)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,3 +19,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+EnzymeTestUtils = "0.1.4"

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -395,18 +395,6 @@ end
         B = rand(TE, sizeB...)
         Y = zeros(TE, sizeB...)
         A = T(M)
-        @testset "test primal" begin
-            Y1 = deepcopy(Y)
-            Y2 = deepcopy(Y)
-            dY = make_zero(Y)
-            function f!(Y, A, B)
-                ldiv!(Y, A, B)
-                return nothing
-            end
-            ldiv!(Y1, A, B)
-            Enzyme.autodiff(Reverse, f!, Duplicated(Y2, dY), Const(A), Const(B))
-            @test Y1 ≈ Y2
-        end
         @testset "test against EnzymeTestUtils through constructor" begin
             _A = T(A)
             function f!(Y, A, B, ::T) where T

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -401,6 +401,7 @@ end
             _rand_tangent(A::UpperTriangular) = UpperTriangular(rand(size(A)...))
             _rand_tangent(A::LowerTriangular) = LowerTriangular(rand(size(A)...))
             _rand_tangent(A::UnitUpperTriangular) = UpperTriangular(triu!(rand(size(A)...), 1))
+            _rand_tangent(A::UnitLowerTriangular) = LowerTriangular(tril!(rand(size(A)...), -1))
             Y = A \ B
             @test A * Y ≈ B
             dA = Enzyme.make_zero(A)
@@ -412,8 +413,10 @@ end
             @test (h(A, B + ϵ*W) - h(A, B)) / ϵ ≈ tr(W' * dB) rtol = 1e-5
         end
         @testset "test against EnzymeTestUtils" begin
-            for Tret in (Const, Active), TA in (Const, Duplicated), TB in (Const, Duplicated)
-                test_reverse(h, Tret, (A, TA), (B, TB); rtol = 1e-2, atol = 1e-2)
+            for Tret in (Const, Active), TB in (Const, Duplicated)
+                test_reverse(h, Tret, (A, Const), (B, TB); rtol = 1e-2, atol = 1e-2)
+                dA = T(Enzyme._zero_unused_elements!(EnzymeTestUtils.rand_tangent(A)))
+                test_reverse(h, Tret, Duplicated(A, dA), (B, TB); rtol = 1e-2, atol = 1e-2)
             end
         end
     end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -416,6 +416,7 @@ end
             for TY in (Const, Duplicated, BatchDuplicated),
                 TM in (Const, Duplicated, BatchDuplicated),
                 TB in (Const, Duplicated, BatchDuplicated)
+                are_activities_compatible(Const, TY, TA, TB) || continue
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -398,9 +398,9 @@ end
     _rand_tangent(A::UnitUpperTriangular) = UpperTriangular(triu!(rand(eltype(A), size(A)...), 1))
     _rand_tangent(A::UnitLowerTriangular) = LowerTriangular(tril!(rand(eltype(A), size(A)...), -1))
     @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular),
-        TE in (Float64, ComplexF64)
+        TE in (Float64, ComplexF64), sizeB in ((3,), (3, 3))
         M = rand(TE, 3, 3)
-        B = rand(TE, 3, 3)
+        B = rand(TE, sizeB...)
         A = T(M)
         @testset "test against hand-rolled FD" begin
             Y = A \ B
@@ -408,7 +408,7 @@ end
             dA = Enzyme.make_zero(A)
             dB = Enzyme.make_zero(B)
             V = _rand_tangent(A)
-            W = rand(TE, 3, 3)
+            W = rand(TE, size(B)...)
             ϵ = 1e-9
             Enzyme.autodiff(Reverse, h, Duplicated(A, dA), Duplicated(B, dB))
             @test (h(A + ϵ*V, B) - h(A, B)) / ϵ ≈ tr(adjoint(dA) * V) rtol = 1e-6

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -2,6 +2,7 @@ module InternalRules
 
 using Enzyme
 using Enzyme.EnzymeRules
+using EnzymeTestUtils
 using FiniteDifferences
 using LinearAlgebra
 using SparseArrays

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -405,7 +405,7 @@ end
             for TY in (Const, Duplicated, BatchDuplicated),
                 TM in (Const, Duplicated, BatchDuplicated),
                 TB in (Const, Duplicated, BatchDuplicated)
-                are_activities_compatible(Const, TY, TA, TB) || continue
+                are_activities_compatible(Const, TY, TB) || continue
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -395,6 +395,18 @@ end
         B = rand(TE, sizeB...)
         Y = zeros(TE, sizeB...)
         A = T(M)
+        @testset "test primal" begin
+            Y1 = deepcopy(Y)
+            Y2 = deepcopy(Y)
+            dY = make_zero(Y)
+            function f!(Y, A, B)
+                ldiv!(Y, A, B)
+                return nothing
+            end
+            ldiv!(Y1, A, B)
+            Enzyme.autodiff(Reverse, f!, Duplicated(Y2, dY), Const(A), Const(B))
+            @test Y1 ≈ Y2
+        end
         @testset "test against EnzymeTestUtils through constructor" begin
             _A = T(A)
             function f!(Y, A, B, ::T) where T

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -414,9 +414,9 @@ end
                 return nothing
             end
             for TY in (Const, Duplicated, BatchDuplicated),
-                TA in (Const, Duplicated, BatchDuplicated),
+                TM in (Const, Duplicated, BatchDuplicated),
                 TB in (Const, Duplicated, BatchDuplicated)
-                test_reverse(f!, Const, (Y, TY), (M, TA), (B, TB), (_A, Const))
+                test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end
     end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -413,9 +413,9 @@ end
                 return ldiv!(Y, T(A), B)
             end
             for Tret in (Const, Active),
-                TY in (Const, Duplicated),
-                TA in (Const, Duplicated),
-                TB in (Const, Duplicated)
+                TY in (Const, Duplicated, BatchDuplicated),
+                TA in (Const, Duplicated, BatchDuplicated),
+                TB in (Const, Duplicated, BatchDuplicated)
                 test_reverse(f!, Const, (Y, TY), (M, TA), (B, TB), (_A, Const))
             end
         end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -389,7 +389,6 @@ end
 end
 
 @testset "Linear solve for triangular matrices" begin
-    h!(Y, A, B) = (copyto!(Y, A \ B); nothing)
     @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular),
         TE in (Float64, ComplexF64), sizeB in ((3,), (3, 3))
         M = rand(TE, 3, 3)
@@ -399,7 +398,7 @@ end
         @testset "test against EnzymeTestUtils through constructor" begin
             _A = T(A)
             function f!(Y, A, B, ::T) where T
-                return h!(Y, T(A), B)
+                return ldiv!(Y, T(A), B)
             end
             for Tret in (Const, Active),
                 TY in (Const, Duplicated),

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -390,45 +390,38 @@ end
 
 @testset "Linear solve for triangular matrices" begin
     h(A, B) = sum(A \ B)
-    M = rand(3, 3)
-    B = rand(3, 3)
-    ϵ = 1e-9
-    @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+    # Custom tangent for triangular matrices
+    # EnzymeTestUtils.rand_tangent is not in the tangent space for `Unit...Triangular`
+    # matrices
+    _rand_tangent(A::UpperTriangular) = UpperTriangular(rand(eltype(A), size(A)...))
+    _rand_tangent(A::LowerTriangular) = LowerTriangular(rand(eltype(A), size(A)...))
+    _rand_tangent(A::UnitUpperTriangular) = UpperTriangular(triu!(rand(eltype(A), size(A)...), 1))
+    _rand_tangent(A::UnitLowerTriangular) = LowerTriangular(tril!(rand(eltype(A), size(A)...), -1))
+    @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular),
+        TE in (Float64, ComplexF64)
+        M = rand(TE, 3, 3)
+        B = rand(TE, 3, 3)
         A = T(M)
         @testset "test against hand-rolled FD" begin
-            # Custom tangent for triangular matrices
-            # EnzymeTestUtils.rand_tangent is not in the tangent space for `Unit...Triangular`
-            # matrices
-            _rand_tangent(A::UpperTriangular) = UpperTriangular(rand(size(A)...))
-            _rand_tangent(A::LowerTriangular) = LowerTriangular(rand(size(A)...))
-            _rand_tangent(A::UnitUpperTriangular) = UpperTriangular(triu!(rand(size(A)...), 1))
-            _rand_tangent(A::UnitLowerTriangular) = LowerTriangular(tril!(rand(size(A)...), -1))
             Y = A \ B
             @test A * Y ≈ B
             dA = Enzyme.make_zero(A)
             dB = Enzyme.make_zero(B)
             V = _rand_tangent(A)
-            W = rand(3, 3)
+            W = rand(TE, 3, 3)
+            ϵ = 1e-9
             Enzyme.autodiff(Reverse, h, Duplicated(A, dA), Duplicated(B, dB))
-            @test (h(A + ϵ*V, B) - h(A, B)) / ϵ ≈ tr(V' * dA) rtol = 1e-5
-            @test (h(A, B + ϵ*W) - h(A, B)) / ϵ ≈ tr(W' * dB) rtol = 1e-5
+            @test (h(A + ϵ*V, B) - h(A, B)) / ϵ ≈ tr(adjoint(dA) * V) rtol = 1e-6
+            @test (h(A, B + ϵ*W) - h(A, B)) / ϵ ≈ tr(adjoint(dB) * W) rtol = 1e-6
         end
-        @testset "test against EnzymeTestUtils" begin
-            for Tret in (Const, Active), TB in (Const, Duplicated)
-                test_reverse(h, Tret, (A, Const), (B, TB); rtol = 1e-2, atol = 1e-2)
-                dA = T(Enzyme._zero_unused_elements!(EnzymeTestUtils.rand_tangent(A)))
-                test_reverse(h, Tret, Duplicated(A, dA), (B, TB); rtol = 1e-2, atol = 1e-2)
+        @testset "test against EnzymeTestUtils through constructor" begin
+            _A = T(A)
+            function f(::T, A, B) where T
+                return h(T(A), B)
             end
-        end
-    end
-    @testset "test against EnzymeTestUtils through constructor" begin
-        hUT(A, B) = h(UpperTriangular(A), B)
-        hLT(A, B) = h(LowerTriangular(A), B)
-        hUUT(A, B) = h(UnitUpperTriangular(A), B)
-        hULT(A, B) = h(UnitLowerTriangular(A), B)
-        for f in (hUT, hLT, hUUT, hULT),
-            Tret in (Const, Active), TA in (Const, Duplicated), TB in (Const, Duplicated)
-            test_reverse(f, Tret, (M, TA), (B, TB); rtol = 1e-2, atol = 1e-2)
+            for Tret in (Const, Active), TA in (Const, Duplicated), TB in (Const, Duplicated)
+                test_reverse(f, Tret, (_A, Const), (M, TA), (B, TB))
+            end
         end
     end
 end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -405,7 +405,7 @@ end
             for TY in (Const, Duplicated, BatchDuplicated),
                 TM in (Const, Duplicated, BatchDuplicated),
                 TB in (Const, Duplicated, BatchDuplicated)
-                are_activities_compatible(Const, TY, TB) || continue
+                are_activities_compatible(Const, TY, TM, TB) || continue
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -410,10 +410,10 @@ end
         @testset "test against EnzymeTestUtils through constructor" begin
             _A = T(A)
             function f!(Y, A, B, ::T) where T
-                return ldiv!(Y, T(A), B)
+                ldiv!(Y, T(A), B)
+                return nothing
             end
-            for Tret in (Const, Active),
-                TY in (Const, Duplicated, BatchDuplicated),
+            for TY in (Const, Duplicated, BatchDuplicated),
                 TA in (Const, Duplicated, BatchDuplicated),
                 TB in (Const, Duplicated, BatchDuplicated)
                 test_reverse(f!, Const, (Y, TY), (M, TA), (B, TB), (_A, Const))

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -391,7 +391,8 @@ end
 @testset "Linear solve for triangular matrices" begin
     @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular),
         TE in (Float64, ComplexF64), sizeB in ((3,), (3, 3))
-        M = rand(TE, 3, 3)
+        n = sizeB[1]
+        M = rand(TE, n, n)
         B = rand(TE, sizeB...)
         Y = zeros(TE, sizeB...)
         A = T(M)


### PR DESCRIPTION
So this is a first attempt by a complete beginner at this.
One issue is that the tests using EnzymeTestUtils fail because they seem to compare the `data` field of the cotangents:
```julia
A = UpperTriangular(rand(2, 2))
B = copy(A); B.data[2, 1] = 0
EnzymeTestUtils.test_approx(A, B) # Errors because the `data` field is not the same
```
The remaining tests currently pass, but they are not covering all cases.