### PR TITLE
Fix triangular solve rule for `Adjoint`s

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -493,7 +493,7 @@ function EnzymeRules.reverse(
             end
             if !isa(A, Const)
                 dA = EnzymeRules.width(config) == 1 ? A.dval : A.dval[b]
-                dA.data .-= _zero_unused_elements!(AT(z * adjoint(cache_Yout)))
+                dA.data .-= _zero_unused_elements!(A.val, z * adjoint(cache_Yout))
             end
             dY .= zero(eltype(dY))
         end
@@ -501,10 +501,10 @@ function EnzymeRules.reverse(
     return (nothing, nothing, nothing)
 end
 
-_zero_unused_elements!(A::UpperTriangular) = triu!(A.data)
-_zero_unused_elements!(A::LowerTriangular) = tril!(A.data)
-_zero_unused_elements!(A::UnitUpperTriangular) = triu!(A.data, 1)
-_zero_unused_elements!(A::UnitLowerTriangular) = tril!(A.data, -1)
+_zero_unused_elements!(::UpperTriangular, X) = triu!(X)
+_zero_unused_elements!(::LowerTriangular, X) = tril!(X)
+_zero_unused_elements!(::UnitUpperTriangular, X) = triu!(X, 1)
+_zero_unused_elements!(::UnitLowerTriangular, X) = tril!(X, -1)
 
 @static if VERSION >= v"1.7-"
 # Force a rule around hvcat_fill as it is type unstable if the tuple is not of the same type (e.g., int, float, int, float)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -493,7 +493,7 @@ function EnzymeRules.reverse(
             end
             if !isa(A, Const)
                 dA = EnzymeRules.width(config) == 1 ? A.dval : A.dval[b]
-                dA.data .-= _zero_unused_elements!(A.val, z * adjoint(cache_Yout))
+                dA.data .-= _zero_unused_elements!(z * adjoint(cache_Yout), A.val)
             end
             dY .= zero(eltype(dY))
         end
@@ -501,10 +501,10 @@ function EnzymeRules.reverse(
     return (nothing, nothing, nothing)
 end
 
-_zero_unused_elements!(::UpperTriangular, X) = triu!(X)
-_zero_unused_elements!(::LowerTriangular, X) = tril!(X)
-_zero_unused_elements!(::UnitUpperTriangular, X) = triu!(X, 1)
-_zero_unused_elements!(::UnitLowerTriangular, X) = tril!(X, -1)
+_zero_unused_elements!(X, ::UpperTriangular) = triu!(X)
+_zero_unused_elements!(X, ::LowerTriangular) = tril!(X)
+_zero_unused_elements!(X, ::UnitUpperTriangular) = triu!(X, 1)
+_zero_unused_elements!(X, ::UnitLowerTriangular) = tril!(X, -1)
 
 @static if VERSION >= v"1.7-"
 # Force a rule around hvcat_fill as it is type unstable if the tuple is not of the same type (e.g., int, float, int, float)

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -493,7 +493,7 @@ function EnzymeRules.reverse(
             end
             if !isa(A, Const)
                 dA = EnzymeRules.width(config) == 1 ? A.dval : A.dval[b]
-                dA.data .-= _zero_unused_elements!(A.val, z * adjoint(cache_Yout))
+                dA.data .-= _zero_unused_elements!(AT(z * adjoint(cache_Yout)))
             end
             dY .= zero(eltype(dY))
         end
@@ -501,10 +501,10 @@ function EnzymeRules.reverse(
     return (nothing, nothing, nothing)
 end
 
-_zero_unused_elements!(::UpperTriangular, X) = triu!(X)
-_zero_unused_elements!(::LowerTriangular, X) = tril!(X)
-_zero_unused_elements!(::UnitUpperTriangular, X) = triu!(X, 1)
-_zero_unused_elements!(::UnitLowerTriangular, X) = tril!(X, -1)
+_zero_unused_elements!(A::UpperTriangular) = triu!(A.data)
+_zero_unused_elements!(A::LowerTriangular) = tril!(A.data)
+_zero_unused_elements!(A::UnitUpperTriangular) = triu!(A.data, 1)
+_zero_unused_elements!(A::UnitLowerTriangular) = tril!(A.data, -1)
 
 @static if VERSION >= v"1.7-"
 # Force a rule around hvcat_fill as it is type unstable if the tuple is not of the same type (e.g., int, float, int, float)

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -409,7 +409,9 @@ end
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end
-        @testset "regression test for #1306" begin
+        @testset "test through `Adjoint` wrapper (regression test for #1306)" begin
+            # Test that we get the same derivative for `M` as for the adjoint of its
+            # (materialized) transpose. It's the same matrix, but represented differently
             function f!(Y, A, B)
                 ldiv!(Y, A, B)
                 return nothing

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -396,7 +396,7 @@ end
         B = rand(TE, sizeB...)
         Y = zeros(TE, sizeB...)
         A = T(M)
-        @testset "test against EnzymeTestUtils through constructor" begin
+        @testset "test through constructor" begin
             _A = T(A)
             function f!(Y, A, B, ::T) where T
                 ldiv!(Y, T(A), B)
@@ -407,6 +407,19 @@ end
                 TB in (Const, Duplicated, BatchDuplicated)
                 are_activities_compatible(Const, TY, TM, TB) || continue
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
+            end
+        end
+        @testset "test without constructor" for A in (T(M),)
+            function f!(Y, A, B)
+                ldiv!(Y, A, B)
+                return nothing
+            end
+            A = T(M)
+            for TY in (Const, Duplicated, BatchDuplicated),
+                TA in (Const, Duplicated, BatchDuplicated),
+                TB in (Const, Duplicated, BatchDuplicated)
+                are_activities_compatible(Const, TY, TA, TB) || continue
+                test_reverse(f!, Const, (Y, TY), (A, TA), (B, TB))
             end
         end
     end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -415,16 +415,17 @@ end
                 return nothing
             end
             A1 = T(M)
-            A2 = T(permutedims(M)')
+            A2 = T(conj(permutedims(M))')
             dA1 = make_zero(A1)
             dA2 = make_zero(A2)
             dB1 = make_zero(B)
             dB2 = make_zero(B)
-            dY = rand(TE, sizeB...)
-            autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A1, dA1), Duplicated(B, dB1))
-            autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A2, dA2), Duplicated(B, dB2))
-            # @test dA1 ≈ dA2
-            # @test dB1 ≈ dB2
+            dY1 = rand(TE, sizeB...)
+            dY2 = copy(dY1)
+            autodiff(Reverse, f!, Duplicated(Y, dY1), Duplicated(A1, dA1), Duplicated(B, dB1))
+            autodiff(Reverse, f!, Duplicated(Y, dY2), Duplicated(A2, dA2), Duplicated(B, dB2))
+            @test dA1.data ≈ dA2.data
+            @test dB1 ≈ dB2
         end
     end
 end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -409,18 +409,22 @@ end
                 test_reverse(f!, Const, (Y, TY), (M, TM), (B, TB), (_A, Const))
             end
         end
-        @testset "test without constructor" for A in (T(M),)
+        @testset "regression test for #1306" begin
             function f!(Y, A, B)
                 ldiv!(Y, A, B)
                 return nothing
             end
-            A = T(M)
-            for TY in (Const, Duplicated, BatchDuplicated),
-                TA in (Const, Duplicated, BatchDuplicated),
-                TB in (Const, Duplicated, BatchDuplicated)
-                are_activities_compatible(Const, TY, TA, TB) || continue
-                test_reverse(f!, Const, (Y, TY), (A, TA), (B, TB))
-            end
+            A1 = T(M)
+            A2 = T(permutedims(M)')
+            dA1 = make_zero(A1)
+            dA2 = make_zero(A2)
+            dB1 = make_zero(B)
+            dB2 = make_zero(B)
+            dY = rand(TE, sizeB...)
+            autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A1, dA1), Duplicated(B, dB1))
+            # autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A2, dA2), Duplicated(B, dB2))
+            # @test dA1 ≈ dA2
+            # @test dB1 ≈ dB2
         end
     end
 end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -422,7 +422,7 @@ end
             dB2 = make_zero(B)
             dY = rand(TE, sizeB...)
             autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A1, dA1), Duplicated(B, dB1))
-            # autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A2, dA2), Duplicated(B, dB2))
+            autodiff(Reverse, f!, Duplicated(Y, dY), Duplicated(A2, dA2), Duplicated(B, dB2))
             # @test dA1 ≈ dA2
             # @test dB1 ≈ dB2
         end


### PR DESCRIPTION
When wrapping an `Adjoint`, the previous rule errored.