### PR TITLE
fix LLVM 8 depwarns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [weakdeps]
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [weakdeps]
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -47,7 +47,7 @@ import GPUCompiler: @safe_debug, @safe_info, @safe_warn, @safe_error
 
 include("compiler/utils.jl")
 
-if (pkgversion(LLVM) < v"8") && LLVM.has_orc_v1()
+if ((VERSION < v"1.9") || (pkgversion(LLVM) < v"8")) && LLVM.has_orc_v1()
     include("compiler/orcv1.jl")
 else
     include("compiler/orcv2.jl")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -47,7 +47,7 @@ import GPUCompiler: @safe_debug, @safe_info, @safe_warn, @safe_error
 
 include("compiler/utils.jl")
 
-if LLVM.has_orc_v1()
+if (pkgversion(LLVM) < v"8") && LLVM.has_orc_v1()
     include("compiler/orcv1.jl")
 else
     include("compiler/orcv2.jl")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -19,6 +19,14 @@ import GPUCompiler: CompilerJob, codegen, safe_name
 using LLVM.Interop
 import LLVM: Target, TargetMachine
 
+@static if VERSION < v"1.9"
+    import TOML
+    const LLVM_VERSION = VersionNumber(TOML.parsefile(joinpath(Base.pkgdir(LLVM), 
+        "Project.toml"))["version"])
+else
+    const LLVM_VERSION = pkgversion(LLVM)
+end
+
 using Printf
 
 using Preferences
@@ -47,7 +55,7 @@ import GPUCompiler: @safe_debug, @safe_info, @safe_warn, @safe_error
 
 include("compiler/utils.jl")
 
-if ((VERSION < v"1.9") || (pkgversion(LLVM) < v"8")) && LLVM.has_orc_v1()
+if (LLVM_VERSION < v"8") && LLVM.has_orc_v1()
     include("compiler/orcv1.jl")
 else
     include("compiler/orcv2.jl")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -19,14 +19,6 @@ import GPUCompiler: CompilerJob, codegen, safe_name
 using LLVM.Interop
 import LLVM: Target, TargetMachine
 
-@static if VERSION < v"1.9"
-    import TOML
-    const LLVM_VERSION = VersionNumber(TOML.parsefile(joinpath(Base.pkgdir(LLVM), 
-        "Project.toml"))["version"])
-else
-    const LLVM_VERSION = pkgversion(LLVM)
-end
-
 using Printf
 
 using Preferences
@@ -55,7 +47,7 @@ import GPUCompiler: @safe_debug, @safe_info, @safe_warn, @safe_error
 
 include("compiler/utils.jl")
 
-if (LLVM_VERSION < v"8") && LLVM.has_orc_v1()
+if v"8" <= LLVM.version() < v"12"
     include("compiler/orcv1.jl")
 else
     include("compiler/orcv2.jl")

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -6,14 +6,10 @@ import LLVM:TargetMachine
 
 import GPUCompiler
 import ..Compiler
-import ..Compiler: API, cpu_name, cpu_features, LLVM_VERSION
+import ..Compiler: API, cpu_name, cpu_features
 
 @inline function use_ojit()
-    if LLVM_VERSION < v"8"
-        return LLVM.has_julia_ojit() && !Sys.iswindows()
-    else
-        return !Sys.iswindows()
-    end
+        return (VERSION >= v"1.10.0-DEV.1395") && !Sys.iswindows()
 end
 
 export get_trampoline

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -9,7 +9,11 @@ import ..Compiler
 import ..Compiler: API, cpu_name, cpu_features
 
 @inline function use_ojit()
-    return LLVM.has_julia_ojit() && !Sys.iswindows()
+    if pkgversion(LLVM) < v"8"
+        return LLVM.has_julia_ojit() && !Sys.iswindows()
+    else
+        return !Sys.iswindows()
+    end
 end
 
 export get_trampoline

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -6,10 +6,10 @@ import LLVM:TargetMachine
 
 import GPUCompiler
 import ..Compiler
-import ..Compiler: API, cpu_name, cpu_features
+import ..Compiler: API, cpu_name, cpu_features, LLVM_VERSION
 
 @inline function use_ojit()
-    if (VERSION < v"1.9") || (pkgversion(LLVM) < v"8")
+    if LLVM_VERSION < v"8"
         return LLVM.has_julia_ojit() && !Sys.iswindows()
     else
         return !Sys.iswindows()

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -9,7 +9,7 @@ import ..Compiler
 import ..Compiler: API, cpu_name, cpu_features
 
 @inline function use_ojit()
-    if pkgversion(LLVM) < v"8"
+    if (VERSION < v"1.9") || (pkgversion(LLVM) < v"8")
         return LLVM.has_julia_ojit() && !Sys.iswindows()
     else
         return !Sys.iswindows()


### PR DESCRIPTION
SciML has moved to failing CI for depwarns, and Enzyme is a dependency of many SciML packages, so it would be nice to get a release that doesn't have these two depwarns.

I don't know the best practice for checking the version of a dependency (LLVM in this case), but would be happy to modify this PR if I should be doing something else.

Thanks!