### PR TITLE
Add GPL guards for CHOLMOD usage to make Enzyme.jl GPL-safe

### DIFF
--- a/src/absint.jl
+++ b/src/absint.jl
@@ -608,7 +608,12 @@ function abs_typeof(
             # add the extra poitner offset when loading here]. However for pointers constructed by ccall outside julia
             # to a julia object, which are not inline by type but appear so, like SparseArrays, this is a problem
             # and merits further investigation. x/ref https://github.com/EnzymeAD/Enzyme.jl/issues/2085
-            if !Base.allocatedinline(typ) && typ != SparseArrays.cholmod_dense_struct && typ != SparseArrays.cholmod_sparse_struct && typ != SparseArrays.cholmod_factor_struct
+            @static if Base.USE_GPL_LIBS
+                cholmod_exception = typ != SparseArrays.cholmod_dense_struct && typ != SparseArrays.cholmod_sparse_struct && typ != SparseArrays.cholmod_factor_struct
+            else
+                cholmod_exception = true
+            end
+            if !Base.allocatedinline(typ) && cholmod_exception
                 shouldLoad = false
                 offset %= sizeof(Int)
             else

--- a/src/analyses/activity.jl
+++ b/src/analyses/activity.jl
@@ -19,7 +19,9 @@ end
 @inline ptreltype(::Type{Tuple{Vararg{T}}}) where {T} = T
 @inline ptreltype(::Type{IdDict{K,V}}) where {K,V} = V
 @inline ptreltype(::Type{IdDict{K,V} where K}) where {V} = V
+@static if Base.USE_GPL_LIBS
 @inline ptreltype(::Type{SparseArrays.CHOLMOD.Dense{T}}) where T = T
+end
 @static if VERSION < v"1.11-"
 else
 @inline ptreltype(::Type{Memory{T}}) where T = T
@@ -33,7 +35,9 @@ end
 @inline is_arrayorvararg_ty(::Type{Base.RefValue{T}}) where {T} = true
 @inline is_arrayorvararg_ty(::Type{IdDict{K,V}}) where {K,V} = true
 @inline is_arrayorvararg_ty(::Type{IdDict{K,V} where K}) where {V} = true
+@static if Base.USE_GPL_LIBS
 @inline is_arrayorvararg_ty(::Type{SparseArrays.CHOLMOD.Dense{T}}) where T = true
+end
 @static if VERSION < v"1.11-"
 else
 @inline is_arrayorvararg_ty(::Type{Memory{T}}) where T = true


### PR DESCRIPTION
## Summary

This PR adds `@static if Base.USE_GPL_LIBS` guards around all CHOLMOD-related dispatches in Enzyme.jl to ensure license compatibility when Julia is built without GPL libraries (Suitesparse/CHOLMOD).

## Changes

- **src/analyses/activity.jl**: Added GPL guards around:
  - `ptreltype(::Type{SparseArrays.CHOLMOD.Dense{T}})` dispatch (lines 22-24)
  - `is_arrayorvararg_ty(::Type{SparseArrays.CHOLMOD.Dense{T}})` dispatch (lines 38-40)

- **src/absint.jl**: Added GPL guard around CHOLMOD struct type checks (lines 611-618):
  - Wrapped checks for `cholmod_dense_struct`, `cholmod_sparse_struct`, and `cholmod_factor_struct`
  - When GPL libs are not available, the code gracefully skips CHOLMOD-specific handling

## Test Plan

- [x] Package precompiles successfully with the changes
- [x] Package loads correctly: `using Enzyme` works without errors
- [x] Changes are backward compatible - when `Base.USE_GPL_LIBS` is true, behavior is unchanged

## Background

CHOLMOD is part of Suitesparse, which is licensed under GPL. When Julia is built with `USE_GPL_LIBS=0`, these libraries are not available, and code that references them should be guarded to maintain license compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)