### PR TITLE
Fix methodinstance usage and backedges

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -410,7 +410,7 @@ Enzyme.autodiff(ReverseWithPrimal, x->x*x, Active(3.0))
     end
 
     opt_mi = if RABI <: NonGenABI
-        Compiler.fspec(eltype(FA), tt′)
+        my_methodinstance(Reverse, eltype(FA), tt)
     else
         Val(0)
     end
@@ -536,7 +536,7 @@ Like [`autodiff`](@ref) but will try to guess the activity of the return value.
 ) where {FA<:Annotation,CMode<:Mode,Nargs}
     tt = vaEltypeof(args...)
     rt = Compiler.primal_return_type(
-        mode,
+        mode isa ForwardMode ? Forward : Reverse,
         eltype(FA),
         tt,
     )
@@ -632,7 +632,7 @@ f(x) = x*x
     tt = vaEltypeof(args...)
 
     opt_mi = if RABI <: NonGenABI
-        Compiler.fspec(eltype(FA), tt′)
+        my_methodinstance(Forward, eltype(FA), tt)
     else
         Val(0)
     end
@@ -968,7 +968,7 @@ result, ∂v, ∂A
 
     tt′ = Tuple{args...}
     opt_mi = if RABI <: NonGenABI
-        Compiler.fspec(eltype(FA), tt′)
+        my_methodinstance(Reverse, eltype(FA), tt)
     else
         Val(0)
     end
