### PR TITLE
[CI] Build documentation on Julia v1.11

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - name: Instantiate docs environment
         shell: julia --color=yes --project=docs {0}


### PR DESCRIPTION
Until v1.12 is properly supported by Enzyme.jl, we need to stick to v1.11 for building the docs.