### PR TITLE
1.12: fix edge

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -386,6 +386,7 @@ function methodinstance_generator(world::UInt, source, self, @nospecialize(mode:
     ci = create_fresh_codeinfo(prevmethodinstance, source, world, slotnames, code)
     ci.min_world = min_world[]
     ci.max_world = max_world[]
+    ci.edges = Any[mi]
 
     # TODO: Missing edge handling
     return ci


### PR DESCRIPTION
Fixes
```
  Generated function result with `edges == nothing` and `max_world == typemax(UInt)` must have `min_world == 1`
  Stacktrace:
    [1] my_methodinstance
      @ ~/git/Enzyme.jl/src/utils.jl:402 [inlined]
    [2] #147
      @ ~/git/Enzyme.jl/src/sugar.jl:21 [inlined]
    [3] JuliaContext(f::Enzyme.var"#147#148"{Type{Matrix{Float32}}}; kwargs::@Kwargs{})
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Gp8bZ/src/driver.jl:34
    [4] JuliaContext(f::Function)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Gp8bZ/src/driver.jl:25
    [5] macro expansion
      @ ~/git/Enzyme.jl/src/sugar.jl:16 [inlined]
    [6] var"#s700#145"(F::Any, T::Any, ::Any, fn::Any, x::Any, startv::Any, lengthv::Any)
      @ Enzyme ./none:0
    [7] (::Core.GeneratedFunctionStub)(::UInt64, ::Method, ::Any, ::Vararg{Any})
      @ Base ./expr.jl:1694
    [8] onehot
      @ ~/git/Enzyme.jl/src/sugar.jl:129 [inlined]
    [9] vector_forward_ad(x::Matrix{Float32})
```