@@ -1098,7 +1098,7 @@ forward = autodiff_thunk(Forward, Const{typeof(f)}, Duplicated, Duplicated{Float
 
     tt′ = Tuple{args...}
     opt_mi = if RABI <: NonGenABI
-        Compiler.fspec(eltype(FA), tt′)
+        my_methodinstance(Forward, eltype(FA), tt)
     else
         Val(0)
     end
@@ -1166,7 +1166,7 @@ end
 
     primal_tt = Tuple{map(eltype, args)...}
     opt_mi = if RABI <: NonGenABI
-        Compiler.fspec(eltype(FA), TT)
+        my_methodinstance(Forward, eltype(FA), primal_tt)
     else
         Val(0)
     end
@@ -1196,7 +1196,7 @@ const tape_cache = Dict{UInt,Type}()
 
 const tape_cache_lock = ReentrantLock()
 
-import .Compiler: fspec, remove_innerty, UnknownTapeType
+import .Compiler: remove_innerty, UnknownTapeType
 
 @inline function tape_type(
     parent_job::Union{GPUCompiler.CompilerJob,Nothing},
@@ -1246,7 +1246,7 @@ import .Compiler: fspec, remove_innerty, UnknownTapeType
 
     primal_tt = Tuple{map(eltype, args)...}
 
-    mi = Compiler.fspec(eltype(FA), TT)
+    mi = my_methodinstance(parent_job === nothing ? Reverse : GPUCompiler.get_interpreter(parent_job), eltype(FA), primal_tt)
 
     target = Compiler.EnzymeTarget()
     params = Compiler.EnzymeCompilerParams(

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -370,7 +370,7 @@ Enzyme.autodiff(ReverseWithPrimal, x->x*x, Active(3.0))
     FTy = Core.Typeof(f.val)
 
     rt = if A isa UnionAll
-        Compiler.primal_return_type(mode, FTy, tt)
+        Compiler.primal_return_type(Reverse, FTy, tt)
     else
         eltype(A)
     end

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -687,7 +687,7 @@ code, as well as high-order differentiation.
     A2 = A
 
     if A isa UnionAll
-        rt = Compiler.primal_return_type(mode, FTy, tt)
+        rt = Compiler.primal_return_type(Reverse, FTy, tt)
         A2 = A{rt}
         if rt == Union{}
             rt = Nothing 
@@ -840,7 +840,7 @@ code, as well as high-order differentiation.
     FT = Core.Typeof(f.val)
 
     if RT isa UnionAll
-        rt = Compiler.primal_return_type(mode, FT, tt)
+        rt = Compiler.primal_return_type(Forward, FT, tt)
 	if rt == Union{}
 	   rt = Nothing
 	end
@@ -1382,7 +1382,7 @@ result, ∂v, ∂A
     TT = Tuple{args...}
 
     primal_tt = Tuple{map(eltype, args)...}
-    rt0 = Compiler.primal_return_type(mode, eltype(FA), primal_tt)
+    rt0 = Compiler.primal_return_type(Reverse, eltype(FA), primal_tt)
 
     rt = Compiler.remove_innerty(A2){rt0}
 

--- a/src/analyses/activity.jl
+++ b/src/analyses/activity.jl
@@ -249,6 +249,7 @@ end
         EnzymeCore.EnzymeRules.inactive_type(T)
     else
         inmi = my_methodinstance(
+            nothing,
             typeof(EnzymeCore.EnzymeRules.inactive_type),
             Tuple{Type{T}},
             world,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3802,7 +3802,7 @@ end
             continue
         end
         if EnzymeRules.is_inactive_from_sig(specTypes; world, method_table, caller) &&
-           has_method(
+           Enzyme.has_method(
             Tuple{typeof(EnzymeRules.inactive),specTypes.parameters...},
             world,
             method_table,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -3556,13 +3556,13 @@ function GPUCompiler.codegen(
         caller = mi
         if mode == API.DEM_ForwardMode
             has_custom_rule =
-                EnzymeRules.has_frule_from_sig(specTypes; world, method_table, caller)
+                EnzymeRules.has_frule_from_sig(specTypes; world, method_table) # , caller)
             if has_custom_rule
                 @safe_debug "Found frule for" mi.specTypes
             end
         else
             has_custom_rule =
-                EnzymeRules.has_rrule_from_sig(specTypes; world, method_table, caller)
+                EnzymeRules.has_rrule_from_sig(specTypes; world, method_table) # , caller)
             if has_custom_rule
                 @safe_debug "Found rrule for" mi.specTypes
             end
@@ -3577,7 +3577,7 @@ function GPUCompiler.codegen(
             actualRetType = k.ci.rettype
         end
 
-        if EnzymeRules.noalias_from_sig(mi.specTypes; world, method_table, caller)
+        if EnzymeRules.noalias_from_sig(mi.specTypes; world, method_table) #, caller)
             push!(return_attributes(llvmfn), EnumAttribute("noalias"))
             for u in LLVM.uses(llvmfn)
                 c = LLVM.user(u)
@@ -3801,7 +3801,7 @@ end
             end
             continue
         end
-        if EnzymeRules.is_inactive_from_sig(specTypes; world, method_table, caller) &&
+        if EnzymeRules.is_inactive_from_sig(specTypes; world, method_table) && # , caller) &&
            Enzyme.has_method(
             Tuple{typeof(EnzymeRules.inactive),specTypes.parameters...},
             world,
@@ -3819,7 +3819,7 @@ end
             )
             continue
         end
-        if EnzymeRules.is_inactive_noinl_from_sig(specTypes; world, method_table, caller) &&
+        if EnzymeRules.is_inactive_noinl_from_sig(specTypes; world, method_table) && #, caller) &&
            has_method(
             Tuple{typeof(EnzymeRules.inactive_noinl),specTypes.parameters...},
             world,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -2139,7 +2139,7 @@ function create_abi_wrapper(
             push!(realparms, val)
         elseif T <: BatchDuplicatedFunc
             Func = get_func(T)
-            funcspec = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, Tuple{}, world)
+            funcspec = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, Func, Tuple{}, world)
             llvmf = nested_codegen!(Mode, mod, funcspec, world)
             push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
             Func_RT = return_type(interp, funcspec)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1207,8 +1207,8 @@ if VERSION >= v"1.11.0-DEV.1552"
 
     @inline EnzymeCacheToken(target_type, always_inline, method_table, param_type, is_forward, is_reverse) =
         EnzymeCacheToken(target_type, always_inline, method_table, param_type,
-            is_forward ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.forward, Tuple{<:FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
-            is_reverse ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
+            is_forward ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.forward, Tuple{<:EnzymeCore.EnzymeRules.FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
+            is_reverse ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:EnzymeCore.EnzymeRules.RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
             (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.inactive, Tuple{Vararg{Any}}, world)...,)
         )
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1205,7 +1205,7 @@ if VERSION >= v"1.11.0-DEV.1552"
         last_ina_rule_world::Tuple
     end
 
-    @inline EnzymeCacheToken(target_type, always_inline, method_table, param_type, is_forward, is_reverse) =
+    @inline EnzymeCacheToken(target_type::Type, always_inline::Any, method_table::Core.MethodTable, param_type::Type, world::UInt, is_forward::Bool, is_reverse::Bool) =
         EnzymeCacheToken(target_type, always_inline, method_table, param_type,
             is_forward ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.forward, Tuple{<:EnzymeCore.EnzymeRules.FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
             is_reverse ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:EnzymeCore.EnzymeRules.RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
@@ -1218,6 +1218,7 @@ if VERSION >= v"1.11.0-DEV.1552"
             job.config.always_inline,
             GPUCompiler.method_table(job),
             typeof(job.config.params),
+            job.world,
             job.config.params.mode == API.DEM_ForwardMode,
             job.config.params.mode != API.DEM_ForwardMode
         )

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -24,105 +24,6 @@ else
     import Core.Compiler: get_world_counter, get_world_counter as get_inference_world
 end
 
-function rule_backedge_holder_generator(world::UInt, source, self, ft::Type)
-    @nospecialize
-    sig = Tuple{typeof(Base.identity), Int}
-    min_world = Ref{UInt}(typemin(UInt))
-    max_world = Ref{UInt}(typemax(UInt))
-    has_ambig = Ptr{Int32}(C_NULL) 
-    mthds = Base._methods_by_ftype(
-        sig,
-        nothing,
-        -1, #=lim=#
-        world,
-        false, #=ambig=#
-        min_world,
-        max_world,
-        has_ambig,
-    )
-    mtypes, msp, m = mthds[1]
-    mi = ccall(
-        :jl_specializations_get_linfo,
-        Ref{Core.MethodInstance},
-        (Any, Any, Any),
-        m,
-        mtypes,
-        msp,
-    )
-    ci = Core.Compiler.retrieve_code_info(mi, world)::Core.Compiler.CodeInfo
-
-    # prepare a new code info
-    new_ci = copy(ci)
-    empty!(new_ci.code)
-    @static if isdefined(Core, :DebugInfo)
-      new_ci.debuginfo = Core.DebugInfo(:none)
-    else
-      empty!(new_ci.codelocs)
-      resize!(new_ci.linetable, 1)                # see note below
-    end
-    empty!(new_ci.ssaflags)
-    new_ci.ssavaluetypes = 0
-    new_ci.min_world = min_world[]
-    new_ci.max_world = max_world[]
-
-    ### TODO: backedge from inactive, augmented_primal, forward, reverse
-    edges = Any[]
-
-    if ft == typeof(EnzymeRules.augmented_primal)
-        rev_sig = Tuple{typeof(EnzymeRules.augmented_primal), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
-        push!(edges, ccall(:jl_method_table_for, Any, (Any,), rev_sig)::Core.MethodTable)
-        push!(edges, rev_sig)
-        
-        rev_sig = Tuple{typeof(EnzymeRules.reverse), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Union{Type{<:Enzyme.EnzymeCore.Annotation}, Enzyme.EnzymeCore.Active}, Any, Vararg{Enzyme.EnzymeCore.Annotation}}
-        push!(edges, ccall(:jl_method_table_for, Any, (Any,), rev_sig)::Core.MethodTable)
-        push!(edges, rev_sig)
-    elseif ft == typeof(EnzymeRules.forward)
-        fwd_sig = Tuple{typeof(EnzymeRules.forward), <:EnzymeRules.FwdConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
-        push!(edges, ccall(:jl_method_table_for, Any, (Any,), fwd_sig)::Core.MethodTable)
-        push!(edges, fwd_sig)
-    elseif ft == typeof(EnzymeRules.inactive)
-        ina_sig = Tuple{typeof(EnzymeRules.inactive), Vararg{Any}}
-        push!(edges, ccall(:jl_method_table_for, Any, (Any,), ina_sig)::Core.MethodTable)
-        push!(edges, ina_sig)
-    else
-        for gen_sig in (
-            Tuple{typeof(EnzymeRules.inactive_noinl), Vararg{Any}},
-            Tuple{typeof(EnzymeRules.noalias), Vararg{Any}},
-            Tuple{typeof(EnzymeRules.inactive_type), Type},
-        )
-            push!(edges, ccall(:jl_method_table_for, Any, (Any,), gen_sig)::Core.MethodTable)
-            push!(edges, gen_sig)
-        end
-    end
-
-    new_ci.edges = edges
-
-    # XXX: setting this edge does not give us proper method invalidation, see
-    #      JuliaLang/julia#34962 which demonstrates we also need to "call" the kernel.
-    #      invoking `code_llvm` also does the necessary codegen, as does calling the
-    #      underlying C methods -- which GPUCompiler does, so everything Just Works.
-
-    # prepare the slots
-    new_ci.slotnames = Symbol[Symbol("#self#"), :ft]
-    new_ci.slotflags = UInt8[0x00 for i = 1:2]
-
-    # return the codegen world age
-    push!(new_ci.code, Core.Compiler.ReturnNode(0))
-    push!(new_ci.ssaflags, 0x00)   # Julia's native compilation pipeline (and its verifier) expects `ssaflags` to be the same length as `code`
-    @static if isdefined(Core, :DebugInfo)
-    else
-      push!(new_ci.codelocs, 1)   # see note below
-    end
-    new_ci.ssavaluetypes += 1
-
-    return new_ci
-end
-
-@eval Base.@assume_effects :removable :foldable :nothrow @inline function rule_backedge_holder(ft)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, rule_backedge_holder_generator))
-end
-
 struct EnzymeInterpreter{T} <: AbstractInterpreter
     @static if HAS_INTEGRATED_CACHE
         token::Any
@@ -319,32 +220,32 @@ function Core.Compiler.abstract_call_gf_by_type(
         callinfo = AlwaysInlineCallInfo(callinfo, atype)
     else
         method_table = Core.Compiler.method_table(interp)
-        if EnzymeRules.is_inactive_from_sig(specTypes; world = interp.world, method_table)
+        if is_inactive_from_sig(interp, specTypes, sv)
             callinfo = NoInlineCallInfo(callinfo, atype, :inactive)
         else
             if interp.forward_rules
-              if EnzymeRules.has_frule_from_sig(specTypes; world = interp.world, method_table)
+              if has_frule_from_sig(interp, specTypes, sv)
                 callinfo = NoInlineCallInfo(callinfo, atype, :frule)
               end
             end
         
             if interp.reverse_rules
-                if EnzymeRules.has_rrule_from_sig(specTypes; world = interp.world, method_table)
+                if has_rrule_from_sig(interp, specTypes, sv)
                   callinfo = NoInlineCallInfo(callinfo, atype, :rrule)
                 end
             end
         end
 
-        if interp.forward_rules
-            Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.forward)}, interp.world)::Core.MethodInstance)
-            Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(EnzymeRules.forward))
-        end
-        if interp.reverse_rules
-            Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.augmented_primal)}, interp.world)::Core.MethodInstance)
-            Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(EnzymeRules.augmented_primal))
-        end
-        Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.inactive)}, interp.world)::Core.MethodInstance)
-        Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(typeof(EnzymeRules.inactive)))
+        # if interp.forward_rules
+        #     Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.forward)}, interp.world)::Core.MethodInstance)
+        #     Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(EnzymeRules.forward))
+        # end
+        # if interp.reverse_rules
+        #     Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.augmented_primal)}, interp.world)::Core.MethodInstance)
+        #     Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(EnzymeRules.augmented_primal))
+        # end
+        # Core.Compiler.add_backedge!(sv, GPUCompiler.methodinstance(typeof(Enzyme.Compiler.Interpreter.rule_backedge_holder), Tuple{typeof(EnzymeRules.inactive)}, interp.world)::Core.MethodInstance)
+        # Enzyme.Compiler.Interpreter.rule_backedge_holder(Base.inferencebarrier(typeof(EnzymeRules.inactive)))
     end
 
     @static if VERSION ≥ v"1.11-"

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -208,7 +208,7 @@ function get_trampoline(job)
         # 2 Add a module defining "foo.rt.impl" to the JITDylib.
         # 2. Call MR.replace(symbolAliases({"my_deferred_decision_sym.1" -> "foo.rt.impl"})).
         GPUCompiler.JuliaContext() do ctx
