### PR TITLE
Reduce time for enzyme import

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -6820,8 +6820,9 @@ end
 @inline function thunk(mi::Core.MethodInstance, ::Type{FA}, ::Type{A}, tt::Type{TT},::Val{Mode}, ::Val{width}, ::Val{ModifiedBetween}, ::Val{ReturnPrimal}, ::Val{ShadowInit}, ::Type{ABI}) where {FA<:Annotation, A<:Annotation, TT, Mode, ModifiedBetween, width, ReturnPrimal, ShadowInit, ABI}
   ts_ctx = JuliaContext()
   ctx = context(ts_ctx)
+  activate(ctx)
   try
-    return thunkbase(mi, Val(#=World=#nothing), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
+    return thunkbase(ctx, mi, Val(#=World=#nothing), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
   finally
     deactivate(ctx)
     dispose(ts_ctx)
@@ -6832,8 +6833,9 @@ end
   mi = fspec(eltype(FA), TT, World)
   ts_ctx = JuliaContext()
   ctx = context(ts_ctx)
+  activate(ctx)
   res = try
-    thunkbase(mi, Val(World), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
+    thunkbase(ctx, mi, Val(World), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
   finally
     deactivate(ctx)
     dispose(ts_ctx)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -6819,26 +6819,38 @@ end
 
 @inline function thunk(mi::Core.MethodInstance, ::Type{FA}, ::Type{A}, tt::Type{TT},::Val{Mode}, ::Val{width}, ::Val{ModifiedBetween}, ::Val{ReturnPrimal}, ::Val{ShadowInit}, ::Type{ABI}) where {FA<:Annotation, A<:Annotation, TT, Mode, ModifiedBetween, width, ReturnPrimal, ShadowInit, ABI}
   ts_ctx = JuliaContext()
-  ctx = context(ts_ctx)
+  ctx = @static if VERSION >= v"1.9.0-DEV.115"
+    context(ts_ctx)
+  else
+    ts_ctx
+  end
   activate(ctx)
   try
     return thunkbase(ctx, mi, Val(#=World=#nothing), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
   finally
     deactivate(ctx)
-    dispose(ts_ctx)
+    @static if VERSION >= v"1.9.0-DEV.115"
+      dispose(ts_ctx)
+     end
   end
 end
 
 @inline @generated function thunk(::Val{World}, ::Type{FA}, ::Type{A}, tt::Type{TT},::Val{Mode}, ::Val{width}, ::Val{ModifiedBetween}, ::Val{ReturnPrimal}, ::Val{ShadowInit}, ::Type{ABI}) where {FA<:Annotation, A<:Annotation, TT, Mode, ModifiedBetween, width, ReturnPrimal, ShadowInit, World, ABI}
   mi = fspec(eltype(FA), TT, World)
   ts_ctx = JuliaContext()
-  ctx = context(ts_ctx)
+  ctx = @static if VERSION >= v"1.9.0-DEV.115"
+    context(ts_ctx)
+  else
+    ts_ctx
+  end
   activate(ctx)
   res = try
     thunkbase(ctx, mi, Val(World), FA, A, TT, Val(Mode), Val(width), Val(ModifiedBetween), Val(ReturnPrimal), Val(ShadowInit), ABI)
   finally
     deactivate(ctx)
-    dispose(ts_ctx)
+    @static if VERSION >= v"1.9.0-DEV.115"
+      dispose(ts_ctx)
+    end
   end
   return quote
     Base.@_inline_meta

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3137,6 +3137,10 @@ function __init__()
                                                shadow_alloc_rewrite, Cvoid, (LLVM.API.LLVMValueRef,API.EnzymeGradientUtilsRef)))
     register_alloc_rules()
     register_llvm_rules()
+
+    # Force compilation of AD stack
+    # thunk = Enzyme.Compiler.thunk(Enzyme.Compiler.fspec(typeof(Base.identity), Tuple{Active{Float64}}), Const{typeof(Base.identity)}, Active, Tuple{Active{Float64}}, #=Split=# Val(Enzyme.API.DEM_ReverseModeCombined), #=width=#Val(1), #=ModifiedBetween=#Val((false,false)), Val(#=ReturnPrimal=#false), #=ShadowInit=#Val(false), NonGenABI)
+    # thunk(Const(Base.identity), Active(1.0), 1.0)
 end
 
 # Define EnzymeTarget

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -6102,7 +6102,7 @@ struct CompileResult{AT, PT}
     TapeType::Type
 end
 
-@inline (thunk::PrimalErrorThunk{PT, FA, RT, TT, Width, ReturnPrimal})(fn::FA, args...) where {PT, FA, RT, TT, Width, ReturnPrimal, World} =
+@inline (thunk::PrimalErrorThunk{PT, FA, RT, TT, Width, ReturnPrimal})(fn::FA, args...) where {PT, FA, RT, TT, Width, ReturnPrimal} =
 enzyme_call(Val(false), thunk.adjoint, PrimalErrorThunk{PT, FA, RT, TT, Width, ReturnPrimal}, Val(Width), Val(ReturnPrimal), TT, RT, fn, Cvoid, args...)
 
 @inline (thunk::CombinedAdjointThunk{PT, FA, RT, TT, Width, ReturnPrimal})(fn::FA, args...) where {PT, FA, Width, RT, TT, ReturnPrimal} =

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -340,7 +340,7 @@ function custom_rule_method_error(world, fn, args...)
     throw(MethodError(fn, (args...,), world))
 end
 
-function enzyme_custom_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function enzyme_custom_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -640,7 +640,7 @@ end
     return aug_fwd_mi(orig, gutils)[1] !== nothing
 end
 
-function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils, normalR, shadowR, tape)::LLVM.API.LLVMValueRef
+@register_rev function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils, normalR, shadowR, tape)::LLVM.API.LLVMValueRef
 
     ctx = LLVM.context(orig)
 
@@ -1065,7 +1065,7 @@ function enzyme_custom_common_rev(forward::Bool, B, orig::LLVM.CallInst, gutils,
 end
 
 
-function enzyme_custom_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function enzyme_custom_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig) && !has_aug_fwd_rule(orig, gutils)
         return true
     end
@@ -1076,8 +1076,7 @@ function enzyme_custom_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     return false
 end
 
-
-function enzyme_custom_rev(B, orig, gutils, tape)
+@register_rev function enzyme_custom_rev(B, orig, gutils, tape)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig) && !has_aug_fwd_rule(orig, gutils)
         return
     end
@@ -1085,7 +1084,7 @@ function enzyme_custom_rev(B, orig, gutils, tape)
     return nothing
 end
 
-function enzyme_custom_diffuse(orig, gutils, val, isshadow, mode)
+@register_diffuse function enzyme_custom_diffuse(orig, gutils, val, isshadow, mode)
     # use default
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig) && !has_aug_fwd_rule(orig, gutils)
         return (false, true)

--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -1334,7 +1334,7 @@ function common_generic_fwd(offset, B, orig, gutils, normalR, shadowR)
     return false
 end
 
-function generic_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function generic_fwd(B, orig, gutils, normalR, shadowR)
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
     @assert conv == 37
@@ -1390,7 +1390,7 @@ function common_generic_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR)
     return false
 end
 
-function generic_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function generic_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
 
@@ -1414,7 +1414,7 @@ function common_generic_rev(offset, B, orig, gutils, tape)::Cvoid
     return nothing
 end
 
-function generic_rev(B, orig, gutils, tape)::Cvoid
+@register_rev function generic_rev(B, orig, gutils, tape)::Cvoid
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
 
@@ -1532,7 +1532,7 @@ function common_apply_latest_rev(offset, B, orig, gutils, tape)::Cvoid
     return nothing
 end
 
-function apply_latest_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function apply_latest_fwd(B, orig, gutils, normalR, shadowR)
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
     @assert conv == 37
@@ -1540,7 +1540,7 @@ function apply_latest_fwd(B, orig, gutils, normalR, shadowR)
     common_apply_latest_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function apply_latest_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function apply_latest_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
     @assert conv == 37
@@ -1548,7 +1548,7 @@ function apply_latest_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_apply_latest_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function apply_latest_rev(B, orig, gutils, tape)
+@register_rev function apply_latest_rev(B, orig, gutils, tape)
     conv = LLVM.callconv(orig)
     # https://github.com/JuliaLang/julia/blob/5162023b9b67265ddb0bbbc0f4bd6b225c429aa0/src/codegen_shared.h#L20
     @assert conv == 37
@@ -1728,15 +1728,15 @@ function common_apply_iterate_rev(offset, B, orig, gutils, tape)
     return nothing
 end
 
-function apply_iterate_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function apply_iterate_fwd(B, orig, gutils, normalR, shadowR)
     common_apply_iterate_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function apply_iterate_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function apply_iterate_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_apply_iterate_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function apply_iterate_rev(B, orig, gutils, tape)
+@register_rev function apply_iterate_rev(B, orig, gutils, tape)
     common_apply_iterate_rev(1, B, orig, gutils, tape)
     return nothing
 end
@@ -1851,15 +1851,15 @@ function common_invoke_rev(offset, B, orig, gutils, tape)
     return nothing
 end
 
-function invoke_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function invoke_fwd(B, orig, gutils, normalR, shadowR)
     common_invoke_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function invoke_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function invoke_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_invoke_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function invoke_rev(B, orig, gutils, tape)
+@register_rev function invoke_rev(B, orig, gutils, tape)
     common_invoke_rev(1, B, orig, gutils, tape)
     return nothing
 end

--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -1270,25 +1270,25 @@ function register_handler!(variants, augfwd_handler, rev_handler, fwd_handler=no
 end
 
 macro augfunc(f)
-    cname = string(f)*"_cfunc"
+    cname = Symbol(string(f)*"_cfunc")
    :(@cfunction($cname, UInt8, (LLVM.API.LLVMBuilderRef, LLVM.API.LLVMValueRef, API.EnzymeGradientUtilsRef, Ptr{LLVM.API.LLVMValueRef}, Ptr{LLVM.API.LLVMValueRef}, Ptr{LLVM.API.LLVMValueRef})
     ))
 end
 
 macro revfunc(f)
-    cname = string(f)*"_cfunc"
+    cname = Symbol(string(f)*"_cfunc")
    :(@cfunction($cname,  Cvoid, (LLVM.API.LLVMBuilderRef, LLVM.API.LLVMValueRef, API.EnzymeGradientUtilsRef, LLVM.API.LLVMValueRef)
     ))
 end
 
 macro fwdfunc(f)
-    cname = string(f)*"_cfunc"
+    cname = Symbol(string(f)*"_cfunc")
    :(@cfunction($cname, UInt8, (LLVM.API.LLVMBuilderRef, LLVM.API.LLVMValueRef, API.EnzymeGradientUtilsRef, Ptr{LLVM.API.LLVMValueRef}, Ptr{LLVM.API.LLVMValueRef})
     ))
 end
 
 macro diffusefunc(f)
-    cname = string(f)*"_cfunc"
+    cname = Symbol(string(f)*"_cfunc")
    :(@cfunction($cname, UInt8, (LLVM.API.LLVMValueRef, API.EnzymeGradientUtilsRef, LLVM.API.LLVMValueRef, UInt8, API.CDerivativeMode, Ptr{UInt8})
     ))
 end

--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -39,7 +39,6 @@ macro register_fwd(expr)
     cname = Symbol(cname)
     expr2 = :(@inline $expr)
     res = quote
-        @inline $expr
         function $cname(B::LLVM.API.LLVMBuilderRef, OrigCI::LLVM.API.LLVMValueRef, gutils::API.EnzymeGradientUtilsRef, normalR::Ptr{LLVM.API.LLVMValueRef}, shadowR::Ptr{LLVM.API.LLVMValueRef})::UInt8
             return UInt8($name(LLVM.IRBuilder(B), LLVM.CallInst(OrigCI), GradientUtils(gutils), normalR, shadowR)::Bool)
         end
@@ -55,7 +54,6 @@ macro register_diffuse(expr)
     cname = Symbol(cname)
     expr2 = :(@inline $expr)
     res = quote
-        @inline $expr
         function $cname(OrigCI::LLVM.API.LLVMValueRef, gutils::API.EnzymeGradientUtilsRef, val::LLVM.API.LLVMValueRef, shadow::UInt8, mode::API.CDerivativeMode, useDefault::Ptr{UInt8})::UInt8
             res = $name(LLVM.CallInst(OrigCI), GradientUtils(gutils), LLVM.Value(val), shadow != 0, mode)::Tuple{Bool, Bool}
             unsafe_store!(useDefault, UInt8(res[2]))

--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -381,7 +381,7 @@ end
     return refed, LLVM.name(subfunc), dfuncT, vals, thunkTy, TapeType, copies
 end
 
-function threadsfor_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function threadsfor_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end
@@ -419,7 +419,7 @@ end
     return false
 end
 
-function threadsfor_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function threadsfor_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
 
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
@@ -474,7 +474,7 @@ end
     return false
 end
 
-function threadsfor_rev(B, orig, gutils, tape)
+@register_rev function threadsfor_rev(B, orig, gutils, tape)
     mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
     world = enzyme_extract_world(LLVM.parent(position(B)))
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
@@ -512,7 +512,7 @@ end
     return nothing
 end
 
-function newtask_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function newtask_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end
@@ -550,7 +550,7 @@ function newtask_fwd(B, orig, gutils, normalR, shadowR)
     return false
 end
 
-function newtask_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function newtask_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     # fn, dfn = augmentAndGradient(fn)
     # t = jl_new_task(fn)
     # # shadow t
@@ -608,11 +608,11 @@ function newtask_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     return false
 end
 
-function newtask_rev(B, orig, gutils, tape)
+@register_rev function newtask_rev(B, orig, gutils, tape)
     return nothing
 end
 
-function set_task_tid_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function set_task_tid_fwd(B, orig, gutils, normalR, shadowR)
     ops = collect(operands(orig))[1:end-1]
     if is_constant_value(gutils, ops[1])
         return true
@@ -641,15 +641,15 @@ function set_task_tid_fwd(B, orig, gutils, normalR, shadowR)
     return false
 end
 
-function set_task_tid_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function set_task_tid_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     set_task_tid_fwd(B, orig, gutils, normalR, shadowR)
 end
 
-function set_task_tid_rev(B, orig, gutils, tape)
+@register_rev function set_task_tid_rev(B, orig, gutils, tape)
     return nothing
 end
 
-function enq_work_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function enq_work_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end
@@ -661,7 +661,7 @@ function enq_work_fwd(B, orig, gutils, normalR, shadowR)
     return false
 end
 
-function enq_work_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function enq_work_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     enq_work_fwd(B, orig, gutils, normalR, shadowR)
 end
 
@@ -684,7 +684,7 @@ function find_match(mod, name)
     return nothing
 end
 
-function enq_work_rev(B, orig, gutils, tape)
+@register_rev function enq_work_rev(B, orig, gutils, tape)
     # jl_wait(shadow(t))
     origops = LLVM.operands(orig)
     mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
@@ -701,7 +701,7 @@ function enq_work_rev(B, orig, gutils, tape)
     return nothing
 end
 
-function wait_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function wait_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end
@@ -712,7 +712,7 @@ function wait_fwd(B, orig, gutils, normalR, shadowR)
     return false
 end
 
-function wait_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function wait_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     if is_constant_value(gutils, orig) && is_constant_inst(gutils, orig)
         return true
     end
@@ -723,7 +723,7 @@ function wait_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     return false
 end
 
-function wait_rev(B, orig, gutils, tape)
+@register_rev function wait_rev(B, orig, gutils, tape)
     # jl_enq_work(shadow(t))
     origops = LLVM.operands(orig)
     mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -471,33 +471,33 @@ function common_f_tuple_rev(offset, B, orig, gutils, tape)
 end
 
 
-function f_tuple_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function f_tuple_fwd(B, orig, gutils, normalR, shadowR)
     common_f_tuple_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function f_tuple_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
+@register_aug function f_tuple_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
     common_f_tuple_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function f_tuple_rev(B, orig, gutils, tape)
+@register_rev function f_tuple_rev(B, orig, gutils, tape)
     common_f_tuple_rev(1, B, orig, gutils, tape)
     return nothing
 end
 
-function new_structv_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function new_structv_fwd(B, orig, gutils, normalR, shadowR)
     common_newstructv_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function new_structv_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
+@register_aug function new_structv_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
     common_newstructv_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function new_structv_rev(B, orig, gutils, tape)
+@register_rev function new_structv_rev(B, orig, gutils, tape)
     common_apply_latest_rev(1, B, orig, gutils, tape)
     return nothing
 end
 
-function new_structt_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function new_structt_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) || unsafe_load(shadowR) == C_NULL
         return true
     end
@@ -526,11 +526,12 @@ function new_structt_fwd(B, orig, gutils, normalR, shadowR)
     unsafe_store!(shadowR, shadowres.ref)
     return false
 end
-function new_structt_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
+
+@register_aug function new_structt_augfwd(B, orig, gutils, normalR, shadowR, tapeR)::Bool
     new_structt_fwd(B, orig, gutils, normalR, shadowR)
 end
 
-function new_structt_rev(B, orig, gutils, tape)
+@register_rev function new_structt_rev(B, orig, gutils, tape)
     if is_constant_value(gutils, orig)
         return true
     end
@@ -978,7 +979,7 @@ function common_jl_getfield_rev(offset, B, orig, gutils, tape)
     return nothing
 end
 
-function jl_nthfield_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function jl_nthfield_fwd(B, orig, gutils, normalR, shadowR)
     if is_constant_value(gutils, orig) || unsafe_load(shadowR) == C_NULL
         return true
     end
@@ -1020,7 +1021,7 @@ function jl_nthfield_fwd(B, orig, gutils, normalR, shadowR)
     end
     return false
 end
-function jl_nthfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function jl_nthfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     if is_constant_value(gutils, orig) || unsafe_load(shadowR) == C_NULL
         return true
     end
@@ -1097,7 +1098,7 @@ function jl_nthfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     unsafe_store!(tapeR, cal.ref)
     return false
 end
-function jl_nthfield_rev(B, orig, gutils, tape)
+@register_rev function jl_nthfield_rev(B, orig, gutils, tape)
     if is_constant_value(gutils, orig)
         return
     end
@@ -1159,13 +1160,13 @@ function jl_nthfield_rev(B, orig, gutils, tape)
     return nothing
 end
 
-function jl_getfield_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function jl_getfield_fwd(B, orig, gutils, normalR, shadowR)
     common_jl_getfield_fwd(1, B, orig, gutils, normalR, shadowR)
 end
-function jl_getfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function jl_getfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_jl_getfield_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
-function jl_getfield_rev(B, orig, gutils, tape)
+@register_rev function jl_getfield_rev(B, orig, gutils, tape)
     common_jl_getfield_rev(1, B, orig, gutils, tape)
 end
 
@@ -1314,15 +1315,15 @@ function common_setfield_rev(offset, B, orig, gutils, tape)
 end
 
 
-function setfield_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function setfield_fwd(B, orig, gutils, normalR, shadowR)
     common_setfield_fwd(1, B, orig, gutils, normalR, shadowR)
 end
 
-function setfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function setfield_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_setfield_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
 end
 
-function setfield_rev(B, orig, gutils, tape)
+@register_rev function setfield_rev(B, orig, gutils, tape)
     common_setfield_rev(1, B, orig, gutils, tape)
 end
 
@@ -1438,17 +1439,17 @@ function common_finalizer_rev(offset, B, orig, gutils, tape)
     return nothing
 end
 
-function f_svec_ref_fwd(B, orig, gutils, normalR, shadowR)
+@register_fwd function f_svec_ref_fwd(B, orig, gutils, normalR, shadowR)
     common_f_svec_ref_fwd(1, B, orig, gutils, normalR, shadowR)
     return nothing
 end
 
-function f_svec_ref_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
+@register_aug function f_svec_ref_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     common_f_svec_ref_augfwd(1, B, orig, gutils, normalR, shadowR, tapeR)
     return nothing
 end
 
-function f_svec_ref_rev(B, orig, gutils, tape)
+@register_rev function f_svec_ref_rev(B, orig, gutils, tape)
     common_f_svec_ref_rev(1, B, orig, gutils, tape)
     return nothing
 end


### PR DESCRIPTION
Before this change:
```
julia> @time_imports using Enzyme
┌ Warning: The project dependencies or compat requirements have changed since the manifest was last resolved.
│ It is recommended to `Pkg.resolve()` or consider `Pkg.update()` if necessary.
└ @ Pkg.API /Applications/Julia-1.10.app/Contents/Resources/julia/share/julia/stdlib/v1.10/Pkg/src/API.jl:1807
Precompiling Enzyme
        Info Given Enzyme was explicitly requested, output will be shown live 
WARNING: method definition for PrimalErrorThunk at /Users/wmoses/git/Enzyme.jl/src/compiler.jl:6105 declares type variable World but does not use it.
  2 dependencies successfully precompiled in 112 seconds. 16 already precompiled.
  1 dependency had output during precompilation:
┌ Enzyme
│  [Output was shown above]
└  
      1.3 ms  EnzymeCore
      1.1 ms  CEnum
      6.8 ms  Preferences
      0.3 ms  LazyArtifacts
      0.5 ms  JLLWrappers
               ┌ 3.3 ms LLVMExtra_jll.__init__() 69.32% compilation time
     16.4 ms  LLVMExtra_jll 88.20% compilation time
               ┌ 0.1 ms LLVM.__init__() 
     20.0 ms  LLVM
               ┌ 1.0 ms Enzyme_jll.__init__() 
      2.0 ms  Enzyme_jll
      0.4 ms  ExprTools
               ┌ 0.0 ms TimerOutputs.__init__() 
     10.8 ms  TimerOutputs
      0.4 ms  Scratch
               ┌ 0.4 ms GPUCompiler.__init__() 
     66.1 ms  GPUCompiler 0.14% compilation time
      0.5 ms  Reexport
      0.4 ms  StructIO
               ┌ 0.0 ms ObjectFile.__init__() 
      5.6 ms  ObjectFile
               ┌ 6.4 ms Enzyme.API.__init__() 
               ├ 0.2 ms Enzyme.Compiler.JIT.__init__() 
               ├ 0.0 ms Enzyme.Compiler.FFI.BLASSupport.__init__() 
               ├ 1.9 ms Enzyme.Compiler.FFI.__init__() 
               ├ 0.3 ms Enzyme.Compiler.__init__() 
   1429.7 ms  Enzyme 0.00% compilation time
```

After this change:

```
julia> @time_imports using Enzyme
      1.4 ms  EnzymeCore
      1.3 ms  CEnum
      7.9 ms  Preferences
      0.4 ms  LazyArtifacts
      0.4 ms  JLLWrappers
               ┌ 3.3 ms LLVMExtra_jll.__init__() 63.70% compilation time
     17.1 ms  LLVMExtra_jll 87.53% compilation time
               ┌ 0.2 ms LLVM.__init__() 
     19.8 ms  LLVM
               ┌ 1.2 ms Enzyme_jll.__init__() 
      1.9 ms  Enzyme_jll
      0.4 ms  ExprTools
               ┌ 0.0 ms TimerOutputs.__init__() 
     11.2 ms  TimerOutputs
      0.4 ms  Scratch
               ┌ 0.4 ms GPUCompiler.__init__() 
     71.0 ms  GPUCompiler 0.06% compilation time
      0.4 ms  Reexport
      0.4 ms  StructIO
               ┌ 0.0 ms ObjectFile.__init__() 
      5.4 ms  ObjectFile
               ┌ 1.4 ms Enzyme.API.__init__() 
               ├ 0.1 ms Enzyme.Compiler.JIT.__init__() 
               ├ 0.0 ms Enzyme.Compiler.FFI.BLASSupport.__init__() 
               ├ 1.9 ms Enzyme.Compiler.FFI.__init__() 
               ├ 0.0 ms Enzyme.Compiler.__init__() 
     75.3 ms  Enzyme 0.10% compilation time
```