### PR TITLE
Fix typo in jl_array_ptr_copy_fwd

### DIFF
--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -1093,7 +1093,7 @@ end
                 push!(vargs, extract_value!(B, a, idx-1))
             end
             push!(vargs, args[end])
-            cal = call_samefunc_with_inverted_bundles!(b, gutils, orig, vargs, valTys, #=lookup=#false)
+            cal = call_samefunc_with_inverted_bundles!(B, gutils, orig, vargs, valTys, #=lookup=#false)
             debug_from_orig!(gutils, cal, orig)
             callconv!(cal, callconv(orig))
         end


### PR DESCRIPTION
Spotted a simple typo in a forward rule. Should probably have a test that checks for this code path, but I have no idea how this code even works, so will leave writing that to someone else.