-            mod, adjoint_name, primal_name = Compiler._thunk(job)
+            mod, edges, adjoint_name, primal_name = Compiler._thunk(job)
             func_name = use_primal ? primal_name : adjoint_name
             other_name = !use_primal ? primal_name : adjoint_name
 

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -23,9 +23,10 @@ function get_job(
         world=Base.get_world_counter()
     end
 
-    primal = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, eltype(Core.Typeof(func)), Tuple{map(eltype, types.parameters)...}, world)
+    primal = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, Core.Typeof(func), tt, world)
     rt = Compiler.primal_return_type_world(mode == API.DEM_ForwardMode ? Forward : Reverse, world, Core.Typeof(func), tt)
 
+    @assert primal !== nothing
     rt = A{rt}
     target = Compiler.EnzymeTarget()
     if modifiedBetween === nothing

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -19,8 +19,6 @@ function get_job(
 
     tt = Tuple{map(eltype, types.parameters)...}
 
-
-    primal, rt = 
     if world isa Nothing
         world=Base.get_world_counter()
     end

--- a/src/compiler/tfunc.jl
+++ b/src/compiler/tfunc.jl
@@ -41,8 +41,9 @@ function isapplicable(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
     end
     # also need an edge to the method table in case something gets
     # added that did not intersect with any existing method
-    fullmatch = Core.Compiler._any(match::Core.MethodMatch -> match.fully_covers, matches)
-    if !fullmatch
+    # fullmatch = Core.Compiler._any(match::Core.MethodMatch -> match.fully_covers, matches)
+    # if !fullmatch
+    if true
         if partialsig === nothing
             Core.Compiler.add_mt_backedge!(sv, mt, sig)
         else
@@ -53,11 +54,11 @@ function isapplicable(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
     if Core.Compiler.isempty(matches)
         return false
     else
-        for i = 1:Core.Compiler.length(matches)
-            match = Core.Compiler.getindex(matches, i)::Core.MethodMatch
-            edge = Core.Compiler.specialize_method(match)::Core.MethodInstance
-            Core.Compiler.add_backedge!(sv, edge)
-        end
+        #for i = 1:Core.Compiler.length(matches)
+        #    match = Core.Compiler.getindex(matches, i)::Core.MethodMatch
+        #    edge = Core.Compiler.specialize_method(match)::Core.MethodInstance
+        #    Core.Compiler.add_backedge!(sv, edge)
+        #end
         return true
     end
 end

--- a/src/compiler/tfunc.jl
+++ b/src/compiler/tfunc.jl
@@ -2,30 +2,32 @@ import EnzymeCore: Annotation
 import EnzymeCore.EnzymeRules: FwdConfig, RevConfig, forward, augmented_primal, inactive, _annotate_tt
 
 function has_frule_from_sig(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
-    @nospecialize(TT), sv::Core.Compiler.AbsIntState)::Bool
+    @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState, partialedge::Bool=true)::Bool
     ft, tt = _annotate_tt(TT)
     TT = Tuple{<:FwdConfig,<:Annotation{ft},Type{<:Annotation},tt...}
-    return isapplicable(interp, forward, TT, sv)
+    fwd_sig = Tuple{typeof(EnzymeRules.forward), <:EnzymeRules.FwdConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
+    return isapplicable(interp, forward, TT, sv, fwd_sig)
 end
 
 function has_rrule_from_sig(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
-    @nospecialize(TT), sv::Core.Compiler.AbsIntState)::Bool
+    @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState, partialedge::Bool=true)::Bool
     ft, tt = _annotate_tt(TT)
     TT = Tuple{<:RevConfig,<:Annotation{ft},Type{<:Annotation},tt...}
-    return isapplicable(interp, augmented_primal, TT, sv)
+    rev_sig = Tuple{typeof(EnzymeRules.augmented_primal), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
+    return isapplicable(interp, augmented_primal, TT, sv, rev_sig)
 end
 
 
 function is_inactive_from_sig(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
-    @nospecialize(TT), sv::Core.Compiler.AbsIntState)
-    return isapplicable(interp, inactive, TT, sv)
+                             @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState)
+    return isapplicable(interp, inactive, TT, sv, TT)
 end
 
 # `hasmethod` is a precise match using `Core.Compiler.findsup`,
 # but here we want the broader query using `Core.Compiler.findall`.
 # Also add appropriate backedges to the caller `MethodInstance` if given.
 function isapplicable(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
-    @nospecialize(f), @nospecialize(TT), sv::Core.Compiler.AbsIntState)::Bool
+                      @nospecialize(f), @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState, @nospecialize(partialsig::Type))::Bool
     tt = Base.to_tuple_type(TT)
     sig = Base.signature_type(f, tt)
     mt = ccall(:jl_method_table_for, Any, (Any,), sig)
@@ -41,7 +43,8 @@ function isapplicable(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
     # added that did not intersect with any existing method
     fullmatch = Core.Compiler._any(match::Core.MethodMatch -> match.fully_covers, matches)
     if !fullmatch
-        Core.Compiler.add_mt_backedge!(sv, mt, sig)
+        pmt = ccall(:jl_method_table_for, Any, (Any,), partialsig)::Core.MethodTable
+        Core.Compiler.add_mt_backedge!(sv, pmt, partialsig)
     end
     if Core.Compiler.isempty(matches)
         return false

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -474,24 +474,12 @@ const generic_method_offsets = Dict{String,Tuple{Int,Int}}((
     "ijl_apply_generic" => (1, 2),
 ))
 
-@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Union{Nothing,Core.MethodTable})
-    return ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), sig, mt, world) !== nothing
-end
-
-@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Core.Compiler.InternalMethodTable)
-    return has_method(sig, mt.world, nothing)
-end
-
-@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Core.Compiler.OverlayMethodTable)
-    return has_method(sig, mt.world, mt.mt) || has_method(sig, mt.world, nothing)
-end
-
 @inline function is_inactive(@nospecialize(tys::Union{Vector{Union{Type,Core.TypeofVararg}}, Core.SimpleVector}), world::UInt, @nospecialize(mt))
     specTypes = Interpreter.simplify_kw(Tuple{tys...})
