### PR TITLE
Fix tape_type

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -706,7 +706,7 @@ code, as well as high-order differentiation.
         rt = Compiler.primal_return_type(Reverse, FTy, tt)
         A2 = A{rt}
         if rt == Union{}
-            rt = Nothing 
+            rt = Nothing
         end
     else
         @assert A isa DataType
@@ -933,7 +933,7 @@ forward, reverse = autodiff_thunk(ReverseSplitWithPrimal, Const{typeof(f)}, Acti
 tape, result, shadow_result  = forward(Const(f), Duplicated(A, ∂A), Active(v))
 _, ∂v = reverse(Const(f), Duplicated(A, ∂A), Active(v), 1.0, tape)[1]
 
-result, ∂v, ∂A 
+result, ∂v, ∂A
 
 # output
 
@@ -1305,10 +1305,11 @@ import .Compiler: remove_innerty, UnknownTapeType
 
     try
         obj = get(tape_cache, key, nothing)
+        # If the tape is not cached, compile it
         if obj === nothing
 
             Compiler.JuliaContext() do ctx
-                _, meta = Compiler.codegen(:llvm, job; optimize = false, parent_job)
+                _, meta = GPUCompiler.compile(:llvm, job)
                 obj = meta.TapeType
                 tape_cache[key] = obj
             end
@@ -1356,7 +1357,7 @@ forward, reverse = autodiff_deferred_thunk(ReverseSplitWithPrimal, TapeType, Con
 tape, result, shadow_result  = forward(Const(f), Duplicated(A, ∂A), Active(v))
 _, ∂v = reverse(Const(f), Duplicated(A, ∂A), Active(v), 1.0, tape)[1]
 
-result, ∂v, ∂A 
+result, ∂v, ∂A
 
 # output
 


### PR DESCRIPTION
I'm using this as an example from the tests
```julia
using Enzyme, EnzymeCore
using GPUCompiler
using Test
using CUDA

function square_kernel!(x)
    i = threadIdx().x
    x[i] *= x[i]
    sync_threads()
    return nothing
end

# basic squaring on GPU
function square!(x)
    @cuda blocks = 1 threads = length(x) square_kernel!(x)
    return nothing
end

@testset "Reverse Kernel" begin
    A = CUDA.rand(64)
    dA = CUDA.ones(64)
    A .= (1:1:64)
    dA .= 1
    Enzyme.autodiff(Reverse, square!, Duplicated(A, dA))
    @test all(dA .≈ (2:2:128))

    A = CUDA.rand(32)
    dA = CUDA.ones(32)
    dA2 = CUDA.ones(32)
    A .= (1:1:32)
    dA .= 1
    dA2 .= 3
    Enzyme.autodiff(Reverse, square!, BatchDuplicated(A, (dA, dA2)))
    @test all(dA .≈ (2:2:64))
    @test all(dA2 .≈ 3*(2:2:64))
end
```
It tails with
```julia
Reverse Kernel: Error During Test at /home/michel/git/CUDA.jl/test/extensions/enzyme.jl:51
  Got exception outside of a @test
  AssertionError: actualRetType != Union{}
  Stacktrace:
    [1] compile_unhooked(output::Symbol, job::CompilerJob{Enzyme.Compiler.EnzymeTarget{NativeCompilerTarget}, Enzyme.Compiler.EnzymeCompilerParams{Enzyme.Compiler.PrimalCompilerParams}})
      @ Enzyme.Compiler ~/.julia/dev/Enzyme/src/compiler.jl:4267
    [2] #compile#155
      @ ~/.julia/packages/GPUCompiler/Ecaql/src/driver.jl:67
    [3] compile
      @ ~/.julia/packages/GPUCompiler/Ecaql/src/driver.jl:55 [inlined]
    [4] #140
      @ ~/.julia/dev/Enzyme/src/Enzyme.jl:1311
```

I tried to play around with creating a new job etc. Why was `parent_job` handed over to `codegen`?
    [5] #JuliaContext#154
