### PR TITLE
Support real and complex inputs for sparse matmul

### DIFF
--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -729,15 +729,16 @@ function EnzymeRules.reverse(
 end
 
 
-function EnzymeRules.augmented_primal(config::EnzymeRules.RevConfig, 
-                                      func::Const{typeof(LinearAlgebra.mul!)},
-                                      ::Type{RT}, 
-                                      C::Annotation{<:StridedVecOrMat},
-                                      A::Annotation{<:SparseArrays.SparseMatrixCSCUnion},
-                                      B::Annotation{<:StridedVecOrMat},
-                                      α::Annotation{<:Number},
-                                      β::Annotation{<:Number}
-                                    ) where {RT}
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{typeof(LinearAlgebra.mul!)},
+        ::Type{RT},
+        C::Annotation{<:StridedVecOrMat},
+        A::Annotation{<:SparseArrays.SparseMatrixCSCUnion},
+        B::Annotation{<:StridedVecOrMat},
+        α::Annotation{<:Number},
+        β::Annotation{<:Number}
+    ) where {RT}
 
     cache_C = !(isa(β, Const)) ? copy(C.val) : nothing
     # Always need to do forward pass otherwise primal may not be correct
@@ -755,24 +756,26 @@ function EnzymeRules.augmented_primal(config::EnzymeRules.RevConfig,
         nothing
     end
 
-    
+
     # Check if A is overwritten and B is active (and thus required)
-    cache_A = ( EnzymeRules.overwritten(config)[5]
-                && !(typeof(B) <: Const)
-                && !(typeof(C) <: Const)
-                ) ? copy(A.val) : nothing
-    
-    cache_B = ( EnzymeRules.overwritten(config)[6] 
-                && !(typeof(A) <: Const) 
-                && !(typeof(C) <: Const)
-               ) ? copy(B.val) : nothing
+    cache_A = (
+            EnzymeRules.overwritten(config)[5]
+            && !(typeof(B) <: Const)
+            && !(typeof(C) <: Const)
+        ) ? copy(A.val) : nothing
+
+    cache_B = (
+            EnzymeRules.overwritten(config)[6]
+            && !(typeof(A) <: Const)
+            && !(typeof(C) <: Const)
+        ) ? copy(B.val) : nothing
 
     if !isa(α, Const)
-        cache_α = A.val*B.val
+        cache_α = A.val * B.val
     else
         cache_α = nothing
     end
-    
+
     cache = (cache_C, cache_A, cache_B, cache_α)
 
     return EnzymeRules.AugmentedReturn(primal, shadow, cache)
@@ -784,26 +787,25 @@ _project(::Type{<:Real}, x::Complex) = real(x)
 _project(::Type{<:Complex}, x) = x
 
 function _muladdproject!(::Type{<:Number}, dB::AbstractArray, A::AbstractArray, C::AbstractArray, α)
-    LinearAlgebra.mul!(dB, A, C, α, true)
+    return LinearAlgebra.mul!(dB, A, C, α, true)
 end
 
 function _muladdproject!(::Type{<:Complex}, dB::AbstractArray{<:Real}, A::AbstractArray, C::AbstractArray, α::Number)
-    tmp = A*C
-    dB .+= real.(α.*tmp)
+    tmp = A * C
+    return dB .+= real.(α .* tmp)
 end
 
 
-
-
-function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
-                             func::Const{typeof(LinearAlgebra.mul!)},
-                             ::Type{RT}, cache,
-                             C::Annotation{<:StridedVecOrMat},
-                             A::Annotation{<:SparseArrays.SparseMatrixCSCUnion},
-                             B::Annotation{<:StridedVecOrMat},
-                             α::Annotation{<:Number},
-                             β::Annotation{<:Number}
-                             ) where {RT}
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        func::Const{typeof(LinearAlgebra.mul!)},
+        ::Type{RT}, cache,
+        C::Annotation{<:StridedVecOrMat},
+        A::Annotation{<:SparseArrays.SparseMatrixCSCUnion},
+        B::Annotation{<:StridedVecOrMat},
+        α::Annotation{<:Number},
+        β::Annotation{<:Number}
+    ) where {RT}
 
     cache_C, cache_A, cache_B, cache_α = cache
     Cval = !isnothing(cache_C) ? cache_C : C.val
@@ -813,29 +815,29 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
     N = EnzymeRules.width(config)
     if !isa(C, Const)
         dCs = C.dval
