### PR TITLE
Explicitly exclude the integration tests from `test/runtests.jl`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,11 @@ testsuite = find_tests(@__DIR__)
 # Add threads tests to be run with multiple Julia threads (will be configured in
 # `test_worker`).
 testsuite["threads/2"] = :(include($(joinpath(@__DIR__, "threads.jl"))))
+# Exclude integration tests, they're handled differently (they each run in their
+# own environment)
+for (k, _) in testsuite
+    startswith(k, "integration/") && delete!(testsuite, k)
+end
 
 # Parse arguments
 args = parse_args(ARGS)


### PR DESCRIPTION
Ref: https://github.com/EnzymeAD/Enzyme.jl/pull/518#issuecomment-3457203322.

Maybe in the future we can fold the integration tests under the whole parallel tests business, while still keeping dedicated jobs for them not the break everything, this PR only makes the current setup more robust.