### PR TITLE
Document `Enzyme.Compiler.recursive_accumulate`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -14,6 +14,10 @@ Modules = [Enzyme, EnzymeCore, EnzymeCore.EnzymeRules, EnzymeTestUtils, Enzyme.A
 Order = [:macro, :function]
 ```
 
+```@docs
+Enzyme.Compiler.recursive_accumulate
+```
+
 ## Documentation
 
 ```@autodocs

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -8732,8 +8732,13 @@ end
     end
 end
 
+"""
+    recursive_accumulate(x, y, f=identity)
 
-# Recursively In-place accumulate(aka +=). E.g. generalization of x .+= f(y)
+Recursive in-place accumulation that generalizes `x .+= f(y)` beyond arrays.
+"""
+function recursive_accumulate end
+
 @inline function recursive_accumulate(x::Core.Box, y::Core.Box, f::F = identity) where {F}
     recursive_accumulate(x.contents, y.contents, seen, f)
 end


### PR DESCRIPTION
Adds a docstring for `Enzyme.Compiler.recursive_accumulate` and displays that docstring in the API reference.
I assume we should do the same for `recursive_add` but I don't exactly understand what it does.

This is needed in DifferentiationInterface for accumulating into the shadow between forward and reverse pass in `autodiff_thunk`.
