### PR TITLE
Set `parallel` to `false` if `parent_job` is not `nothing`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -4758,7 +4758,7 @@ function GPUCompiler.codegen(output::Symbol, job::CompilerJob{<:EnzymeTarget};
         target_machine = GPUCompiler.llvm_machine(primal_job.config.target)
     end
 
-    parallel = Threads.nthreads() > 1
+    parallel = parent_job === nothing ? Threads.nthreads() > 1 : false
     process_module = false
     device_module = false
     if parent_job !== nothing


### PR DESCRIPTION
While doing some conference-driven development (🙂) I found that Enzyme was generating `atomicrmw` instructions in the LLVM IR of my gradient, but my backend doesn't support them, and so my program was crashing at runtime...but only in Pluto.  @vchuravy pointed out the problem may be this setting of `parallel`, related to the fact Pluto starts by default `julia` with multiple threads.  I worked around the problem by fixing the number of threads to 1 in my Pluto notebook, but Valentin suggested also this change as a slightly more robust fix.