-    if has_method(Tuple{typeof(EnzymeRules.inactive),tys...}, world, mt)
+    if Enzyme.has_method(Tuple{typeof(EnzymeRules.inactive),tys...}, world, mt)
         return true
     end
-    if has_method(Tuple{typeof(EnzymeRules.inactive_noinl),tys...}, world, mt)
+    if Enzyme.has_method(Tuple{typeof(EnzymeRules.inactive_noinl),tys...}, world, mt)
         return true
     end
     return false

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -538,10 +538,7 @@ end
 
     llvmf = nested_codegen!(mode, mod, fmi, world)
 
-    @show fmi, fwd_RT, world
-    println(string(llvmf))
-
-    # push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
+    push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
 
     swiftself = has_swiftself(llvmf)
     if swiftself

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -537,7 +537,11 @@ end
     fwd_RT = fwd_RT::Type
 
     llvmf = nested_codegen!(mode, mod, fmi, world)
-    push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
+
+    @show fmi, fwd_RT, world
+    println(string(llvmf))
+
+    # push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
 
     swiftself = has_swiftself(llvmf)
     if swiftself

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -984,7 +984,7 @@ function enzyme_custom_common_rev(
         end
 
         @safe_debug "Applying custom reverse rule" TT = rev_TT, functy=functy
-        rmi = my_methodinstance(functy, rev_TT, world)
+        rmi = my_methodinstance(Reverse, functy, rev_TT, world)
 
         if rmi === nothing
             rev_TT = Tuple{typeof(world),functy,rev_TT.parameters...}

--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -238,7 +238,8 @@ end
 
     pfuncT = funcT
 
-    mi2 = fspec(funcT, e_tt, world)
+    mi2 = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
+    @assert mi2 !== nothing
 
     refed = false
 
@@ -306,7 +307,8 @@ end
                 funcT = Core.Typeof(referenceCaller)
                 dupClosure = false
                 modifiedBetween = (false, modifiedBetween...)
-                mi2 = fspec(funcT, e_tt, world)
+                mi2 = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
+                @assert mi2 !== nothing
             end
         end
 

--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -336,7 +336,7 @@ end
                 world,
             )
 