-        dBs  = isa(B, Const) ? dCs : B.dval
+        dBs = isa(B, Const) ? dCs : B.dval
         dα = if !isa(α, Const)
-                if N == 1
-                    _project(typeof(α.val), conj(LinearAlgebra.dot(C.dval, cache_α)))
-                else
-                    ntuple(Val(N)) do i
-                        Base.@_inline_meta
-                        _project(typeof(α.val), conj(LinearAlgebra.dot(C.dval[i], cache_α)))
-                    end
+            if N == 1
+                _project(typeof(α.val), conj(LinearAlgebra.dot(C.dval, cache_α)))
+            else
+                ntuple(Val(N)) do i
+                    Base.@_inline_meta
+                    _project(typeof(α.val), conj(LinearAlgebra.dot(C.dval[i], cache_α)))
                 end
+            end
         else
             nothing
         end
 
         dβ = if !isa(β, Const)
-                if N == 1
-                    _project(typeof(β.val), conj(LinearAlgebra.dot(C.dval, Cval)))
-                else
-                    ntuple(Val(N)) do i
-                        Base.@_inline_meta
-                        _project(typeof(β.val), conj(LinearAlgebra.dot(C.dval[i], Cval)))
-                    end
+            if N == 1
+                _project(typeof(β.val), conj(LinearAlgebra.dot(C.dval, Cval)))
+            else
+                ntuple(Val(N)) do i
+                    Base.@_inline_meta
+                    _project(typeof(β.val), conj(LinearAlgebra.dot(C.dval[i], Cval)))
                 end
+            end
         else
             nothing
         end
@@ -843,7 +845,7 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
         for i in 1:N
             if !isa(A, Const)
                 # dA .+= α'dC*B'
-                # You need to be careful so that dA sparsity pattern does not change. Otherwise 
+                # You need to be careful so that dA sparsity pattern does not change. Otherwise
                 # you will get incorrect gradients. So for now we do the slow and bad way of accumulating
                 dA = EnzymeRules.width(config) == 1 ? A.dval : A.dval[i]
                 dC = EnzymeRules.width(config) == 1 ? C.dval : C.dval[i]
@@ -853,10 +855,10 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
                     Ik, Jk = I[k], J[k]
                     # May need to widen if the eltype differ
                     tmp = zero(promote_type(eltype(dA), eltype(dC)))
-                    for ti in axes(dC,2)
-                        tmp += dC[Ik, ti]*conj(Bval[Jk, ti])
+                    for ti in axes(dC, 2)
+                        tmp += dC[Ik, ti] * conj(Bval[Jk, ti])
                     end
-                    dA[Ik, Jk] += _project(eltype(dA), conj(α.val)*tmp)
+                    dA[Ik, Jk] += _project(eltype(dA), conj(α.val) * tmp)
                 end
                 # mul!(dA, dCs, Bval', α.val, true)
             end
@@ -865,7 +867,7 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
                 #dB .+= α*A'*dC
                 # Get the type of all arguments since we may need to
                 # project down to a smaller type during accumulation
