### PR TITLE
EnzymeTestUtils: check that args are mutated correctly

### DIFF
--- a/lib/EnzymeTestUtils/Project.toml
+++ b/lib/EnzymeTestUtils/Project.toml
@@ -1,7 +1,7 @@
 name = "EnzymeTestUtils"
 uuid = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 authors = ["Seth Axen <seth@sethaxen.com>", "William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
This PR fixes the issue raised in https://github.com/EnzymeAD/Enzyme.jl/pull/1264#discussion_r1486375144 where EnzymeTestUtils was not checking if arguments to a rule were being mutated in the same way as they were by the primal.