-            cmod, adjointnm, augfwdnm, TapeType, _ = _thunk(ejob, false) #=postopt=#
+            cmod, edges, adjointnm, augfwdnm, TapeType, _ = _thunk(ejob, false) #=postopt=#
 
             LLVM.link!(mod, cmod)
 

--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -276,7 +276,7 @@ end
                 world,
             )
 
-            cmod, fwdmodenm, _, _, _ = _thunk(ejob, false) #=postopt=#
+            cmod, edges, fwdmodenm, _, _, _ = _thunk(ejob, false) #=postopt=#
 
             LLVM.link!(mod, cmod)
 

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -899,7 +899,7 @@ this function will retun an AbstractArray of shape `size(output)` of values of t
             Core.Typeof(f)
         end
 
-        rt = Compiler.primal_return_type(mode, FRT, tt)
+        rt = Compiler.primal_return_type(Reverse, FRT, tt)
 
         ModifiedBetweenT = (false, false)
         FA = Const{FRT}

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -13,7 +13,7 @@ end
 
         target = Compiler.DefaultCompilerTarget()
         params = Compiler.PrimalCompilerParams(API.DEM_ForwardMode)
-        mi = my_methodinstance(fn, Tuple{T, Int})
+        mi = my_methodinstance(nothing, fn, Tuple{T, Int})
         job = GPUCompiler.CompilerJob(mi, GPUCompiler.CompilerConfig(target, params; kernel = false))
 
         GPUCompiler.prepare_job!(job)

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -26,6 +26,7 @@ function primal_interp_world(
             GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
             EnzymeCompilerParams,
             false,
+            true
         )
     else
         Enzyme.Compiler.GLOBAL_REV_CACHE
