### PR TITLE
Use right caller for isapplicable usage

### DIFF
--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -209,11 +209,13 @@ function isapplicable(@nospecialize(f), @nospecialize(TT);
     end
     fullmatch = Core.Compiler._any(match::Core.MethodMatch->match.fully_covers, matches)
     if !fullmatch
-        add_mt_backedge!(caller, mt, sig)
+        if caller isa Core.MethodInstance
+            add_mt_backedge!(caller, mt, sig)
+        end
     end
     if Core.Compiler.isempty(matches)
         return false
-    else
+    elseif caller isa Core.MethodInstance
         for i = 1:Core.Compiler.length(matches)
             match = Core.Compiler.getindex(matches, i)::Core.MethodMatch
             edge = Core.Compiler.specialize_method(match)::Core.MethodInstance

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -214,28 +214,23 @@ function Core.Compiler.abstract_call_gf_by_type(
     callinfo = ret.info
     method_table = Core.Compiler.method_table(interp)
     specTypes = simplify_kw(atype)
-    caller = if callinfo isa Core.Compiler.MethodMatchInfo && callinfo.results isa Core.Compiler.MethodLookupResult
-        callinfo.results
-    else
-        nothing
-    end
 
     if is_primitive_func(specTypes)
         callinfo = NoInlineCallInfo(callinfo, atype, :primitive)
     elseif is_alwaysinline_func(specTypes)
         callinfo = AlwaysInlineCallInfo(callinfo, atype)
-    elseif EnzymeRules.is_inactive_from_sig(specTypes; world = interp.world, method_table, caller)
-        callinfo = NoInlineCallInfo(callinfo, atype, :inactive)
+    elseif EnzymeRules.is_inactive_from_sig(specTypes; world=interp.world, method_table, caller=sv.linfo) 
+            callinfo = NoInlineCallInfo(callinfo, atype, :inactive)
     else
         if interp.forward_rules
-          if EnzymeRules.has_frule_from_sig(specTypes; world = interp.world, method_table, caller)
+            if EnzymeRules.has_frule_from_sig(specTypes; world = interp.world, method_table, caller=sv.linfo)
             callinfo = NoInlineCallInfo(callinfo, atype, :frule)
-          end
+            end
         end
-    
+
         if interp.reverse_rules
-            if EnzymeRules.has_rrule_from_sig(specTypes; world = interp.world, method_table, caller)
-              callinfo = NoInlineCallInfo(callinfo, atype, :rrule)
+            if EnzymeRules.has_rrule_from_sig(specTypes; world = interp.world, method_table, caller=sv.linfo)
+                callinfo = NoInlineCallInfo(callinfo, atype, :rrule)
             end
         end
     end

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -222,44 +222,25 @@ function Core.Compiler.abstract_call_gf_by_type(
     else
         (;fargs, argtypes) = arginfo
         # 1. Check if function is inactive
-        inactive_arginfo = ArgInfo(nothing, pushfirst!(copy(argtypes), Core.Const(EnzymeRules.inactive)))
-        inactive_atype = Tuple{typeof(EnzymeRules.inactive), atype.parameters...} 
-        inactive_meta  = @invoke Core.Compiler.abstract_call_gf_by_type(
-            interp::AbstractInterpreter,
-            EnzymeRules.inactive::Any,
-            inactive_arginfo::ArgInfo,
-            si::StmtInfo,
-            inactive_atype::Any,
-            sv::AbsIntState,
-            max_methods::Int,
-        )
-        if inactive_meta.info isa Core.Compiler.MethodMatchInfo && Core.Compiler.nmatches(inactive_meta.info) != 0
+        inactive_argtypes = pushfirst!(copy(argtypes), Core.Const(EnzymeRules.inactive))
+        inactive_meta = abstract_applicable(interp, inactive_argtypes, sv, max_methods) # Does backedge handling internally
+
+        if inactive_meta.rt !== Core.Const(false) # Ugh it may be Const(true), Const(false), Bool
             callinfo = NoInlineCallInfo(callinfo, atype, :inactive)
         else
             # 2. Check if rule is defined
             if interp.forward_rules
                 rulef = EnzymeRules.forward
                 ft, tt = EnzymeRules._annotate_tt(atype)
-                rule_atype = Tuple{typeof(EnzymeRules.forward), <:FwdConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}
                 rule_argtypes = Any[Core.Const(EnzymeRules.forward), FwdConfig, Annotation{ft}, Type{<:Annotation}, tt...]
             else
                 rulef = EnzymeRules.reverse
                 ft, tt = EnzymeRules._annotate_tt(atype)
-                rule_atype = Tuple{typeof(EnzymeRules.reverse), <:RevConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}
                 rule_argtypes = Any[Core.Const(EnzymeRules.reverse), RevConfig, Annotation{ft}, Type{<:Annotation}, tt...]
             end
 
-            rule_arginfo = ArgInfo(nothing, rule_argtypes)
-            rule_meta  = @invoke Core.Compiler.abstract_call_gf_by_type(
-                interp::AbstractInterpreter,
-                rulef::Any,
-                rule_arginfo::ArgInfo,
-                si::StmtInfo,
-                rule_atype::Any,
-                sv::AbsIntState,
-                max_methods::Int,
-            )
-            if rule_meta.info isa Core.Compiler.MethodMatchInfo && Core.Compiler.nmatches(rule_meta.info) != 0
+            rule_meta = abstract_applicable(interp, rule_argtypes, sv, max_methods) # Does backedge handling internally
+            if rule_meta.rt !== Core.Const(false) # Ugh it may be Const(true), Const(false), Bool
                 callinfo = NoInlineCallInfo(callinfo, atype, interp.forward_rules ? :frule : :rrule)
             end
         end

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -233,7 +233,7 @@ function Core.Compiler.abstract_call_gf_by_type(
             sv::AbsIntState,
             max_methods::Int,
         )
-        if Core.Compiler.nmatches(inactive_meta.info) != 0
+        if inactive_meta.info isa Core.Compiler.MethodMatchInfo && Core.Compiler.nmatches(inactive_meta.info) != 0
             callinfo = NoInlineCallInfo(callinfo, atype, :inactive)
         else
             # 2. Check if rule is defined
@@ -259,7 +259,7 @@ function Core.Compiler.abstract_call_gf_by_type(
                 sv::AbsIntState,
                 max_methods::Int,
             )
-            if Core.Compiler.nmatches(rule_meta.info) != 0
+            if rule_meta.info isa Core.Compiler.MethodMatchInfo && Core.Compiler.nmatches(rule_meta.info) != 0
                 callinfo = NoInlineCallInfo(callinfo, atype, interp.forward_rules ? :frule : :rrule)
             end
         end

--- a/test/ruleinvalidation.jl
+++ b/test/ruleinvalidation.jl
@@ -34,18 +34,14 @@ for m in methods(forward, Tuple{Any,Const{typeof(issue696)},Vararg{Any}})
 end
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 @static if VERSION < v"1.11-"
-@test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+    @test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 else
-@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+    @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 end
 
 # now test invalidation for `inactive`
 inactive(::typeof(issue696), args...) = nothing
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-@static if VERSION < v"1.11-"
-@test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-else
 @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-end
 
 end # module


### PR DESCRIPTION
Originally I was thinking something like:

```
        # 1. Check if function is inactive
        @show fargs
        @show argtypes
        inactive_arginfo = ArgInfo(nothing, pushfirst!(copy(argtypes), Core.Const(EnzymeRules.inactive)))
        inactive_atype = Tuple{typeof(EnzymeRules.inactive), atype.parameters...} 
        @show inactive_arginfo
        @show inactive_atype
        inactive_meta  = @invoke Core.Compiler.abstract_call_gf_by_type(
            interp::AbstractInterpreter,
            EnzymeRules.inactive::Any,
            inactive_arginfo::ArgInfo,
            si::StmtInfo,
            inactive_atype::Any,
            sv::AbsIntState,
            max_methods::Int,
        )

        if Core.Compiler.nmatches(inactive_meta.info) == 0
```

E.g. doing an abstract call against the rules function and checking how many matches we would get,
this ought to do the edge handling for us. But this change is more minimal.
