### PR TITLE
inelegant solution to #1821

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -1566,6 +1566,26 @@ end
     return (one(x),)
 end
 
+@inline function _herm_sym_onehot(type, x::AbstractMatrix, start=1, endl=length(x))
+    idxs = CartesianIndices(x)
+    ntuple(Val(endl - start + 1)) do i0
+        Base.@_inline_meta
+        i = start + i0 - 1
+        idx = idxs[i]
+        res = zeros(eltype(x), size(x))
+        res[idx] = 1
+        res[idx[2],idx[1]] = 1
+        type(res)
+    end
+end
+
+@inline onehot(x::Hermitian) = _herm_sym_onehot(Hermitian, x)
+@inline onehot(x::Symmetric) = _herm_sym_onehot(Symmetric, x)
+
+@inline onehot(x::Hermitian, start, endl) = _herm_sym_onehot(Hermitian, x, start, endl)
+@inline onehot(x::Symmetric, start, endl) = _herm_sym_onehot(Symmetric, x, start, endl)
+
+
 """
     gradient(::ReverseMode, f, args...)
 

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -1566,15 +1566,20 @@ end
     return (one(x),)
 end
 
+function _is_symmed_index(a::CartesianIndex, b::CartesianIndex)
+    (a[1] == b[1] && a[2] == b[2]) || (a[1] == b[2] && a[2] == b[1])
+end
+
 @inline function _herm_sym_onehot(type, x::AbstractMatrix, start=1, endl=length(x))
     idxs = CartesianIndices(x)
     ntuple(Val(endl - start + 1)) do i0
         Base.@_inline_meta
         i = start + i0 - 1
         idx = idxs[i]
-        res = zeros(eltype(x), size(x))
-        res[idx] = 1
-        res[idx[2],idx[1]] = 1
+        res = similar(parent(x))
+        for idx2 ∈ CartesianIndices(x)
+            @inbounds res[idx2] = _is_symmed_index(idx, idx2) ? 1 : 0
+        end
         type(res)
     end
 end


### PR DESCRIPTION
This is a particularly inelegant solution to #1821.

What I do here is for `Symmetric` and `Hermitian` take a redundant basis.  This looks a bit strange because I both set the individual elements and also set the type of the resulting matrix.  The reason for this is that if I do not set all the elements of the underlying buffer, Enzyme's autodiff returns the wrong result, but the wrapper type must also be set because currently `BatchDuplicated` only allows arguments and bases to be of the same type.  I also go out of my way to call `similar` here (e.g. rather than `zeros`) to make it less likely we will run afoul of `BatchDuplicated`.

I *think* this works in general but I have not exhaustively checked it.  I'm not sure how enzyme would be expected to deal with complex arguments here, so I've only tested purely real cases so far.

To see an example of how it works, consider symmetric matrix $X$ and
$$f(X) = X_{11}^2 + 2 X_{12}^2 + 3 X_{21}^2 - X_{22}^2$$
For extra clarity, write $X = \left(\matrix{a & b \cr b & c}\right)$ so that
$$f(X) = a^2 + 5 b^2 - c^2$$
The derivative with respect to the off-diagonal element $b$ is clearly $10b$.

I impelement this in Julia via
```julia
f0(x) = x[1,1]^2 + 2*x[1,2]^2 + 3*x[2,1]^2 - x[2,2]^2
```
Then, for example
```julia
X = Hermitian(Float64[1 2; 2 3])
```
so that
```julia
julia> gradient(Forward, f0, X)[1]
2×2 Enzyme.TupleArray{Float64, (2, 2), 4, 2}:
  2.0  20.0
 20.0  -6.0
```
This also works if the underlying data for `X` is `[1.0 2.0; 0.0 3.0]`.

This will remain a draft until I come up with more comprehensive tests for it.