### PR TITLE
Updated error message for AssertionError in shadowTuple

### DIFF
--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -1140,7 +1140,9 @@ end
 ) where {Ann,Nargs}
     expr = Vector{Expr}(undef, Nargs)
     for i = 1:Nargs
-        @assert !(args[i] <: Active)
+        if args[i] <: Active
+            throw(AssertionError("Unsupported Active arg $(args[i])"))
+        end
         @inbounds expr[i] = if args[i] <: Const
             :(args[$i].val)
         elseif args[i] <: MixedDuplicated


### PR DESCRIPTION
This creates a better error message for an AssertionError in shadow tuple in `jitrules.jl`

@wsmoses