### PR TITLE
Add WithPrimal and NoPrimal function

### DIFF
--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -245,6 +245,21 @@ const ReverseHolomorphicWithPrimal = ReverseMode{true,false,DefaultABI, true, fa
 @inline clear_runtime_activity(::ReverseMode{ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten}) where {ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten} = ReverseMode{ReturnPrimal,false,ABI,Holomorphic,ErrIfFuncWritten}()
 
 """
+        WithPrimal(::Enzyme.Mode)
+
+Modifies the mode to include the primal value.
+"""
+@inline WithPrimal(::ReverseMode{ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten}) where {ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten} = ReverseMode{true,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten}()
+
+"""
+        NoPrimal(::Enzyme.Mode)
+
+Modifies the mode to exclude the primal value.
+"""
+@inline NoPrimal(::ReverseMode{ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten}) where {ReturnPrimal,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten} = ReverseMode{false,RuntimeActivity,ABI,Holomorphic,ErrIfFuncWritten}()
+
+
+"""
     struct ReverseModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI} <: Mode{ABI,ErrIfFuncWritten,RuntimeActivity}
 
 Reverse mode differentiation.
@@ -267,6 +282,10 @@ const ReverseSplitWithPrimal = ReverseModeSplit{true, true, false, 0, true,Defau
 @inline set_runtime_activity(::ReverseModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}, rt::Bool) where {ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten} = ReverseModeSplit{ReturnPrimal,ReturnShadow,rt,Width,ModifiedBetween,ABI, ErrIfFuncWritten}()
 @inline clear_runtime_activity(::ReverseModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten} = ReverseModeSplit{ReturnPrimal,ReturnShadow,false,Width,ModifiedBetween,ABI, ErrIfFuncWritten}()
 
+@inline WithPrimal(::ReverseModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten} = ReverseModeSplit{true,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}()
+@inline NoPrimal(::ReverseModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten} = ReverseModeSplit{false,ReturnShadow,RuntimeActivity,Width,ModifiedBetween,ABI, ErrIfFuncWritten}()
+
+
 """
     struct Forward{ReturnPrimal, ABI, ErrIfFuncWritten,RuntimeActivity} <: Mode{ABI, ErrIfFuncWritten, RuntimeActivity}
 
@@ -285,6 +304,10 @@ const ForwardWithPrimal = ForwardMode{true, DefaultABI, false, false}()
 @inline set_runtime_activity(::ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}) where {ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity} = ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,true}()
 @inline set_runtime_activity(::ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}, rt::Bool) where {ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity} = ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,rt}()
 @inline clear_runtime_activity(::ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}) where {ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity} = ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,false}()
+
+@inline WithPrimal(::ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}) where {ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity} = ForwardMode{true,ABI,ErrIfFuncWritten,RuntimeActivity}()
+@inline NoPrimal(::ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}) where {ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity} = ForwardMode{false,ABI,ErrIfFuncWritten,RuntimeActivity}()
+
 
 function autodiff end
 function autodiff_deferred end

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -46,7 +46,9 @@ import EnzymeCore:
     set_abi,
     set_runtime_activity,
     clear_runtime_activity,
-    within_autodiff
+    within_autodiff,
+    WithPrimal,
+    NoPrimal
 export Annotation,
     Const,
     Active,
@@ -63,6 +65,8 @@ export Annotation,
     set_abi,
     set_runtime_activity,
     clear_runtime_activity,
+    WithPrimal,
+    NoPrimal,
     within_autodiff
 
 import EnzymeCore: BatchDuplicatedFunc

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4066,6 +4066,25 @@ end
     @test res[2][6] ≈ 6.0
 end
 
+@testset "WithPrimal" begin
+    @test WithPrimal(Reverse) === ReverseWithPrimal
+    @test NoPrimal(Reverse) === Reverse
+    @test WithPrimal(ReverseWithPrimal) === ReverseWithPrimal
+    @test NoPrimal(ReverseWithPrimal) === Reverse
+
+    @test WithPrimal(set_runtime_activity(Reverse)) === set_runtime_activity(ReverseWithPrimal)
+
+    @test WithPrimal(Forward) === ForwardWithPrimal
+    @test NoPrimal(Forward) === Forward
+    @test WithPrimal(ForwardWithPrimal) === ForwardWithPrimal
+    @test NoPrimal(ForwardWithPrimal) === Forward
+
+    @test WithPrimal(ReverseSplitNoPrimal) === ReverseSplitWithPrimal
+    @test NoPrimal(ReverseSplitNoPrimal) === ReverseSplitNoPrimal
+    @test WithPrimal(ReverseSplitWithPrimal) === ReverseSplitWithPrimal
+    @test NoPrimal(ReverseSplitWithPrimal) === ReverseSplitNoPrimal
+end
+
 # TEST EXTENSIONS 
 using SpecialFunctions
 @testset "SpecialFunctions ext" begin


### PR DESCRIPTION
Add's a helper function that allows you to include or not include the primal computation for ReverseMode, ForwardMode, and ReverseSplitMode

I ended up exporting the functions in Enzyme, but I am not sure if you want to go this at this point.