### PR TITLE
Add single 1.12 CI job with assertions enabled

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,11 @@ jobs:
             libEnzyme: packaged
             version: '1.11'
             assertions: true
+          - os: ubuntu-24.04
+            arch: default
+            libEnzyme: packaged
+            version: '1.12'
+            assertions: true
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
In contrast to #2613 this only adds one job for now. I propose that we merge this so that we can have a canary when things are breaking (more).