@@ -47,6 +48,7 @@ function primal_interp_world(
             GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
             EnzymeCompilerParams,
             true,
+            false
         )
     else
         Enzyme.Compiler.GLOBAL_FWD_CACHE

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -25,6 +25,7 @@ function primal_interp_world(
             false,
             GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
             EnzymeCompilerParams,
+            world,
             false,
             true
         )
@@ -47,6 +48,7 @@ function primal_interp_world(
             false,
             GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
             EnzymeCompilerParams,
+            world,
             true,
             false
         )

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -97,41 +97,19 @@ function primal_return_type_generator(world::UInt, source, self, @nospecialize(m
 
     # look up the method
     method_error = :(throw(MethodError(ft, tt, $world)))
-    sig = Tuple{ft,tt.parameters...}
+    
     min_world = Ref{UInt}(typemin(UInt))
     max_world = Ref{UInt}(typemax(UInt))
-    has_ambig = Ptr{Int32}(C_NULL)  # don't care about ambiguous results
-    #interp = primal_interp_world(mode, world)
-    #method_table = Core.Compiler.method_table(interp)
-    method_table = nothing
-    mthds = Base._methods_by_ftype(
-        sig,
-        method_table,
-        -1, #=lim=#
-        world,
-        false, #=ambig=#
-        min_world,
-        max_world,
-        has_ambig,
-    )
+   
+    mi = my_methodinstance(mode, ft, tt, world, min_world, max_world)
+
     stub = Core.GeneratedFunctionStub(
         identity,
         Core.svec(:methodinstance, :mode, :ft, :tt),
         Core.svec(),
     )
-    mthds === nothing && return stub(world, source, method_error)
-    length(mthds) == 1 || return stub(world, source, method_error)
+    mi === nothing && return stub(world, source, method_error)
 
-    # look up the method and code instance
-    mtypes, msp, m = mthds[1]
-    mi = ccall(
-        :jl_specializations_get_linfo,
-        Ref{Core.MethodInstance},
-        (Any, Any, Any),
-        m,
-        mtypes,
-        msp,
-    )
     ci = Core.Compiler.retrieve_code_info(mi, world)::Core.Compiler.CodeInfo
 
     # prepare a new code info

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -320,7 +320,7 @@ end
 # XXX: version of Base.method_instance that uses a function type
 @inline function my_methodinstance(@nospecialize(mode::Union{Nothing, EnzymeCore.ForwardMode, EnzymeCore.ReverseMode}), @nospecialize(ft::Type), @nospecialize(tt::Type))::Core.MethodInstance
     sig = GPUCompiler.signature_type_by_tt(ft, tt)
-    return prevmethodinstance(mode, ft, tt, world)::Core.MethodInstance
+    return prevmethodinstance(mode, ft, tt)::Core.MethodInstance
 end
 
 export my_methodinstance

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,33 +169,120 @@ using Base: _methods_by_ftype
 
 # Julia compiler integration
 
+@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Union{Nothing,Core.MethodTable})
+    return ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), sig, mt, world) !== nothing
+end
 
-if VERSION >= v"1.11.0-DEV.1552"
+@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Core.Compiler.InternalMethodTable)
+    return has_method(sig, mt.world, nothing)
+end
 
+@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Core.Compiler.OverlayMethodTable)
+    return has_method(sig, mt.world, mt.mt) || has_method(sig, mt.world, nothing)
+end
 
