### PR TITLE
Revert "Avoid blow up of function pre-amble on higer order AD (#2350)"

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1327,9 +1327,6 @@ struct PrimalCompilerParams <: AbstractEnzymeCompilerParams
     mode::API.CDerivativeMode
 end
 
-# Avoid blow-up of higer-order AD
-GPUCompiler.can_safepoint(::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams}) = false
-
 DefaultCompilerTarget(; kwargs...) =
     GPUCompiler.NativeCompilerTarget(; jlruntime = true, kwargs...)
 


### PR DESCRIPTION
This reverts commit 6059bb34e4ff5fe97476f43aac89a7b0ac492c3d.

Let's see if 1.11 CI comes back