### PR TITLE
[CI] Use `default` architecture instead of forcing `x64`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,13 +48,13 @@ jobs:
           - macOS-latest
           - windows-latest
         arch:
-          - x64
+          - default
         assertions:
           - false
         libEnzyme: [local, packaged]
         exclude:
           - os: windows-latest
-            arch: x64
+            arch: default
             libEnzyme: local
         include:
           - os: ubuntu-24.04
@@ -63,12 +63,12 @@ jobs:
             version: '1.10'
             assertions: false
           - os: ubuntu-24.04
-            arch: x64
+            arch: default
             libEnzyme: packaged
             version: '1.10'
             assertions: true
           - os: ubuntu-24.04
-            arch: x64
+            arch: default
             libEnzyme: packaged
             version: '1.11'
             assertions: true
@@ -157,7 +157,7 @@ jobs:
         os:
           - ubuntu-latest
         arch:
-          - x64
+          - default
         libEnzyme: [packaged]
     steps:
       - uses: actions/checkout@v5
@@ -211,7 +211,7 @@ jobs:
         os:
           - ubuntu-latest
         arch:
-          - x64
+          - default
         libEnzyme: [packaged]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This is in particular relevant on `macOS-latest`, where `default` would be `aarch64`: currently we're running the tests with x86-64 builds of Julia on Apple Silicon via Rosetta, which is slow, unsupported, and likely to fail.  Ref: https://github.com/EnzymeAD/Enzyme.jl/pull/2563#issuecomment-3316103867