-const prevmethodinstance = GPUCompiler.generic_methodinstance
+@inline function lookup_world(
+    @nospecialize(sig::Type),
+    world::UInt,
+    mt::Union{Nothing,Core.MethodTable},
+    min_world::Ref{UInt},
+    max_world::Ref{UInt},
+)
+    res = ccall(
+        :jl_gf_invoke_lookup_worlds,
+        Any,
+        (Any, Any, Csize_t, Ref{Csize_t}, Ref{Csize_t}),
+        sig,
+        mt,
+        world,
+        min_world,
+        max_world,
+    )
+    return res
+end
 
-function methodinstance_generator(world::UInt, source, self, @nospecialize(ft::Type), @nospecialize(tt::Type))
+@inline function lookup_world(
+    @nospecialize(sig::Type),
+    world::UInt,
+    mt::Core.Compiler.InternalMethodTable,
+    min_world::Ref{UInt},
+    max_world::Ref{UInt},
+)
+    res = lookup_world(sig, mt.world, nothing, min_world, max_world)
+    return res
+end
+
+@inline function lookup_world(
+    @nospecialize(sig::Type),
+    world::UInt,
+    mt::Core.Compiler.OverlayMethodTable,
+    min_world::Ref{UInt},
+    max_world::Ref{UInt},
+)
+    res = lookup_world(sig, mt.world, mt.mt, min_world, max_world)
+    if res !== nothing
+        return res
+    else
+        return lookup_world(sig, mt.world, nothing, min_world, max_world)
+    end
+end
+
+@inline function my_methodinstance(@nospecialize(method_table::Union{Core.Compiler.MethodTableView, Nothing}), @nospecialize(ft::Type), @nospecialize(tt::Type), world::UInt, min_world::Union{Nothing, Base.RefValue{UInt}}=nothing, max_world::Union{Nothing, Base.RefValue{UInt}}=nothing)::Union{Core.MethodInstance, Nothing}
+
+    if min_world === nothing
+        min_world = Ref{UInt}(typemin(UInt))
+    end
+    if max_world === nothing
+        max_world = Ref{UInt}(typemax(UInt))
+    end
+
+    sig = Tuple{ft, tt.parameters...}
+    
+    lookup_result = lookup_world(
+        sig, world, method_table, min_world, max_world
+    )
+    if lookup_result === nothing
+        return nothing
+    end
+
+    match = lookup_result::Core.MethodMatch
+    
+    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance},
+               (Any, Any, Any), match.method, match.spec_types, match.sparams)
+    return mi::Core.MethodInstance
+end
+
+@inline function my_methodinstance(@nospecialize(interp::Core.Compiler.AbstractInterpreter), @nospecialize(ft::Type), @nospecialize(tt::Type),  min_world::Union{Nothing, Base.RefValue{UInt}}=nothing, max_world::Union{Nothing, Base.RefValue{UInt}}=nothing)::Union{Core.MethodInstance, Nothing}
+    my_methodinstance(Core.Compiler.method_table(interp), ft, tt, interp.world, min_world, max_world)
+end
+
+@inline function my_methodinstance(@nospecialize(mode::Union{EnzymeCore.ForwardMode, EnzymeCore.ReverseMode}), @nospecialize(ft::Type), @nospecialize(tt::Type), world::UInt, min_world::Union{Nothing, Base.RefValue{UInt}}=nothing, max_world::Union{Nothing, Base.RefValue{UInt}}=nothing)::Union{Core.MethodInstance, Nothing}
+    interp = if mode === Nothing
+        Base.NativeInterpreter(; world)
+    else
+        @assert mode == Forward || mode == Reverse
+        Compiler.primal_interp_world(mode, world)
+    end
+    my_methodinstance(interp, ft, tt, min_world, max_world)
+end
+
+function methodinstance_generator(world::UInt, source, self, @nospecialize(mode::Type), @nospecialize(ft::Type), @nospecialize(tt::Type))
     @nospecialize
     @assert Core.Compiler.isType(ft) && Core.Compiler.isType(tt)
     ft = ft.parameters[1]
     tt = tt.parameters[1]
 
-    stub = Core.GeneratedFunctionStub(identity, Core.svec(:methodinstance, :ft, :tt), Core.svec())
+    stub = Core.GeneratedFunctionStub(identity, Core.svec(:methodinstance, :mode, :ft, :tt), Core.svec())
 
     # look up the method match
     method_error = :(throw(MethodError(ft, tt, $world)))
-    sig = Tuple{ft, tt.parameters...}
     min_world = Ref{UInt}(typemin(UInt))
     max_world = Ref{UInt}(typemax(UInt))
-    match = ccall(:jl_gf_invoke_lookup_worlds, Any,
-                  (Any, Any, Csize_t, Ref{Csize_t}, Ref{Csize_t}),
-                  sig, #=mt=# nothing, world, min_world, max_world)
-    match === nothing && return stub(world, source, method_error)
 
-    # look up the method and code instance
-    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance},
-               (Any, Any, Any), match.method, match.spec_types, match.sparams)
+    mi = my_methodinstance(mode.instance, ft, tt, world, min_world, max_world)
+    
+    mi === nothing && return stub(world, source, method_error)
+    
     ci = Core.Compiler.retrieve_code_info(mi, world)
 
     # prepare a new code info
