### PR TITLE
Add DifferentiationInterface test suite

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+DifferentiationInterfaceTest = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EnzymeTestUtils = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 Enzyme_jll = "7cc45869-7501-5eee-bdea-0790c847d4ef"

--- a/test/differentiationinterface.jl
+++ b/test/differentiationinterface.jl
@@ -1,0 +1,6 @@
+using DifferentiationInterface
+using DifferentiationInterfaceTest
+using Enzyme: Enzyme
+
+test_differentiation([AutoEnzyme(; mode=Enzyme.Forward), AutoEnzyme(; mode=Enzyme.Reverse)];
+                     second_order=false, logging=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,10 @@ end
     include("blas.jl")
 end
 
+@static if VERSION >= v"1.10"
+    include("differentiationinterface.jl")
+end
+
 f0(x) = 1.0 + x
 function vrec(start, x)
     if start > length(x)
@@ -3411,4 +3415,3 @@ end
 
 
 end
-


### PR DESCRIPTION
Prompted by #1562, this PR adds some tests from DifferentiationInterfaceTest to the Enzyme test suite.
Our test suite has caught [numerous bugs in the past](https://github.com/gdalle/DifferentiationInterface.jl/issues/99), so it would be a great asset to check that new Enzyme releases don't jeopardize existing behavior.