### PR TITLE
ci: add DynamicExpressions integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.10'
         os:
           - ubuntu-latest
         test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,8 +248,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
         run: |
-            julia --color=yes --project=test/integration -e 'using Pkg; Pkg.instantiate(); Pkg.develop([PackageSpec(; path) for path in (".", "lib/EnzymeCore")]); Pkg.instantiate()'
-            julia --color=yes --project=test/integration --threads=auto --check-bounds=yes -e test/integration/${{ matrix.test }}.jl
+            julia --color=yes --project=test/integration -e 'using Pkg; Pkg.develop([PackageSpec(; path) for path in (".", "lib/EnzymeCore")]); Pkg.instantiate()'
+            julia --color=yes --project=test/integration --threads=auto --check-bounds=yes test/integration/${{ matrix.test }}.jl
         shell: bash
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,6 +225,33 @@ jobs:
         if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
         with:
           files: lcov.info
+  integration:
+    name: Integration Tests - ${{ matrix.test }}
+    runs-on: ${{ matrix.os }}
+    env:
+      JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        test:
+          - DynamicExpressions
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: "Run tests"
+        run: |
+            julia --color=yes --project=. -e 'using Pkg; pkg"instantiate"'
+            julia --color=yes --project=test/integration -e 'using Pkg; pkg"dev ."; pkg"instantiate"'
+            julia --color=yes --project=test/integration --threads=auto --check-bounds=yes -e test/integration/${{ matrix.test }}.jl
+        shell: bash
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,8 +248,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
         run: |
-            julia --color=yes --project=. -e 'using Pkg; pkg"instantiate"'
-            julia --color=yes --project=test/integration -e 'using Pkg; pkg"dev ."; pkg"instantiate"'
+            julia --color=yes --project=test/integration -e 'using Pkg; Pkg.instantiate(); Pkg.develop([PackageSpec(; path) for path in (".", "lib/EnzymeCore")]); Pkg.instantiate()'
             julia --color=yes --project=test/integration --threads=auto --check-bounds=yes -e test/integration/${{ matrix.test }}.jl
         shell: bash
   docs:

--- a/test/integration/DynamicExpressions.jl
+++ b/test/integration/DynamicExpressions.jl
@@ -1,0 +1,30 @@
+using Test, Enzyme, DynamicExpressions
+
+operators = OperatorEnum(; binary_operators=(+, -, *, /), unary_operators=(cos, sin))
+
+tree = Node(; op=1, l=Node{Float64}(; feature=1), r=Node(; op=1, l=Node{Float64}(; feature=2)))
+# == x1 + cos(x2)
+
+X = randn(3, 100);
+dX = zero(X)
+
+function f(tree, X, operators, output)
+    output[] = sum(eval_tree_array(tree, X, operators; eval_options...)[1])
+    return nothing
+end
+
+output = [0.0]
+doutput = [1.0]
+
+autodiff(
+    Reverse,
+    f,
+    Const(tree),
+    Duplicated(X, dX),
+    Const(operators),
+    Duplicated(output, doutput),
+)
+
+true_dX = cat(ones(100), -sin.(X[2, :]), zeros(100); dims=2)'
+
+@test true_dX ≈ dX

--- a/test/integration/DynamicExpressions.jl
+++ b/test/integration/DynamicExpressions.jl
@@ -9,7 +9,7 @@ X = randn(3, 100);
 dX = zero(X)
 
 function f(tree, X, operators, output)
-    output[] = sum(eval_tree_array(tree, X, operators; eval_options...)[1])
+    output[] = sum(eval_tree_array(tree, X, operators)[1])
     return nothing
 end
 

--- a/test/integration/Project.toml
+++ b/test/integration/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
+
+[compat]
+DynamicExpressions = "=0.18.6"

--- a/test/integration/Project.toml
+++ b/test/integration/Project.toml
@@ -2,4 +2,4 @@
 DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 
 [compat]
-DynamicExpressions = "=0.18.6"
+DynamicExpressions = "=0.18.5"


### PR DESCRIPTION
DynamicExpressions.jl seems to be good at flagging issues in Enzyme, such as the below, so this PR therefore adds a simple integration test for it so that these issues will get flagged immediately.

- #548
- #552
- #816
- #999
- #1009
- #1018
- #1156
- #1662
- #1674

The CI also pins DynamicExpressions to a specific version where it has been known to work, so any failures would indicate some kind of internal regression. Also, this is a separate CI run so won't be recorded in the main test suite.

This is also important for the stability of the PySR/SymbolicRegression.jl ecosystem which have a large number of non-technical users; I would want to prevent breakages for them when I eventually make Enzyme part of the default search code.

I restructured the CI so that packages can add their own integration tests fairly easily: 

```yaml
    matrix:
      version:
        - '1'
      os:
        - ubuntu-latest
      test:
        - DynamicExpressions
    steps:
      - uses: actions/checkout@v4
      - uses: julia-actions/setup-julia@v1
        with:
          version: ${{ matrix.version }}
      - uses: julia-actions/cache@v1
      - uses: julia-actions/julia-buildpkg@v1
      - name: "Run tests"
        run: |
            julia --color=yes --project=. -e 'using Pkg; pkg"instantiate"'
            julia --color=yes --project=test/integration -e 'using Pkg; pkg"dev ."; pkg"instantiate"'
            julia --color=yes --project=test/integration --threads=auto --check-bounds=yes -e test/integration/${{ matrix.test }}.jl
        shell: bash
```

All they need to do is create a new `test/integration/{PackageName}.jl` file and add it to the list.

@gdalle maybe you could rebase #1563 on this so we can have them in the same format?