### PR TITLE
Pushforward dvals in the ranges forward rule

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -825,9 +825,9 @@ function EnzymeRules.forward(func::Const{Colon}, RT::Type{<:Union{Const, Duplica
     dstart = if start isa Const 
         zero(eltype(ret)) 
     elseif start isa Duplicated || start isa DuplicatedNoNeed
-        one(eltype(ret))
+        start.dval * one(eltype(ret))
     elseif start isa BatchDuplicated || start isa BatchDuplicatedNoNeed
-        ntuple(x->one(eltype(ret)), Val(width(RT)))
+        ntuple(i->start.dval[i] * one(eltype(ret)), Val(width(RT)))
     else
         error("Annotation type $(typeof(start)) not supported for range start. Please open an issue")
     end
@@ -835,9 +835,9 @@ function EnzymeRules.forward(func::Const{Colon}, RT::Type{<:Union{Const, Duplica
     dstep = if step isa Const 
         zero(eltype(ret)) 
     elseif step isa Duplicated || step isa DuplicatedNoNeed
-        one(eltype(ret))
+        step.dval * one(eltype(ret))
     elseif step isa BatchDuplicated || step isa BatchDuplicatedNoNeed
-        ntuple(x->one(eltype(ret)), Val(width(RT)))
+        ntuple(x->step.dval[i] * one(eltype(ret)), Val(width(RT)))
     else
         error("Annotation type $(typeof(start)) not supported for range step. Please open an issue")
     end

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -620,29 +620,38 @@ end
 
 @testset "Ranges" begin
     function f1(x)
-	x = 25.0x
+        x = 25.0x
         ts = Array(0.0:x:3.0)
-        sum(ts)
+        return sum(ts)
     end
     function f2(x)
-	x = 25.0x
-        ts = Array(0.0:.25:3.0)
-        sum(ts) + x
+        x = 25.0x
+        ts = Array(0.0:0.25:3.0)
+        return sum(ts) + x
     end
     function f3(x)
-	x = 25.0x
-        ts = Array(x:.25:3.0)
-        sum(ts)
+        x = 25.0x
+        ts = Array(x:0.25:3.0)
+        return sum(ts)
     end
     function f4(x)
-	x = 25.0x
-        ts = Array(0.0:.25:x)
-        sum(ts)
+        x = 25.0x
+        ts = Array(0.0:0.25:x)
+        return sum(ts)
     end
-    @test Enzyme.autodiff(Forward, f1,  Duplicated(0.1, 1.0)) == (78,)
-    @test Enzyme.autodiff(Forward, f2,  Duplicated(0.1, 1.0)) == (1.0,)
-    @test Enzyme.autodiff(Forward, f3,  Duplicated(0.1, 1.0)) == (12,)
-    @test Enzyme.autodiff(Forward, f4,  Duplicated(.12, 1.0)) == (0,)
+    @test Enzyme.autodiff(Forward, f1, Duplicated(0.1, 1.0)) == (25.0,)
+    @test Enzyme.autodiff(Forward, f2, Duplicated(0.1, 1.0)) == (25.0,)
+    @test Enzyme.autodiff(Forward, f3, Duplicated(0.1, 1.0)) == (75.0,)
+    @test Enzyme.autodiff(Forward, f4, Duplicated(0.12, 1.0)) == (0,)
+
+    @test Enzyme.autodiff(Forward, f1, BatchDuplicated(0.1, (1.0, 2.0))) ==
+          ((var"1"=25.0, var"2"=50.0),)
+    @test Enzyme.autodiff(Forward, f2, BatchDuplicated(0.1, (1.0, 2.0))) ==
+          ((var"1"=25.0, var"2"=50.0),)
+    @test Enzyme.autodiff(Forward, f3, BatchDuplicated(0.1, (1.0, 2.0))) ==
+          ((var"1"=75.0, var"2"=150.0),)
+    @test Enzyme.autodiff(Forward, f4, BatchDuplicated(0.12, (1.0, 2.0))) ==
+          ((var"1"=0.0, var"2"=0.0),)
 end
 
 end # InternalRules

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -620,25 +620,29 @@ end
 
 @testset "Ranges" begin
     function f1(x)
+	x = 25.0x
         ts = Array(0.0:x:3.0)
         sum(ts)
     end
     function f2(x)
+	x = 25.0x
         ts = Array(0.0:.25:3.0)
         sum(ts) + x
     end
     function f3(x)
+	x = 25.0x
         ts = Array(x:.25:3.0)
         sum(ts)
     end
     function f4(x)
+	x = 25.0x
         ts = Array(0.0:.25:x)
         sum(ts)
     end
-    @test Enzyme.autodiff(Forward, f1,  Duplicated(0.25, 1.0)) == (78,)
-    @test Enzyme.autodiff(Forward, f2,  Duplicated(0.25, 1.0)) == (1.0,)
-    @test Enzyme.autodiff(Forward, f3,  Duplicated(0.25, 1.0)) == (12,)
-    @test Enzyme.autodiff(Forward, f4,  Duplicated(3.0, 1.0)) == (0,)
+    @test Enzyme.autodiff(Forward, f1,  Duplicated(0.1, 1.0)) == (78,)
+    @test Enzyme.autodiff(Forward, f2,  Duplicated(0.1, 1.0)) == (1.0,)
+    @test Enzyme.autodiff(Forward, f3,  Duplicated(0.1, 1.0)) == (12,)
+    @test Enzyme.autodiff(Forward, f4,  Duplicated(.12, 1.0)) == (0,)
 end
 
 end # InternalRules


### PR DESCRIPTION
I just realized before it merged that we're actually missing a part of the pushforward here. Even though the solution to the derivative is just the range itself, we forgot to multiply it by the dval to pushforward the derivative. It implicitly had it as one, calculating the derivative, instead of the full pushforward. The test should be updated to catch this.