### PR TITLE
Add rules for hypot

### DIFF
--- a/test/rules/internal_rules.jl
+++ b/test/rules/internal_rules.jl
@@ -836,30 +836,36 @@ end
         @testset for RT in (Const, DuplicatedNoNeed, Duplicated),
                 Tx in (Const, Duplicated),
                 Ty in (Const, Duplicated),
-                Tz in (Const, Duplicated)
+                Tz in (Const, Duplicated),
+                Txs in (Const, Duplicated)
 
-            x, y, z = 2.0, 3.0, 5.0
+            x, y, z, xs = 2.0, 3.0, 5.0, 17.0
             test_forward(hypot, RT, (x, Tx), (y, Ty))
             test_forward(hypot, RT, (x, Tx), (y, Ty), (z, Tz))
+            test_forward(hypot, RT, (x, Tx), (y, Ty), (z, Tz), (xs, Txs))
 
-            x, y, z = 2.0 + 7.0im, 3.0 + 11.0im, 5.0 + 13.0im
+            x, y, z, xs = 2.0 + 7.0im, 3.0 + 11.0im, 5.0 + 13.0im, 17.0 + 19.0im
             test_forward(hypot, RT, (x, Tx), (y, Ty))
             test_forward(hypot, RT, (x, Tx), (y, Ty), (z, Tz))
+            test_forward(hypot, RT, (x, Tx), (y, Ty), (z, Tz), (xs, Txs))
         end
     end
     @testset "reverse" begin
         @testset for RT in (Active,),
                 Tx in (Const, Active),
                 Ty in (Const, Active),
-                Tz in (Const, Active)
+                Tz in (Const, Active),
+                Txs in (Const, Active)
 
-            x, y, z = 2.0, 3.0, 5.0
+            x, y, z, xs = 2.0, 3.0, 5.0, 17.0
             test_reverse(hypot, RT, (x, Tx), (y, Ty))
             test_reverse(hypot, RT, (x, Tx), (y, Ty), (z, Tz))
+            test_reverse(hypot, RT, (x, Tx), (y, Ty), (z, Tz), (xs, Txs))
 
-            x, y, z = 2.0 + 7.0im, 3.0 + 11.0im, 5.0 + 13.0im
+            x, y, z, xs = 2.0 + 7.0im, 3.0 + 11.0im, 5.0 + 13.0im, 17.0 + 19.0im
             test_reverse(hypot, RT, (x, Tx), (y, Ty))
             test_reverse(hypot, RT, (x, Tx), (y, Ty), (z, Tz))
+            test_reverse(hypot, RT, (x, Tx), (y, Ty), (z, Tz), (xs, Txs))
         end
     end
 end


### PR DESCRIPTION
Closes #2586.  This PR uses advice from that issue, as well as examples from [JacobiElliptic.j](https://github.com/dominic-chang/JacobiElliptic.jl/blob/main/ext/JacobiEllipticEnzymeExt.jl).  Note that there are still some questions:

  1. How are Enzyme rules applied to complex arguments supposed to behave?
  2. The derivative of `hypot` at the origin is undefined, and returns NaNs with this implementation.  Should it return 0.0 (or something else) instead?
  3. Are all the activities implemented?