### PR TITLE
Fix uses of GeneratedFunctionStub

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -6259,7 +6259,7 @@ function thunk_generator(world::UInt, source::Union{Method, LineNumberNode}, @no
                     :fakeworld, :fa, :a, :tt, :mode, :width,
                     :modifiedbetween, :returnprimal, :shadowinit,
                     :abi, :erriffuncwritten, :runtimeactivity, :strongzero)
-    stub = Core.GeneratedFunctionStub(thunk, slotnames, Core.svec())
+    stub = Core.GeneratedFunctionStub(identity, slotnames, Core.svec())
 
     ft = eltype(FA)
     primal_tt = Tuple{map(eltype, TT.parameters)...}
@@ -6378,7 +6378,7 @@ function deferred_id_generator(world::UInt, source::Union{Method, LineNumberNode
                           :returnprimal, :shadowinit, :expectedtapetype,
                           :erriffuncwritten, :runtimeactivity, :strongzero)
 
-    stub = Core.GeneratedFunctionStub(deferred_id_generator, slotnames, Core.svec())
+    stub = Core.GeneratedFunctionStub(identity, slotnames, Core.svec())
 
     ft = eltype(FA)
     primal_tt = Tuple{map(eltype, TT.parameters)...}

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -111,7 +111,7 @@ function primal_return_type_generator(world::UInt, source, self, @nospecialize(m
 
     slotnames = Core.svec(Symbol("#self#"), :mode, :ft, :tt)
     stub = Core.GeneratedFunctionStub(
-        primal_return_type,
+        identity,
         slotnames,
         Core.svec(),
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -372,7 +372,7 @@ function methodinstance_generator(world::UInt, source, self, @nospecialize(mode:
     tt = tt.parameters[1]
 
     slotnames = Core.svec(Symbol("#self#"), :mode, :ft, :tt)
-    stub = Core.GeneratedFunctionStub(prevmethodinstance, slotnames, Core.svec())
+    stub = Core.GeneratedFunctionStub(identity, slotnames, Core.svec())
 
     # look up the method match
     min_world = Ref{UInt}(typemin(UInt))


### PR DESCRIPTION
The first argument of the GeneratedFunctionStub is a transformator for
the expression not the function being generated for.

fixes #2733