-                if N ==1
+                if N == 1
                     Targs = promote_type(eltype(Aval), eltype(dCs), typeof(α.val))
                     _muladdproject!(Targs, dBs, Aval', dCs, conj(α.val))
                 else
@@ -874,7 +876,7 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
                 end
             end
             #dC = dC*conj(β.val)
-            if N==1
+            if N == 1
                 dCs .*= _project(eltype(dCs), conj(β.val))
             else
                 dCs[i] .*= _project(eltype(dCs[i]), conj(β.val))
@@ -910,58 +912,8 @@ function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
             nothing
         end
     end
-   
+
     return (nothing, nothing, nothing, dα, dβ)
-end
-
-
-
-
-
-
-
-function EnzymeRules.forward(
-    config::EnzymeRules.FwdConfig,
-    ::Const{typeof(sort!)},
-    RT::Type{<:Union{Const,DuplicatedNoNeed,Duplicated}},
-    xs::Duplicated{T};
-    kwargs...,
-) where {T<:AbstractArray{<:AbstractFloat}}
-    inds = sortperm(xs.val; kwargs...)
-    xs.val .= xs.val[inds]
-    xs.dval .= xs.dval[inds]
-    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
-        return xs
-    elseif EnzymeRules.needs_shadow(config)
-        return xs.dval
-    elseif EnzymeRules.needs_primal(config)
-        return xs.val
-    else
-        return nothing
-    end
-end
-
-function EnzymeRules.forward(
-    config::EnzymeRules.FwdConfig,
-    ::Const{typeof(sort!)},
-    RT::Type{<:Union{Const,BatchDuplicatedNoNeed,BatchDuplicated}},
-    xs::BatchDuplicated{T,N};
-    kwargs...,
-) where {T<:AbstractArray{<:AbstractFloat},N}
-    inds = sortperm(xs.val; kwargs...)
-    xs.val .= xs.val[inds]
-    for i = 1:N
-        xs.dval[i] .= xs.dval[i][inds]
-    end
-    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
-        return xs
-    elseif EnzymeRules.needs_shadow(config)
-        return xs.dval
-    elseif EnzymeRules.needs_primal(config)
-        return xs.val
-    else
-        return nothing
-    end
 end
 
 

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -913,6 +913,58 @@ function EnzymeRules.reverse(
         end
     end
 
+
+    return (nothing, nothing, nothing, dα, dβ)
+end
+
+
+
+
+
+
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    ::Const{typeof(sort!)},
+    RT::Type{<:Union{Const,DuplicatedNoNeed,Duplicated}},
+    xs::Duplicated{T};
+    kwargs...,
+) where {T<:AbstractArray{<:AbstractFloat}}
+    inds = sortperm(xs.val; kwargs...)
+    xs.val .= xs.val[inds]
+    xs.dval .= xs.dval[inds]
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        return xs
+    elseif EnzymeRules.needs_shadow(config)
+        return xs.dval
+    elseif EnzymeRules.needs_primal(config)
+        return xs.val
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    ::Const{typeof(sort!)},
+    RT::Type{<:Union{Const,BatchDuplicatedNoNeed,BatchDuplicated}},
+    xs::BatchDuplicated{T,N};
+    kwargs...,
+) where {T<:AbstractArray{<:AbstractFloat},N}
+    inds = sortperm(xs.val; kwargs...)
+    xs.val .= xs.val[inds]
+    for i = 1:N
+        xs.dval[i] .= xs.dval[i][inds]
+    end
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        return xs
+    elseif EnzymeRules.needs_shadow(config)
+        return xs.dval
+    elseif EnzymeRules.needs_primal(config)
+        return xs.val
+    else
+        return nothing
+    end
     return (nothing, nothing, nothing, dα, dβ)
 end
 

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -912,8 +912,7 @@ function EnzymeRules.reverse(
             nothing
         end
     end
-
-
+    
     return (nothing, nothing, nothing, dα, dβ)
 end
 

--- a/src/internal_rules.jl
+++ b/src/internal_rules.jl
@@ -965,7 +965,6 @@ function EnzymeRules.forward(
     else
         return nothing
     end
-    return (nothing, nothing, nothing, dα, dβ)
 end
 
 

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -720,9 +720,9 @@ end
 
     for tm in Ts, tv in Ts, tα in Ts, tβ in Ts
         tout = promote_type(tm, tv, tα, tβ)
-        C = zeros(tout, 9)
-        M = sprand(tm, 9, 5, 0.1)
-        v = randn(tv, 5)
+        C = zeros(tout, 5)
+        M = sprand(tm, 5, 3, 0.3)
+        v = randn(tv, 3)
         α = rand(tα)
         β = rand(tβ)
 
@@ -750,9 +750,9 @@ end
 
     for tm in Ts, tv in Ts, tα in Ts, tβ in Ts
         tout = promote_type(tm, tv, tα, tβ)
-        C = zeros(tout, 9, 5)
-        M = sprand(tm, 9, 5, 0.1)
-        v = randn(tv, 5, 5)
+        C = zeros(tout, 5, 3)
+        M = sprand(tm, 5, 3, 0.3)
+        v = randn(tv, 3, 3)
         α = rand(tα)
         β = rand(tβ)
         

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -718,13 +718,14 @@ end
 @testset "SparseArrays spmatvec reverse rule" begin
     Ts = (Float64, ComplexF64)
 
-    for tm in Ts, tv in Ts, tα in Ts, tβ in Ts
-        tout = promote_type(tm, tv, tα, tβ)
+    Ms = sprandn.(Ts, 5, 3, 0.3)
+    vs = rand.(Ts, 3)
+    αs = rand.(Ts)
+    βs = rand.(Ts)
+
+    for M in Ms, v in vs, α in αs, β in βs
+        tout = promote_type(eltype(M), eltype(v), typeof(α), typeof(β))
         C = zeros(tout, 5)
-        M = sprand(tm, 5, 3, 0.3)
-        v = randn(tv, 3)
-        α = rand(tα)
-        β = rand(tβ)
 
         for Tret in (Duplicated, BatchDuplicated), TM in (Const, Duplicated, BatchDuplicated), Tv in (Const, Duplicated, BatchDuplicated), 
             Tα in (Const, Active), Tβ in (Const, Active)

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -747,11 +747,11 @@ end
 
     for tm in Ts, tv in Ts, tα in Ts, tβ in Ts
         tout = promote_type(tm, tv, tα, tβ)
-        C = zeros(tout, 18)
-        M = sprand(tm, 18, 9, 0.1)
-        v = randn(tv, 9)
-        α = tα <: Complex ? 2.0 + 0.1im : 2.0
-        β = tβ <: Complex ? 1.0 + 0.1im : 1.0
+        C = zeros(tout, 9)
+        M = sprand(tm, 9, 5, 0.1)
+        v = randn(tv, 5)
+        α = rand(tα)
+        β = rand(tβ)
 
         for Tret in (Duplicated, BatchDuplicated), TM in (Const, Duplicated, BatchDuplicated), Tv in (Const, Duplicated, BatchDuplicated), 
             Tα in (Const, Active), Tβ in (Const, Active)
@@ -777,11 +777,11 @@ end
 
     for tm in Ts, tv in Ts, tα in Ts, tβ in Ts
         tout = promote_type(tm, tv, tα, tβ)
-        C = zeros(tout, 18, 11)
-        M = sprand(tm, 18, 9, 0.1)
-        v = randn(tv, 9, 11)
-        α = tα <: Complex ? 2.0 + 0.1im : 2.0
-        β = tβ <: Complex ? 1.0 + 0.1im : 1.0
+        C = zeros(tout, 9, 5)
+        M = sprand(tm, 9, 5, 0.1)
+        v = randn(tv, 5, 5)
+        α = rand(tα)
+        β = rand(tβ)
         
         for Tret in (Duplicated, BatchDuplicated), TM in (Const, Duplicated, BatchDuplicated), Tv in (Const, Duplicated, BatchDuplicated), 
             Tα in (Const, Active), Tβ in (Const, Active)

--- a/test/internal_rules.jl
+++ b/test/internal_rules.jl
@@ -714,33 +714,6 @@ end
     # @test Enzyme.autodiff(Reverse, (x, y) -> begin y[] = f4(x); nothing end,  Active(0.1), BatchDuplicated(Ref(0.0), (Ref(1.0), Ref(2.0)))) == (((0.0,0.0)),)
 end
 
-@testset "SparseArrays spmatvec reverse rule" begin
-    Ts = (Float64, ComplexF64)
-
-    for T in Ts
-        C = zeros(T, 18)
-        M = sprand(T, 18, 9, 0.1)
-        v = randn(T, 9)
-        α = T <: Complex ? 2.0 + 0.1im : 2.0
-        β = T <: Complex ? 1.0 + 0.1im : 1.0
-
-        for Tret in (Duplicated, BatchDuplicated), TM in (Const, Duplicated, BatchDuplicated), Tv in (Const, Duplicated, BatchDuplicated), 
-            Tα in (Const, Active), Tβ in (Const, Active)
-
-            are_activities_compatible(Tret, Tret, TM, Tv, Tα, Tβ) || continue
-            test_reverse(LinearAlgebra.mul!, Tret, (C, Tret), (M, TM), (v, Tv), (α, Tα), (β, Tβ))
-        end
-
-        for Tret in (Duplicated, BatchDuplicated), TM in (Const, Duplicated, BatchDuplicated), 
-            Tv in (Const, Duplicated, BatchDuplicated), bα in (true, false), bβ in (true, false)
-            are_activities_compatible(Tret, Tret, TM, Tv) || continue
-            test_reverse(LinearAlgebra.mul!, Tret, (C, Tret), (M, Const), (v, Tv), (bα, Const), (bβ, Const))
-        end
-
-        test_reverse(LinearAlgebra.mul!, Const, (C, Const), (M, Const), (v, Const), (α, Active), (β, Active))
-
-    end
-end
 
 @testset "SparseArrays spmatvec reverse rule" begin
     Ts = (Float64, ComplexF64)


### PR DESCRIPTION
This fixes #2321 and explicitly supports arguments that mix complex and real arrays. 
The logic is annoying, so it would be good to review this since I made several choices. 