### PR TITLE
fix: Typo LVM -> LLVM.

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -4410,7 +4410,7 @@ function lower_convention(
             println(io, string(mod))
             println(
                 io,
-                LVM.API.LLVMVerifyFunction(wrapper_f, LLVM.API.LLVMPrintMessageAction),
+                LLVM.API.LLVMVerifyFunction(wrapper_f, LLVM.API.LLVMPrintMessageAction),
             )
             println(io, string(wrapper_f))
             println(io, "Broken function")


### PR DESCRIPTION
Fix the obvious type while #2684 tries to figure out how to test that code-path reliably.
