### PR TITLE
fix precompile on 1.12

### DIFF
--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -1770,12 +1770,17 @@ end
 end
 
 # Create specializations
-setfield!(typeof(runtime_generic_fwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_generic_augfwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_generic_rev).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_iterate_fwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_iterate_augfwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_iterate_rev).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
+if !isdefined(Core, :GlobalMethods) # pre https://github.com/JuliaLang/julia/pull/58131
+    set_fn_max_args(f) = setfield!(typeof(f).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
+else
+    set_fn_max_args(f) = setfield!(typeof(f).name, :max_args, fieldtype(Core.TypeName, :max_args)(512), :monotonic)
+end
+set_fn_max_args(runtime_generic_fwd)
+set_fn_max_args(runtime_generic_augfwd)
+set_fn_max_args(runtime_generic_rev)
+set_fn_max_args(runtime_iterate_fwd)
+set_fn_max_args(runtime_iterate_augfwd)
+set_fn_max_args(runtime_iterate_rev)
 # for (N, Width) in Iterators.product(0:30, 1:10)
 #     eval(func_runtime_generic_fwd(N, Width))
 #     eval(func_runtime_generic_augfwd(N, Width))

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -424,10 +424,10 @@ end
     )
 end
 
-setfield!(typeof(runtime_newstruct_augfwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_newstruct_rev).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_tuple_augfwd).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
-setfield!(typeof(runtime_tuple_rev).name.mt, :max_args, fieldtype(Core.MethodTable, :max_args)(512), :monotonic)
+set_fn_max_args(runtime_newstruct_augfwd)
+set_fn_max_args(runtime_newstruct_rev)
+set_fn_max_args(runtime_tuple_augfwd)
+set_fn_max_args(runtime_tuple_rev)
 # for (N, Width) in Iterators.product(0:30, 1:10)
 #     eval(func_runtime_newstruct_augfwd(N, Width))
 #     eval(func_runtime_newstruct_rev(N, Width))


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/58131 unifies the method table, so this is necessary to make Enzyme precompile on 1.12.

Should we do something to make sure CI succeeds in loading Enzyme on 1.12? (even if we don't expect tests to pass).