### PR TITLE
small fix for static array onehot

### DIFF
--- a/ext/EnzymeStaticArraysExt.jl
+++ b/ext/EnzymeStaticArraysExt.jl
@@ -14,7 +14,7 @@ end
     ntuple(Val(endl-start+1)) do i
         Base.@_inline_meta
         StaticArrays.SArray{S, T, N, L}(
-        ntuple(Val(N)) do idx
+        ntuple(Val(L)) do idx
             Base.@_inline_meta
             return (i + start - 1 == idx) ? 1.0 : 0.0
         end)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2774,6 +2774,20 @@ end
     @test dx isa SArray
     @test dx ≈ [0 30 0]
 
+    x = @SVector [1.0, 2.0, 3.0]
+    y = onehot(x)
+    @test eltype(y) ≡ SVector{3,Float64}
+    @test length(y) == 3
+    @test y[1] == [1.0, 0.0, 0.0]
+    @test y[2] == [0.0, 1.0, 0.0]
+    @test y[3] == [0.0, 0.0, 1.0]
+
+    y = onehot(x, 2, 3)
+    @test eltype(y) ≡ SVector{3,Float64}
+    @test length(y) == 2
+    @test y[1] == [0.0, 1.0, 0.0]
+    @test y[2] == [0.0, 0.0, 1.0]
+
 @static if VERSION ≥ v"1.9-" 
     x = @SArray [5.0 0.0 6.0]
     dx = Enzyme.gradient(Forward, prod, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2776,14 +2776,16 @@ end
 
     x = @SVector [1.0, 2.0, 3.0]
     y = onehot(x)
-    @test eltype(y) ≡ SVector{3,Float64}
+    # this should be a very specific type of SArray, but there
+    # is a bizarre issue with older julia versions where it can be MArray
+    @test eltype(y) <: StaticVector
     @test length(y) == 3
     @test y[1] == [1.0, 0.0, 0.0]
     @test y[2] == [0.0, 1.0, 0.0]
     @test y[3] == [0.0, 0.0, 1.0]
 
     y = onehot(x, 2, 3)
-    @test eltype(y) ≡ SVector{3,Float64}
+    @test eltype(y) <: StaticVector
     @test length(y) == 2
     @test y[1] == [0.0, 1.0, 0.0]
     @test y[2] == [0.0, 0.0, 1.0]


### PR DESCRIPTION
This fixes what I think was essentially a typo in the `StaticArrays` extension and adds some tests to check for it.  Think the only reason it wasn't caught was because it was occurring only in the 3-argument version.