### PR TITLE
Revert "First activity cache"

### DIFF
--- a/src/analyses/activity.jl
+++ b/src/analyses/activity.jl
@@ -393,58 +393,9 @@ Base.@nospecializeinfer @inline function active_reg_inner(
     return ty
 end
 
-const ActivityCache = Dict{Tuple{Type, Bool, Bool, Bool}, ActivityState}()
-
-const ActivityWorldCache = Ref(0)
-
-const ActivityMethodCache = Core.MethodMatch[]
-# given the current worldage of compilation, check if there are any methods 
-# of inactive_type which may invalidate the cache, and if so clear it. 
-function check_activity_cache_invalidations(world::UInt)
-    # We've already guaranteed that this world doesn't have any stale caches
-    if world <= ActivityWorldCache[]
-        return
-    end
-
-    invalid = true
-
-    tt = Tuple{typeof(EnzymeRules.inactive_type), Type}
-
-    methods = Core.MethodMatch[]
-    matches = Base._methods_by_ftype(tt, -1, world)
-    if matches === nothing
-        @assert ActivityCache.size() == 0
-        return
-    end
-
-    methods = Core.MethodMatch[]
-    for match in matches::Vector
-        push!(methods, match::Core.MethodMatch)
-    end
-
-    if methods == ActivityMethodCache
-        return
-    end
-
-    empty!(ActivityCache)
-    empty!(ActivityMethodCache)
-    for match in matches::Vector
-        push!(ActivityMethodCache, match::Core.MethodMatch)
-    end
-
-    ActivityWorldCache[] = world
-
-end
-
 Base.@nospecializeinfer @inline function active_reg(@nospecialize(ST::Type), world::UInt; justActive=false, UnionSret = false, AbstractIsMixed = false)
-    key = (ST, justActive, UnionSret, AbstractIsMixed)
-    if haskey(ActivityCache, key)
-        return ActivityCache[key]
-    end
     set = Base.IdSet{Type}()
-    result = active_reg_inner(ST, set, world, justActive, UnionSret, AbstractIsMixed)
-    ActivityCache[key] = result
-    return result
+    return active_reg_inner(ST, set, world, justActive, UnionSret, AbstractIsMixed)
 end
 
 function active_reg_nothrow_generator(world::UInt, source::LineNumberNode, T, self, _)
@@ -462,7 +413,6 @@ function active_reg_nothrow_generator(world::UInt, source::LineNumberNode, T, se
             Core.Compiler.LineInfoNode(@__MODULE__, :active_reg_nothrow, source.file, Int32(source.line), Int32(0))
         ]
     end
-    check_activity_cache_invalidations(world)
     ci.min_world = world
     ci.max_world = typemax(UInt)
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -6049,9 +6049,7 @@ end
         StrongZero
     ) #=abiwrap=#
     tmp_job = if World isa Nothing
-        jb = Compiler.CompilerJob(mi, CompilerConfig(target, params; kernel = false))
-        check_activity_cache_invalidations(jb.world)
-        jb
+        Compiler.CompilerJob(mi, CompilerConfig(target, params; kernel = false))
     else
         Compiler.CompilerJob(mi, CompilerConfig(target, params; kernel = false), World)
     end
@@ -6245,8 +6243,6 @@ function thunk_generator(world::UInt, source::Union{Method, LineNumberNode}, @no
     
     mi === nothing && return stub(world, source, method_error)
  
-    check_activity_cache_invalidations(world)
-
     min_world2 = Ref{UInt}(typemin(UInt))
     max_world2 = Ref{UInt}(typemax(UInt))
    


### PR DESCRIPTION
Reverts EnzymeAD/Enzyme.jl#2594

The current design is prone to "spurious results from the future" and I think it is better to implement this either as a local cache or with proper invalidation integration