### PR TITLE
Widen `cholesky` rule to `Hermitian` and `Symmetric` matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 CEnum = "0.4, 0.5"
 EnzymeCore = "0.6.4, 0.6.5"
-Enzyme_jll = "0.0.98"
+Enzyme_jll = "0.0.99"
 GPUCompiler = "0.21, 0.22, 0.23, 0.24, 0.25"
 LLVM = "6.1"
 ObjectFile = "0.4"

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -724,8 +724,8 @@ function EnzymeRules.reverse(
         dfacts = EnzymeRules.width(config) == 1 ? (dfact,) : dfact
 
         for (dA, dfact) in zip(dAs, dfacts)
-            if dA !== dfact.factors
-                _dA = dA isa LinearAlgebra.RealHermSym ? dA.data : dA
+            _dA = dA isa LinearAlgebra.RealHermSym ? dA.data : dA
+            if _dA !== dfact.factors
                 _dA .+= dfact.factors
                 dfact.factors .= 0
             end

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -677,7 +677,12 @@ function EnzymeRules.forward(
     end
 end
 
-function EnzymeRules.augmented_primal(config, func::Const{typeof(cholesky)}, RT::Type, A::Annotation{AT}; kwargs...) where {AT <: Array}
+function EnzymeRules.augmented_primal(
+    config,
+    func::Const{typeof(cholesky)},
+    RT::Type,
+    A::Annotation{<:Union{Matrix,LinearAlgebra.RealHermSym{<:Real,<:Matrix}}};
+    kwargs...)
     fact = if EnzymeRules.needs_primal(config)
         cholesky(A.val; kwargs...)
     else
@@ -711,8 +716,8 @@ function EnzymeRules.reverse(
     ::Const{typeof(cholesky)},
     RT::Type,
     dfact,
-    A::Annotation{AT};
-    kwargs...) where {AT <: Array}
+    A::Annotation{<:Union{Matrix,LinearAlgebra.RealHermSym{<:Real,<:Matrix}}};
+    kwargs...)
 
     if !(RT <: Const) && !isa(A, Const)
         dAs = EnzymeRules.width(config) == 1 ? (A.dval,) : A.dval
@@ -720,7 +725,8 @@ function EnzymeRules.reverse(
 
         for (dA, dfact) in zip(dAs, dfacts)
             if dA !== dfact.factors
-                dA .+= dfact.factors
+                _dA = dA isa LinearAlgebra.RealHermSym ? dA.data : dA
+                _dA .+= dfact.factors
                 dfact.factors .= 0
             end
         end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -134,9 +134,29 @@ end
         fact = cholesky(A)
         divdriver_NC(x, fact, b)
     end
+
+    function divdriver_herm(x, A, b)
+        fact = cholesky(Hermitian(A))
+        divdriver_NC(x, fact, b)
+    end
+
+    function divdriver_sym(x, A, b)
+        fact = cholesky(Symmetric(A))
+        divdriver_NC(x, fact, b)
+    end
     
     function ldivdriver(x, A, b)
         fact = cholesky(A)
+        ldivdriver_NC(x, fact, b)
+    end
+
+    function ldivdriver_herm(x, A, b)
+        fact = cholesky(Hermitian(A))
+        ldivdriver_NC(x, fact, b)
+    end
+
+    function ldivdriver_sym(x, A, b)
+        fact = cholesky(Symmetric(A))
         ldivdriver_NC(x, fact, b)
     end
 
@@ -306,7 +326,14 @@ end
         return J
     end
     
-    @testset "Testing $op" for (op, driver, driver_NC) in ((:\, divdriver, divdriver_NC), (:ldiv!, ldivdriver, ldivdriver_NC))
+    @testset "Testing $op" for (op, driver, driver_NC) in (
+        (:\, divdriver, divdriver_NC),
+        (:\, divdriver_herm, divdriver_NC),
+        (:\, divdriver_sym, divdriver_NC),
+        (:ldiv!, ldivdriver, ldivdriver_NC),
+        (:ldiv!, ldivdriver_herm, ldivdriver_NC),
+        (:ldiv!, ldivdriver_sym, ldivdriver_NC)
+    )
         A, b = symmetric_definite(10)
         n = length(b)
         A = Matrix(A)


### PR DESCRIPTION
Seems to fix #1272:
```julia
julia> using Enzyme, LinearAlgebra

julia> g(C, X) = sum(C \ X)
g (generic function with 1 method)

julia> g2(A, X) = g(cholesky(A * A' + I), X)
g2 (generic function with 1 method)

julia> A = rand(2, 2);

julia> X = rand(2, 2);

julia> ∂g2_∂A = zero(A);

julia> ∂g2_∂X = zero(X);

julia> autodiff(Reverse, g2, Active, Duplicated(A, ∂g2_∂A), Duplicated(X, ∂g2_∂X))
┌ Warning: Using fallback BLAS replacements, performance may be degraded
└ @ Enzyme.Compiler ~/.julia/packages/GPUCompiler/U36Ed/src/utils.jl:59
warning: didn't implement memmove, using memcpy as fallback which can result in errors
((nothing, nothing),)

julia> g3(A, X) = g(cholesky(Symmetric(A * A' + I)), X)
g3 (generic function with 1 method)

julia> ∂g3_∂A = zero(A);

julia> ∂g3_∂X = zero(X);

julia> autodiff(Reverse, g3, Active, Duplicated(A, ∂g3_∂A), Duplicated(X, ∂g3_∂X))
┌ Warning: Using fallback BLAS replacements, performance may be degraded
└ @ Enzyme.Compiler ~/.julia/packages/GPUCompiler/U36Ed/src/utils.jl:59
warning: didn't implement memmove, using memcpy as fallback which can result in errors
((nothing, nothing),)

julia> ∂g3_∂A == ∂g2_∂A
true

julia> ∂g3_∂X == ∂g2_∂X
true
```

However, the big caveat is that I don't know if this is the correct approach.