### PR TITLE
Define `compiler_job_from_backend`

### DIFF
--- a/lib/EnzymeCore/Project.toml
+++ b/lib/EnzymeCore/Project.toml
@@ -1,7 +1,7 @@
 name = "EnzymeCore"
 uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [compat]
 Adapt = "3, 4"

--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -239,7 +239,7 @@ end
 
 function tape_type end
 
-function parent_job_for_tape_type end
+function compiler_config_from_backend end
 
 include("rules.jl")
 

--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -239,6 +239,8 @@ end
 
 function tape_type end
 
+function parent_job_for_tape_type end
+
 include("rules.jl")
 
 end # module EnzymeCore

--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -239,7 +239,21 @@ end
 
 function tape_type end
 
-function compiler_config_from_backend end
+"""
+    compiler_job_from_backend(::KernelAbstractions.Backend, F::Type, TT:Type)::GPUCompiler.CompilerJob
+
+Returns a GPUCompiler CompilerJob from a backend as specified by the first argument to the function.
+
+For example, in CUDA one would do:
+
+```julia
+function EnzymeCore.compiler_job_from_backend(::CUDABackend, @nospecialize(F::Type), @nospecialize(TT::Type))
+    mi = GPUCompiler.methodinstance(F, TT)
+    return GPUCompiler.CompilerJob(mi, CUDA.compiler_config(CUDA.device()))
+end
+```
+"""
+function compiler_job_from_backend end
 
 include("rules.jl")
 


### PR DESCRIPTION
As noted in https://github.com/JuliaGPU/CUDA.jl/pull/2260#discussion_r1508550355 
it is a bit akward to add a specific interface to KernelAbstraction
so instead we add it to EnzymeCore.
