### PR TITLE
Capture and test some of the warnings emitted during the tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2267,7 +2267,7 @@ end
     end
     A = Float64[1, 3, 3, 7]
     dA = Float64[1, 1, 1, 1]
-    autodiff(Reverse, cost, Const, Duplicated(A, dA))
+    @test_warn "3.0" autodiff(Reverse, cost, Const, Duplicated(A, dA))
     @test dA ≈ [0.0, 1.0, 6.0, 1.0]
 end
 

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -15,7 +15,10 @@ using Test
     R = Float64[0., 0.]
     dR = Float64[2., 3.]
 
-    @test 5.0 ≈ Enzyme.autodiff(Reverse, tasktest, Duplicated(R, dR), Active(2.0))[1][2]
+    # We define the local variable `autodiff` as a `Ref` wrapper only to be able to capture
+    # and test the warning emitted by the `@generated` function `Enzyme.autodiff`.
+    autodiff = Ref{Any}(Enzyme.autodiff)
+    @test 5.0 ≈ @test_warn r"active variables passed by value to jl_new_task are not yet supported" autodiff[](Reverse, tasktest, Duplicated(R, dR), Active(2.0))[1][2]
     @test Float64[2.0, 2.0] ≈ R
     @test Float64[0.0, 0.0] ≈ dR
     
@@ -30,7 +33,7 @@ using Test
         nothing
     end
     # The empty return previously resulted in an illegal instruction error
-    @test 0.0 ≈ Enzyme.autodiff(Reverse, tasktest2, Duplicated(R, dR), Active(2.0))[1][2]
+    @test 0.0 ≈ @test_warn r"active variables passed by value to jl_new_task are not yet supported" autodiff[](Reverse, tasktest2, Duplicated(R, dR), Active(2.0))[1][2]
     @test () === Enzyme.autodiff(Forward, tasktest, Duplicated(R, dR), Duplicated(2.0, 1.0))
 end
 


### PR DESCRIPTION
This captures over 600 warnings emitted when running the tests, sensibly reducing the noise.  There are some warnings left still, but the vast majority is gone.

The trick of using a `Ref{Any}` wrapper was suggested by @MasonProtter at https://discourse.julialang.org/t/capturing-warnings-inside-generated-functions/132535/2.