### PR TITLE
Add CI testing for EnzymeCore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -188,6 +188,68 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false  # or true if you want CI to fail when Codecov fails
+  enzymecore:
+    name: EnzymeCore - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.libEnzyme }} libEnzyme - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
+    env:
+      JULIA_PROJECT: "lib/EnzymeCore"
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+          - ~1.11.0-0
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        libEnzyme: [packaged]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: setup EnzymeCore
+        shell: julia --color=yes {0}
+        id: setup_testutils
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        run: |
+          using Pkg
+          Pkg.develop([PackageSpec(; path) for path in (".",)])
+          Pkg.instantiate()
+        env:
+          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
+      - name: Run the tests
+        if: matrix.version != 'nightly' || steps.setup_testutils.outcome == 'success'
+        continue-on-error: ${{ matrix.version == 'nightly' }}
+        id: run_tests
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.test("EnzymeCore"; coverage=true)
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
+        with:
+          directories: lib/EnzymeCore/src
+      - uses: codecov/codecov-action@v4
+        if: matrix.version != 'nightly' || steps.run_tests.outcome == 'success'
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false  # or true if you want CI to fail when Codecov fails
   integration:
     name: Integration Tests - ${{ matrix.test }}
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+lib/EnzymeCore/Manifest.toml
 /Manifest-v*.toml
 /test/Manifest.toml
 /docs/Manifest.toml

--- a/lib/EnzymeCore/test/misc.jl
+++ b/lib/EnzymeCore/test/misc.jl
@@ -24,4 +24,4 @@ y = @view data[3:end]
 @test_skip @test_throws AssertionError Duplicated(d, y)
 
 @test_throws ErrorException Active(data)
-@test_skip@test_throws ErrorException Active(d)
+@test_skip @test_throws ErrorException Active(d)

--- a/lib/EnzymeCore/test/misc.jl
+++ b/lib/EnzymeCore/test/misc.jl
@@ -1,0 +1,27 @@
+using Test
+using EnzymeCore
+import EnzymeCore.EnzymeRules: forward, has_frule_from_sig
+
+g(x) = x ^ 2
+function forward(config, ::Const{typeof(g)}, ::Type{<:Const}, x::Const)
+    return Const(g(x.val))
+end
+
+@test has_frule_from_sig(Base.signature_type(g, Tuple{Float64}))
+
+f(;kwargs) = 1.0
+
+function forward(config, ::Const{typeof(f)}, ::Type{<:Const}; kwargs...)
+    return Const(f(; kwargs...))
+end
+
+@test has_frule_from_sig(Base.signature_type(f, Tuple{}))
+
+data = [1.0, 2.0, 3.0, 4.0]
+
+d = @view data[2:end]
+y = @view data[3:end]
+@test_skip @test_throws AssertionError Duplicated(d, y)
+
+@test_throws ErrorException Active(data)
+@test_skip@test_throws ErrorException Active(d)

--- a/lib/EnzymeCore/test/runtests.jl
+++ b/lib/EnzymeCore/test/runtests.jl
@@ -1,28 +1,8 @@
 using Test
 using EnzymeCore
 
-import EnzymeCore.EnzymeRules: forward, has_frule_from_sig
-
-g(x) = x ^ 2
-function forward(config, ::Const{typeof(g)}, ::Type{<:Const}, x::Const)
-    return Const(g(x.val))
+@testset verbose = true "EnzymeCore" begin
+    @testset "Miscellaneous" begin
+        include("misc.jl")
+    end
 end
-
-@test has_frule_from_sig(Base.signature_type(g, Tuple{Float64}))
-
-f(;kwargs) = 1.0
-
-function forward(config, ::Const{typeof(f)}, ::Type{<:Const}; kwargs...)
-    return Const(f(; kwargs...))
-end
-
-@test has_frule_from_sig(Base.signature_type(f, Tuple{}))
-
-data = [1.0, 2.0, 3.0, 4.0]
-
-d = @view data[2:end]
-y = @view data[3:end]
-@test_throws ErrorException Duplicated(d, y)
-
-@test_throws ErrorException Active(data)
-@test_throws ErrorException Active(d)


### PR DESCRIPTION
As discussed in #1979, this PR adds a CI job for testing EnzymeCore and reporting coverage, following the model of EnzymeTestUtils.
It also skips two tests which seem broken but were never run before so we didn't know.