### PR TITLE
Suggestion: remove code-suggester, print diff instead

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -11,9 +11,6 @@ permissions:
   # needed for julia-actions/cache to delete old caches
   actions: write
 
-  # needed for googleapis/code-suggester
-  pull-requests: write
-
 jobs:
   runic:
     runs-on: ubuntu-latest
@@ -42,14 +39,4 @@ jobs:
       - name: Run Runic
         run: |
           set +e
-          git runic origin/main
-          [ $? -eq 2 ] && exit 1 || exit 0
-
-      - name: Suggest changes
-        uses: googleapis/code-suggester@v4
-        env:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          command: review
-          pull_number: ${{ github.event.pull_request.number }}
-          git_dir: '.'
+          git runic --diff origin/main


### PR DESCRIPTION
In addition to creating rather noisy PR threads, code-suggester is fundamentally broken as evidenced by all the nonsense suggestions in #1852. Google does not intend to fix this as explained here: https://github.com/googleapis/code-suggester/issues/505#issuecomment-2638231834.

So I thought it might be better to skip the suggestions and simply let the CI action pass/fail depending on whether the PR is compliant. Runic's suggested diff can then be found in the CI logs.