### PR TITLE
fix: typetree_inner is not in Compiler module

### DIFF
--- a/ext/EnzymeBFloat16sExt.jl
+++ b/ext/EnzymeBFloat16sExt.jl
@@ -3,7 +3,7 @@ module EnzymeBFloat16sExt
 using BFloat16s
 using Enzyme
 
-function Enzyme.Compiler.typetree_inner(::Type{Core.BFloat16}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
+function Enzyme.typetree_inner(::Type{Core.BFloat16}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
     return TypeTree(Enzyme.API.DT_BFloat16, -1, ctx)
 end
 


### PR DESCRIPTION
https://buildkite.com/julialang/luxlib-dot-jl/builds/1115#01913493-6aff-48e4-af64-3212902f9a52/301-1734