### PR TITLE
[EnzymeTestUtils] Add rng keyword to testing functions and test with seed

### DIFF
--- a/lib/EnzymeTestUtils/Project.toml
+++ b/lib/EnzymeTestUtils/Project.toml
@@ -1,7 +1,7 @@
 name = "EnzymeTestUtils"
 uuid = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 authors = ["Seth Axen <seth@sethaxen.com>", "William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/EnzymeTestUtils/src/generate_tangent.jl
+++ b/lib/EnzymeTestUtils/src/generate_tangent.jl
@@ -41,7 +41,7 @@ _build_activity(rng, primal, ::Type{<:Active}) = Active(primal)
 function _build_activity(rng, primal, ::Type{<:Duplicated})
     return Duplicated(primal, rand_tangent(rng, primal))
 end
-function _build_activity(rng, ::Type{<:BatchDuplicated})
+function _build_activity(rng, primal, ::Type{<:BatchDuplicated})
     return BatchDuplicated(primal, ntuple(_ -> rand_tangent(rng, primal), 2))
 end
 function _build_activity(rng, primal, T::Type{<:Annotation})

--- a/lib/EnzymeTestUtils/src/test_forward.jl
+++ b/lib/EnzymeTestUtils/src/test_forward.jl
@@ -17,6 +17,7 @@ additional constraints:
 
 # Keywords
 
+- `rng::AbstractRNG`: The random number generator to use for generating random tangents.
 - `fdm=FiniteDifferences.central_fdm(5, 1)`: The finite differences method to use.
 - `fkwargs`: Keyword arguments to pass to `f`.
 - `rtol`: Relative tolerance for `isapprox`.
@@ -54,6 +55,7 @@ function test_forward(
     f,
     ret_activity,
     args...;
+    rng::Random.AbstractRNG=Random.default_rng(),
     fdm=FiniteDifferences.central_fdm(5, 1),
     fkwargs::NamedTuple=NamedTuple(),
     rtol::Real=1e-9,
@@ -67,7 +69,7 @@ function test_forward(
     end
     @testset "$testset_name" begin
         # format arguments for autodiff and FiniteDifferences
-        activities = map(auto_activity, (f, args...))
+        activities = map(Base.Fix1(auto_activity, rng), (f, args...))
         primals = map(x -> x.val, activities)
         # call primal, avoid mutating original arguments
         fcopy = deepcopy(first(primals))

--- a/lib/EnzymeTestUtils/src/test_reverse.jl
+++ b/lib/EnzymeTestUtils/src/test_reverse.jl
@@ -102,7 +102,7 @@ function test_reverse(
             batch_size = _batch_size(map(typeof, activities)...)
             ks = ntuple(Symbol ∘ string, batch_size)
             ȳ = ntuple(batch_size) do _
-                ret_activity <: Const ? zero_tangent(y) : rand_tangent(rng, y)
+                return ret_activity <: Const ? zero_tangent(y) : rand_tangent(rng, y)
             end
         end
         # call finitedifferences, avoid mutating original arguments

--- a/lib/EnzymeTestUtils/src/test_reverse.jl
+++ b/lib/EnzymeTestUtils/src/test_reverse.jl
@@ -39,6 +39,7 @@ additional constraints:
 
 # Keywords
 
+- `rng::AbstractRNG`: The random number generator to use for generating random tangents.
 - `fdm=FiniteDifferences.central_fdm(5, 1)`: The finite differences method to use.
 - `fkwargs`: Keyword arguments to pass to `f`.
 - `rtol`: Relative tolerance for `isapprox`.
@@ -75,6 +76,7 @@ function test_reverse(
     f,
     ret_activity,
     args...;
+    rng::Random.AbstractRNG=Random.default_rng(),
     fdm=FiniteDifferences.central_fdm(5, 1),
     fkwargs::NamedTuple=NamedTuple(),
     rtol::Real=1e-9,
@@ -87,7 +89,7 @@ function test_reverse(
     end
     @testset "$testset_name" begin
         # format arguments for autodiff and FiniteDifferences
-        activities = map(auto_activity, (f, args...))
+        activities = map(Base.Fix1(auto_activity, rng), (f, args...))
         primals = map(x -> x.val, activities)
         # call primal, avoid mutating original arguments
         fcopy = deepcopy(first(primals))
@@ -95,12 +97,12 @@ function test_reverse(
         y = fcopy(args_copy...; deepcopy(fkwargs)...)
         # generate tangent for output
         if !_any_batch_duplicated(map(typeof, activities)...)
-            ȳ = ret_activity <: Const ? zero_tangent(y) : rand_tangent(y)
+            ȳ = ret_activity <: Const ? zero_tangent(y) : rand_tangent(rng, y)
         else
             batch_size = _batch_size(map(typeof, activities)...)
             ks = ntuple(Symbol ∘ string, batch_size)
             ȳ = ntuple(batch_size) do _
-                ret_activity <: Const ? zero_tangent(y) : rand_tangent(y)
+                ret_activity <: Const ? zero_tangent(y) : rand_tangent(rng, y)
             end
         end
         # call finitedifferences, avoid mutating original arguments

--- a/lib/EnzymeTestUtils/test/runtests.jl
+++ b/lib/EnzymeTestUtils/test/runtests.jl
@@ -1,5 +1,8 @@
 using EnzymeTestUtils
+using Random
 using Test
+
+Random.seed!(0)
 
 @testset "EnzymeTestUtils.jl" begin
     include("helpers.jl")


### PR DESCRIPTION
As suggested in https://github.com/EnzymeAD/Enzyme.jl/issues/1397#issuecomment-2067767354, with this PR, `test_forward` and `test_reverse` can accept a user-specified random number generator. Additionally, the seed in the test suite is now fixed.

Fixes #1397 