### PR TITLE
Clarify use cases for DuplicatedNoNeed

### DIFF
--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -79,6 +79,13 @@ end
 
 Like [`Duplicated`](@ref), except also specifies that Enzyme may avoid computing
 the original result and only compute the derivative values.
+
+This should only be used if `x` is a write-only variable. Otherwise, if the differentiated
+function stores values in `x` and reads them back in subsequent computations, using
+`DuplicatedNoNeed` may result in incorrect derivatives. In particular, `DuplicatedNoNeed`
+should not be used for preallocated workspace, even if the user might not care about its
+final value, as marking a variable as NoNeed means that reads from the variable are now
+undefined.
 """
 struct DuplicatedNoNeed{T} <: Annotation{T}
     val::T


### PR DESCRIPTION
Does this sound OK? Basically, my misunderstanding was that I thought I could use `DuplicatedNoNeed` if I, the user, don't care about the final value of the variable, while the correct (?) understanding is that it can be used if the differentiated function doesn't make further use of values stored in the variable.