@@ -212,8 +299,8 @@ function methodinstance_generator(world::UInt, source, self, @nospecialize(ft::T
     new_ci.edges = MethodInstance[mi]
 
     # prepare the slots
-    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
-    new_ci.slotflags = UInt8[0x00 for i = 1:3]
+    new_ci.slotnames = Symbol[Symbol("#self#"), :mode, :ft, :tt]
+    new_ci.slotflags = UInt8[0x00 for i = 1:4]
 
     # return the method instance
     push!(new_ci.code, Core.Compiler.ReturnNode(mi))
@@ -225,23 +312,15 @@ function methodinstance_generator(world::UInt, source, self, @nospecialize(ft::T
     return new_ci
 end
 
-@eval function prevmethodinstance(ft, tt)::Core.MethodInstance
+@eval function prevmethodinstance(mode, ft, tt)::Core.MethodInstance
     $(Expr(:meta, :generated_only))
     $(Expr(:meta, :generated, methodinstance_generator))
 end
 
 # XXX: version of Base.method_instance that uses a function type
-@inline function my_methodinstance(@nospecialize(ft::Type), @nospecialize(tt::Type),
-                                world::Integer=tls_world_age())::Core.MethodInstance
+@inline function my_methodinstance(@nospecialize(mode::Union{Nothing, EnzymeCore.ForwardMode, EnzymeCore.ReverseMode}), @nospecialize(ft::Type), @nospecialize(tt::Type))::Core.MethodInstance
     sig = GPUCompiler.signature_type_by_tt(ft, tt)
-    if Base.isdispatchtuple(sig)   # JuliaLang/julia#52233
-        return GPUCompiler.methodinstance(ft, tt, world)::Core.MethodInstance
-    else
-        return prevmethodinstance(ft, tt, world)::Core.MethodInstance
-    end
-end
-else
-    import GPUCompiler: methodinstance as my_methodinstance
+    return prevmethodinstance(mode, ft, tt, world)::Core.MethodInstance
 end
 
 export my_methodinstance

--- a/test/ruleinvalidation.jl
+++ b/test/ruleinvalidation.jl
@@ -33,11 +33,23 @@ for m in methods(forward, Tuple{Any,Const{typeof(issue696)},Vararg{Any}})
     Base.delete_method(m)
 end
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+@static if VERSION < v"1.11-"
+    @test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+else
+    @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+end
 
 # now test invalidation for `inactive`
 inactive(::typeof(issue696), args...) = nothing
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
 @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
+
+# check that `Base.delete_method` works as expected
+for m in methods(inactive, Tuple{typeof(issue696),Vararg{Any}})
+    Base.delete_method(m)
+end
+
+@test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 
 end # module

--- a/test/ruleinvalidation.jl
+++ b/test/ruleinvalidation.jl
@@ -33,18 +33,11 @@ for m in methods(forward, Tuple{Any,Const{typeof(issue696)},Vararg{Any}})
     Base.delete_method(m)
 end
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-@static if VERSION < v"1.11-"
-    @test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-else
-    @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-end
+@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 
 # now test invalidation for `inactive`
 inactive(::typeof(issue696), args...) = nothing
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-@static if VERSION < v"1.11-"
-    @test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-else
-    @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
-end
+@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 0.0
+
 end # module

--- a/test/ruleinvalidation.jl
+++ b/test/ruleinvalidation.jl
@@ -33,11 +33,7 @@ for m in methods(forward, Tuple{Any,Const{typeof(issue696)},Vararg{Any}})
     Base.delete_method(m)
 end
 @test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-@static if VERSION < v"1.11-"
-    @test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-else
-    @test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-end
+@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 
 # now test invalidation for `inactive`
 inactive(::typeof(issue696), args...) = nothing

--- a/test/ruleinvalidation.jl
+++ b/test/ruleinvalidation.jl
@@ -45,7 +45,7 @@ for m in methods(inactive, Tuple{typeof(issue696),Vararg{Any}})
     Base.delete_method(m)
 end
 
-@test autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
-@test autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+@test_broken autodiff(Forward, issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
+@test_broken autodiff(Forward, call_issue696, Duplicated(1.0, 1.0))[1] ≈ 2.0
 
 end # module


### PR DESCRIPTION
Hopefully now that I understand backedges, this fixes pending issues.

Simultaneously this gets rid of a bunch of inner generated functions so hopefully compile time comes down.

Time to first derivative (post precompile) is now:

```julia
julia> @time autodiff(Forward, sin, Duplicated(1.0, 2.0))
  0.000014 seconds
(1.0806046117362795,)

julia> @time autodiff(Forward, sin, Duplicated(1.0, 2.0))
  0.000003 seconds
(1.0806046117362795,)

julia> @time autodiff(Forward, sin, Duplicated(1.0, 2.0))
  0.000002 seconds
(1.0806046117362795,)
```