### PR TITLE
Update CI.yml to skip integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
       - 'lib/**'
       - 'src/**'
       - 'test/**'
+      - '!test/integration/**'
       - 'Project.toml'
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - 'lib/**'
       - 'src/**'
       - 'test/**'
+      - '!test/integration/**'
       - 'Project.toml'
     tags: '*'
 


### PR DESCRIPTION
Exclude integration tests from CI workflow, they're run in a dedicated workflow.