### PR TITLE
Get the triple from the JIT to avoid differences in handling

### DIFF
--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -93,11 +93,11 @@ function setup_globals()
         optlevel = LLVM.API.LLVMCodeGenLevelAggressive
     end
 
-    tempTM = LLVM.JITTargetMachine(LLVM.triple(), cpu_name(), cpu_features(); optlevel)
+    lljit = JuliaOJIT()
+
+    tempTM = LLVM.JITTargetMachine(LLVM.triple(lljit), cpu_name(), cpu_features(); optlevel)
     LLVM.asm_verbosity!(tempTM, true)
     tm[] = tempTM
-
-    lljit = JuliaOJIT()
 
     jd_main = JITDylib(lljit)
 


### PR DESCRIPTION
This avoids the windows issues we were seeing while throwing errors and other differences. (LLVM triples are a mess and normalization is too so this helps for now)