### PR TITLE
Try narrowing inactive rules for `rand`

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -72,6 +72,12 @@ end
 function EnzymeRules.inactive(::typeof(Random.rand!), ::Random.AbstractRNG, ::Random.Sampler, ::AbstractArray)
     return nothing
 end
+function EnzymeRules.inactive(::typeof(Random.randn), args...)
+    return nothing
+end
+function EnzymeRules.inactive(::typeof(Random.randn!), args...)
+    return nothing
+end
 function EnzymeRules.inactive(::typeof(Random.default_rng), args...)
     return nothing
 end

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -66,36 +66,12 @@ end
 function EnzymeRules.inactive(::typeof(Core.kwfunc), args...)
     return nothing
 end
-
-# Copy from ChainRules.jl
 function EnzymeRules.inactive(::typeof(Random.rand), ::Random.AbstractRNG, ::Random.Sampler)
     return nothing
 end
-
-# maybe don't need all these though, they fall back to above?
-# function EnzymeRules.inactive(::typeof(Random.rand), ::Random.AbstractRNG, ::Integer...)
-#     return nothing
-# end
-# function EnzymeRules.inactive(::typeof(Random.rand), ::Type{<:Real})
-#     return nothing
-# end
-# function EnzymeRules.inactive(::typeof(Random.rand), ::Type{<:Real}, ::Tuple)
-#     return nothing
-# end
-# function EnzymeRules.inactive(::typeof(Random.rand), ::Integer...)
-#     return nothing
-# end
-
-# hide as possibly unsafe for parameter-dependent distrs
-# function EnzymeRules.inactive(::typeof(Random.rand!), args...)
-#     return nothing
-# end
-# function EnzymeRules.inactive(::typeof(Random.randn), args...)
-#     return nothing
-# end
-# function EnzymeRules.inactive(::typeof(Random.randn!), args...)
-#     return nothing
-# end
+function EnzymeRules.inactive(::typeof(Random.rand!), ::Random.AbstractRNG, ::Random.Sampler, ::AbstractArray)
+    return nothing
+end
 function EnzymeRules.inactive(::typeof(Random.default_rng), args...)
     return nothing
 end

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -66,18 +66,36 @@ end
 function EnzymeRules.inactive(::typeof(Core.kwfunc), args...)
     return nothing
 end
-function EnzymeRules.inactive(::typeof(Random.rand), args...)
+
+# Copy from ChainRules.jl
+function EnzymeRules.inactive(::typeof(Random.rand), ::Random.AbstractRNG, ::Random.Sampler)
     return nothing
 end
-function EnzymeRules.inactive(::typeof(Random.rand!), args...)
-    return nothing
-end
-function EnzymeRules.inactive(::typeof(Random.randn), args...)
-    return nothing
-end
-function EnzymeRules.inactive(::typeof(Random.randn!), args...)
-    return nothing
-end
+
+# maybe don't need all these though, they fall back to above?
+# function EnzymeRules.inactive(::typeof(Random.rand), ::Random.AbstractRNG, ::Integer...)
+#     return nothing
+# end
+# function EnzymeRules.inactive(::typeof(Random.rand), ::Type{<:Real})
+#     return nothing
+# end
+# function EnzymeRules.inactive(::typeof(Random.rand), ::Type{<:Real}, ::Tuple)
+#     return nothing
+# end
+# function EnzymeRules.inactive(::typeof(Random.rand), ::Integer...)
+#     return nothing
+# end
+
+# hide as possibly unsafe for parameter-dependent distrs
+# function EnzymeRules.inactive(::typeof(Random.rand!), args...)
+#     return nothing
+# end
+# function EnzymeRules.inactive(::typeof(Random.randn), args...)
+#     return nothing
+# end
+# function EnzymeRules.inactive(::typeof(Random.randn!), args...)
+#     return nothing
+# end
 function EnzymeRules.inactive(::typeof(Random.default_rng), args...)
     return nothing
 end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -443,7 +443,7 @@ end
     Random.rand(d::MyDistribution) = rand(Random.default_rng(), d)
 
     # Outer rand should be differentiated through, and inner rand and randn should be ignored.
-    @test autodiff(Enzyme.Reverse, x -> rand(DiracDelta(x)), Active, Active(1.0)) == ((1.0,),)
+    @test autodiff(Enzyme.Reverse, x -> rand(MyDistribution(x)), Active, Active(1.0)) == ((1.0,),)
 end
 
 end # InternalRules

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -432,4 +432,19 @@ end
     end
 end
 end
+
+@testset "rand and randn rules" begin
+    # Distributed as x + unit normal + uniform
+    struct MyDistribution
+        x::Float64
+    end
+
+    Random.rand(rng::Random.AbstractRNG, d::MyDistribution) = d.x + randn() + rand()
+    Random.rand(d::MyDistribution) = rand(Random.default_rng(), d)
+
+    # Outer rand should be differentiated through, and inner rand and randn should be ignored.
+    @test autodiff(Enzyme.Reverse, x -> rand(DiracDelta(x)), Active, Active(1.0)) == ((1.0,),)
+end
+
+
 end # InternalRules

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -7,6 +7,7 @@ using FiniteDifferences
 using LinearAlgebra
 using SparseArrays
 using Test
+import Random
 
 struct TPair
     a::Float64

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -446,5 +446,4 @@ end
     @test autodiff(Enzyme.Reverse, x -> rand(DiracDelta(x)), Active, Active(1.0)) == ((1.0,),)
 end
 
-
 end # InternalRules


### PR DESCRIPTION
Addresses #1387 

These new rules could potentially be too narrow for some cases. Also, for reference, here are the ones in `ChainRules.jl`: https://github.com/JuliaDiff/ChainRules.jl/blob/f9f0722558e065ee8bbdf042c2d99a9d56ba0070/src/rulesets/Random/random.jl#L15-L25. It seemed like we might not need some of them, and also the generic `rand!` ones there would be dangerous for Enzyme when differentiating parameter-dependent mutable sampling.

