### PR TITLE
[CI] Run integration tests only when editing `test/integration/`

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -6,7 +6,7 @@ on:
       - 'ext/**'
       - 'lib/**'
       - 'src/**'
-      - 'test/**'
+      - 'test/integration/**'
       - 'Project.toml'
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - 'ext/**'
       - 'lib/**'
       - 'src/**'
-      - 'test/**'
+      - 'test/integration/**'
       - 'Project.toml'
     tags: '*'
 


### PR DESCRIPTION
We don't need to run integration tests when editing files in `test/` outside of `test/integration/`.  Spotted in #2648.