### PR TITLE
Fix Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://enzyme.mit.edu/julia/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://enzyme.mit.edu/julia/dev)
-[![Build Status](https://github.com/wsmoses/Enzyme.jl/workflows/CI/badge.svg)](https://github.com/wsmoses/Enzyme.jl/actions)
-[![Coverage](https://codecov.io/gh/wsmoses/Enzyme.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/wsmoses/Enzyme.jl)
+[![Build Status](https://github.com/EnzymeAD/Enzyme.jl/workflows/CI/badge.svg)](https://github.com/EnzymeAD/Enzyme.jl/actions)
+[![Coverage](https://codecov.io/gh/EnzymeAD/Enzyme.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/EnzymeAD/Enzyme.jl)
 
-This is a package containing the Julia bindings for [Enzyme](https://github.com/wsmoses/enzyme). This is very much a work in progress and bug reports/discussion is greatly appreciated!
+This is a package containing the Julia bindings for [Enzyme](https://github.com/EnzymeAD/enzyme). This is very much a work in progress and bug reports/discussion is greatly appreciated!
 
 Enzyme is a plugin that performs automatic differentiation (AD) of statically analyzable LLVM. It is highly-efficient and its ability perform AD on optimized code allows Enzyme to meet or exceed the performance of state-of-the-art AD tools.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://enzyme.mit.edu/julia/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://enzyme.mit.edu/julia/dev)
 [![Build Status](https://github.com/EnzymeAD/Enzyme.jl/workflows/CI/badge.svg)](https://github.com/EnzymeAD/Enzyme.jl/actions)
-[![Coverage](https://codecov.io/gh/EnzymeAD/Enzyme.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/EnzymeAD/Enzyme.jl)
+[![Coverage](https://codecov.io/gh/EnzymeAD/Enzyme.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/EnzymeAD/Enzyme.jl)
 
 This is a package containing the Julia bindings for [Enzyme](https://github.com/EnzymeAD/enzyme). This is very much a work in progress and bug reports/discussion is greatly appreciated!
 


### PR DESCRIPTION
The links in the README were pointing to @wsmoses's GitHub profile, which is not a problem for GitHub but confused CodeCov