### PR TITLE
Fix #1630

### DIFF
--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -231,7 +231,7 @@ function enzyme_custom_setup_args(B, orig::LLVM.CallInst, gutils::GradientUtils,
                 if mixed
                     RefTy = arg.typ
                     if width != 1
-                        RefTy = NTuple{N, RefTy}
+                        RefTy = NTuple{Int(width), RefTy}
                     end
                     llrty = convert(LLVMType, RefTy)
                     RefTy = Base.RefValue{RefTy}
@@ -1035,7 +1035,7 @@ function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils,
         for (ptr_val, argTyp, refal) in mixeds
             RefTy = argTyp
             if width != 1
-                RefTy = NTuple{N, RefTy}
+                RefTy = NTuple{Int(width), RefTy}
             end
             curs = load!(B, convert(LLVMType, RefTy), refal)
 


### PR DESCRIPTION
I think this fix is correct (copied the pattern on line 944), but I don't have a test case. The rules I was experimenting with when triggering the bug are incorrect and likely fundamentally misguided, and I don't understand the system well enough to create tests that should pass but don't because of this bug.

Including a stack trace below in case it can help someone write an appropriate test.

<details>
<summary>Stack trace</summary>

```
LoadError: UndefVarError: `N` not defined
Stacktrace:
  [1] enzyme_custom_setup_args(B::LLVM.IRBuilder, orig::LLVM.CallInst, gutils::Enzyme.Compiler.GradientUtils, mi::Core.MethodInstance, RT::Any, reverse::Bool, isKWCall::Bool)
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/rules/customrules.jl:234
  [2] enzyme_custom_fwd(B::LLVM.IRBuilder, orig::LLVM.CallInst, gutils::Enzyme.Compiler.GradientUtils, normalR::Ptr{Ptr{LLVM.API.LLVMOpaqueValue}}, shadowR::Ptr{Ptr{LLVM.API.LLVMOpaqueValue}})
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/rules/customrules.jl:367
  [3] (::Enzyme.Compiler.var"#28262#28263")(B::Ptr{LLVM.API.LLVMOpaqueBuilder}, OrigCI::Ptr{LLVM.API.LLVMOpaqueValue}, gutils::Ptr{Nothing}, normalR::Ptr{Ptr{LLVM.API.LLVMOpaqueValue}}, shadowR::Ptr{Ptr{LLVM.API.LLVMOpaqueValue}})
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/rules/llvmrules.jl:1228
  [4] EnzymeCreateForwardDiff(logic::Enzyme.Logic, todiff::LLVM.Function, retType::Enzyme.API.CDIFFE_TYPE, constant_args::Vector{Enzyme.API.CDIFFE_TYPE}, TA::Enzyme.TypeAnalysis, returnValue::Bool, mode::Enzyme.API.CDerivativeMode, width::Int64, additionalArg::Ptr{Nothing}, typeInfo::Enzyme.FnTypeInfo, uncacheable_args::Vector{Bool})
    @ Enzyme.API ~/.julia/packages/Enzyme/SiyIj/src/api.jl:170
  [5] enzyme!(job::GPUCompiler.CompilerJob{Enzyme.Compiler.EnzymeTarget, Enzyme.Compiler.EnzymeCompilerParams}, mod::LLVM.Module, primalf::LLVM.Function, TT::Type, mode::Enzyme.API.CDerivativeMode, width::Int64, parallel::Bool, actualRetType::Type, wrap::Bool, modifiedBetween::Tuple{Bool, Bool}, returnPrimal::Bool, expectedTapeType::Type, loweredArgs::Set{Int64}, boxedArgs::Set{Int64})
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:3725
  [6] codegen(output::Symbol, job::GPUCompiler.CompilerJob{Enzyme.Compiler.EnzymeTarget, Enzyme.Compiler.EnzymeCompilerParams}; libraries::Bool, deferred_codegen::Bool, optimize::Bool, toplevel::Bool, strip::Bool, validate::Bool, only_entry::Bool, parent_job::Nothing)
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:5867
  [7] codegen
    @ ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:5143 [inlined]
  [8] _thunk(job::GPUCompiler.CompilerJob{Enzyme.Compiler.EnzymeTarget, Enzyme.Compiler.EnzymeCompilerParams}, postopt::Bool)
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:6674
  [9] _thunk
    @ ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:6674 [inlined]
 [10] cached_compilation
    @ ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:6712 [inlined]
 [11] (::Enzyme.Compiler.var"#28595#28596"{DataType, DataType, Enzyme.API.CDerivativeMode, Tuple{Bool, Bool}, Int64, Bool, Bool, UInt64, DataType})(ctx::LLVM.Context)
    @ Enzyme.Compiler ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:6781
 [12] JuliaContext(f::Enzyme.Compiler.var"#28595#28596"{DataType, DataType, Enzyme.API.CDerivativeMode, Tuple{Bool, Bool}, Int64, Bool, Bool, UInt64, DataType}; kwargs::@Kwargs{})
    @ GPUCompiler ~/.julia/packages/GPUCompiler/Y4hSX/src/driver.jl:52
 [13] JuliaContext(f::Function)
    @ GPUCompiler ~/.julia/packages/GPUCompiler/Y4hSX/src/driver.jl:42
 [14] #s2010#28594
    @ ~/.julia/packages/Enzyme/SiyIj/src/compiler.jl:6732 [inlined]
 [15] var"#s2010#28594"(FA::Any, A::Any, TT::Any, Mode::Any, ModifiedBetween::Any, width::Any, ReturnPrimal::Any, ShadowInit::Any, World::Any, ABI::Any, ::Any, ::Type, ::Type, ::Type, tt::Any, ::Type, ::Type, ::Type, ::Type, ::Type, ::Any)
    @ Enzyme.Compiler ./none:0
 [16] (::Core.GeneratedFunctionStub)(::UInt64, ::LineNumberNode, ::Any, ::Vararg{Any})
    @ Core ./boot.jl:602
 [17] autodiff(::ForwardMode{FFIABI}, f::Const{typeof(objective)}, ::Type{BatchDuplicatedNoNeed}, args::BatchDuplicated{Vector{Float64}, 2})
    @ Enzyme ~/.julia/packages/Enzyme/SiyIj/src/Enzyme.jl:415
 [18] autodiff
    @ ~/.julia/packages/Enzyme/SiyIj/src/Enzyme.jl:321 [inlined]
 [19] gradient(::ForwardMode{FFIABI}, f::Function, x::Vector{Float64}; shadow::Tuple{Vector{Float64}, Vector{Float64}})
    @ Enzyme ~/.julia/packages/Enzyme/SiyIj/src/Enzyme.jl:1092
 [20] gradient(::ForwardMode{FFIABI}, f::Function, x::Vector{Float64})
    @ Enzyme ~/.julia/packages/Enzyme/SiyIj/src/Enzyme.jl:1088
```

</details>