### PR TITLE
Backport EnzymeCore Adapt fix to 0.6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ steps:
     matrix:
       setup:
         version:
+          - "1.8"
           - "1.9"
           - "1.10"
     plugins:

--- a/lib/EnzymeCore/Project.toml
+++ b/lib/EnzymeCore/Project.toml
@@ -1,7 +1,7 @@
 name = "EnzymeCore"
 uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.6.5"
+version = "0.6.6"
 
 [compat]
 Adapt = "3, 4"

--- a/lib/EnzymeCore/Project.toml
+++ b/lib/EnzymeCore/Project.toml
@@ -7,6 +7,9 @@ version = "0.6.5"
 Adapt = "3, 4"
 julia = "1.6"
 
+[deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
 [extensions]
 AdaptExt = "Adapt"
 

--- a/lib/EnzymeCore/ext/AdaptExt.jl
+++ b/lib/EnzymeCore/ext/AdaptExt.jl
@@ -1,11 +1,19 @@
 module AdaptExt
-    using Adapt
-    using EnzymeCore
 
-	Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
-	Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
-	Adapt.adapt_structure(to, x::Duplicated) = Duplicated(adapt(to, x.val), adapt(to, x.dval))
-	Adapt.adapt_structure(to, x::DuplicatedNoNeed) = DuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
-	Adapt.adapt_structure(to, x::BatchDuplicated) = BatchDuplicated(adapt(to, x.val), adapt(to, x.dval))
-	Adapt.adapt_structure(to, x::BatchDuplicatedNoNeed) = BatchDuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+using Adapt
+using EnzymeCore
+
+Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
+Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
+Adapt.adapt_structure(to, x::Duplicated) = Duplicated(adapt(to, x.val), adapt(to, x.dval))
+function Adapt.adapt_structure(to, x::DuplicatedNoNeed)
+    return DuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
 end
+function Adapt.adapt_structure(to, x::BatchDuplicated)
+    return BatchDuplicated(adapt(to, x.val), adapt(to, x.dval))
+end
+function Adapt.adapt_structure(to, x::BatchDuplicatedNoNeed)
+    return BatchDuplicatedNoNeed(adapt(to, x.val), adapt(to, x.dval))
+end
+
+end #module

--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -236,4 +236,8 @@ function tape_type end
 
 include("rules.jl")
 
+if !isdefined(Base, :get_extension)
+    include("../ext/AdaptExt.jl")
+end
+
 end # module EnzymeCore


### PR DESCRIPTION
- Load Adapt unconditionally for Julia 1.8 (#1369)
- Bump EnzymeCore to 0.6.6
