### PR TITLE
fix: conditionally define typetree_inner for BFloat16

### DIFF
--- a/ext/EnzymeBFloat16sExt.jl
+++ b/ext/EnzymeBFloat16sExt.jl
@@ -3,8 +3,10 @@ module EnzymeBFloat16sExt
 using BFloat16s
 using Enzyme
 
+if !(isdefined(Core, :BFloat16) && Core.BFloat16 === BFloat16)
 function Enzyme.typetree_inner(::Type{BFloat16}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
     return Enzyme.TypeTree(Enzyme.API.DT_BFloat16, -1, ctx)
+end
 end
 
 end


### PR DESCRIPTION
### Previous

```julia
julia> using BFloat16s, Enzyme
Precompiling Enzyme...
Info Given Enzyme was explicitly requested, output will be shown live 
┌ Warning: `has_orc_v1()` is deprecated, use `false` instead.
│   caller = top-level scope at compiler.jl:50
└ @ Core /mnt/research/lux/Enzyme.jl/src/compiler.jl:50
┌ Warning: `has_julia_ojit()` is deprecated, use `true` instead.
│   caller = use_ojit() at orcv2.jl:12
└ @ Enzyme.Compiler.JIT /mnt/research/lux/Enzyme.jl/src/compiler/orcv2.jl:12
  ? Enzyme → EnzymeBFloat16sExt
  1 dependency successfully precompiled in 165 seconds. 45 already precompiled.
  1 dependencies failed but may be precompilable after restarting julia
  2 dependencies had output during precompilation:
┌ Enzyme → EnzymeBFloat16sExt
│  WARNING: Method definition typetree_inner(Type{Core.BFloat16}, Any, Any, Base.IdDict{Any, Union{Nothing, Enzyme.TypeTree}}) in module Enzyme at /mnt/research/lux/Enzyme.jl/src/typetree.jl:115 overwritten in module EnzymeBFloat16sExt at /mnt/research/lux/Enzyme.jl/ext/EnzymeBFloat16sExt.jl:7.
│  ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
└  
┌ Enzyme
│  [Output was shown above]
└  
Precompiling EnzymeBFloat16sExt...
Info Given EnzymeBFloat16sExt was explicitly requested, output will be shown live 
WARNING: Method definition typetree_inner(Type{Core.BFloat16}, Any, Any, Base.IdDict{Any, Union{Nothing, Enzyme.TypeTree}}) in module Enzyme at /mnt/research/lux/Enzyme.jl/src/typetree.jl:115 overwritten in module EnzymeBFloat16sExt at /mnt/research/lux/Enzyme.jl/ext/EnzymeBFloat16sExt.jl:7.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
  ? Enzyme → EnzymeBFloat16sExt
[ Info: Precompiling EnzymeBFloat16sExt [81044f38-2e40-5cb6-802a-fb09abd5af23] 
WARNING: Method definition typetree_inner(Type{Core.BFloat16}, Any, Any, Base.IdDict{Any, Union{Nothing, Enzyme.TypeTree}}) in module Enzyme at /mnt/research/lux/Enzyme.jl/src/typetree.jl:115 overwritten in module EnzymeBFloat16sExt at /mnt/research/lux/Enzyme.jl/ext/EnzymeBFloat16sExt.jl:7.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
┌ Info: Skipping precompilation due to precompilable error. Importing EnzymeBFloat16sExt [81044f38-2e40-5cb6-802a-fb09abd5af23].
└   exception = Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.
```

### After the patch

```julia
julia> using BFloat16s, Enzyme
Precompiling EnzymeBFloat16sExt...
  1 dependency successfully precompiled in 2 seconds. 46 already precompiled.
```