### PR TITLE
Try to extend map_fields_recursive for MixedDuplicated

### DIFF
--- a/lib/EnzymeTestUtils/src/generate_tangent.jl
+++ b/lib/EnzymeTestUtils/src/generate_tangent.jl
@@ -15,6 +15,11 @@ function map_fields_recursive(f, x::T...) where {T<:Union{Array,Tuple,NamedTuple
         map_fields_recursive(f, xi...)
     end
 end
+function map_fields_recursive(f::typeof(Base.copyto!), x::Base.RefValue{T}, y::T) where {T}
+    x[] = y
+    return x
+end
+
 function map_fields_recursive(f::typeof(Base.copyto!), y::T, x::T) where {T<:LinearAlgebra.HermOrSym{<:Number}}
     copyto!(x.uplo == 'U' ? UpperTriangular(parent(y)) : LowerTriangular(parent(y)), x.uplo == 'U' ? UpperTriangular(parent(x)) : LowerTriangular(parent(x)))
     return y


### PR DESCRIPTION
No idea if this is the correct approach, I'm getting errors when I try to use it like:

```julia
test_reverse: eig_trunc with return activity EnzymeCore.MixedDuplicated on (::Matrix{Float64}, EnzymeCore.Duplicated): Error During Test at /Users/khyatt/.julia/dev/Enzyme/lib/EnzymeTestUtils/src/test_reverse.jl:84
  Got exception outside of a @test
  MethodError: no method matching (::Enzyme.Compiler.AdjointThunk{Ptr{Nothing}, EnzymeCore.Const{typeof(EnzymeTestUtils.call_with_kwargs)}, EnzymeCore.MixedDuplicated{Tuple{LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}, Matrix{ComplexF64}, Float64}}, Tuple{EnzymeCore.Const{@NamedTuple{alg::MatrixAlgebraKit.TruncatedAlgorithm{MatrixAlgebraKit.LAPACK_Simple{@NamedTuple{}}, MatrixAlgebraKit.TruncationByOrder{typeof(abs)}}}}, EnzymeCore.Const{typeof(MatrixAlgebraKit.eig_trunc)}, EnzymeCore.Duplicated{Matrix{Float64}}}, 1, @NamedTuple{1::@NamedTuple{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11::@NamedTuple{1, 2::Tuple{Core.LLVMPtr{UInt8, 0}, Core.LLVMPtr{UInt8, 0}, @NamedTuple{1::@NamedTuple{1, 2, 3, 4::@NamedTuple{1, 2, 3, 4::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 5::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 6::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 7::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 8::Core.LLVMPtr{Float64, 0}, 9::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 10::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 11::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 12::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 13::UInt64, 14::Float64, 15::Float64, 16::Float64, 17::Float64, 18::Core.LLVMPtr{Float64, 0}, 19::Float64, 20::Float64, 21::Float64, 22::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 23::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 24::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 25::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 26::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 27::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 28::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 29::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 30::Core.LLVMPtr{Float64, 0}, 31::Core.LLVMPtr{Float64, 0}}, 5::Float64, 6::Float64, 7::Core.LLVMPtr{Float64, 0}, 8::UInt64, 9::Core.LLVMPtr{Float64, 0}, 10::Float64, 11::Float64, 12::Float64, 13::Float64, 14::Float64, 15::Float64, 16::Core.LLVMPtr{Float64, 0}, 17::Core.LLVMPtr{Float64, 0}}, 2::Float64, 3, 4::Float64, 5, 6::Core.LLVMPtr{Float64, 0}, 7::UInt64, 8::Core.LLVMPtr{Float64, 0}, 9::Core.LLVMPtr{Float64, 0}, 10::Float64, 11::Core.LLVMPtr{Float64, 0}, 12::Core.LLVMPtr{Float64, 0}, 13::Core.LLVMPtr{Bool, 0}, 14::Float64, 15::Float64, 16::Float64}, Tuple{Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Float64, Float64}, Core.LLVMPtr{UInt8, 0}, UInt64, UInt64}, 3::Bool, 4::Bool, 5, 6::Core.LLVMPtr{Any, 0}, 7::UInt64, 8::UInt64, 9, 10::Bool, 11::Bool, 12::Core.LLVMPtr{UInt64, 0}}, 12::@NamedTuple{1, 2, 3::Core.LLVMPtr{UInt8, 0}, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14::Core.LLVMPtr{UInt8, 0}, 15, 16::Core.LLVMPtr{Core.LLVMPtr{UInt8, 0}, 0}, 17, 18::@NamedTuple{1, 2, 3, 4, 5, 6::UInt64, 7::Core.LLVMPtr{UInt64, 0}, 8::Core.LLVMPtr{UInt64, 0}}, 19, 20, 21, 22::Bool, 23::Bool, 24::UInt64, 25::UInt64, 26::Core.LLVMPtr{UInt8, 0}, 27, 28::Core.LLVMPtr{Core.LLVMPtr{UInt8, 0}, 0}, 29, 30::UInt64, 31::UInt64, 32::Core.LLVMPtr{UInt64, 0}}, 13::@NamedTuple{1}, 14, 15, 16::UInt64}, 2, 3, 4, 5}})(::EnzymeCore.Const{typeof(EnzymeTestUtils.call_with_kwargs)}, ::EnzymeCore.Const{@NamedTuple{alg::MatrixAlgebraKit.TruncatedAlgorithm{MatrixAlgebraKit.LAPACK_Simple{@NamedTuple{}}, MatrixAlgebraKit.TruncationByOrder{typeof(abs)}}}}, ::EnzymeCore.Const{typeof(MatrixAlgebraKit.eig_trunc)}, ::EnzymeCore.Duplicated{Matrix{Float64}}, ::@NamedTuple{1::@NamedTuple{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11::@NamedTuple{1, 2::Tuple{Core.LLVMPtr{UInt8, 0}, Core.LLVMPtr{UInt8, 0}, @NamedTuple{1::@NamedTuple{1, 2, 3, 4::@NamedTuple{1, 2, 3, 4::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 5::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 6::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 7::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 8::Core.LLVMPtr{Float64, 0}, 9::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 10::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 11::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 12::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 13::UInt64, 14::Float64, 15::Float64, 16::Float64, 17::Float64, 18::Core.LLVMPtr{Float64, 0}, 19::Float64, 20::Float64, 21::Float64, 22::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 23::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 24::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 25::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 26::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 27::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 28::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 29::Core.LLVMPtr{Core.LLVMPtr{Float64, 0}, 0}, 30::Core.LLVMPtr{Float64, 0}, 31::Core.LLVMPtr{Float64, 0}}, 5::Float64, 6::Float64, 7::Core.LLVMPtr{Float64, 0}, 8::UInt64, 9::Core.LLVMPtr{Float64, 0}, 10::Float64, 11::Float64, 12::Float64, 13::Float64, 14::Float64, 15::Float64, 16::Core.LLVMPtr{Float64, 0}, 17::Core.LLVMPtr{Float64, 0}}, 2::Float64, 3, 4::Float64, 5, 6::Core.LLVMPtr{Float64, 0}, 7::UInt64, 8::Core.LLVMPtr{Float64, 0}, 9::Core.LLVMPtr{Float64, 0}, 10::Float64, 11::Core.LLVMPtr{Float64, 0}, 12::Core.LLVMPtr{Float64, 0}, 13::Core.LLVMPtr{Bool, 0}, 14::Float64, 15::Float64, 16::Float64}, Tuple{Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Core.LLVMPtr{Float64, 0}, Float64, Float64}, Core.LLVMPtr{UInt8, 0}, UInt64, UInt64}, 3::Bool, 4::Bool, 5, 6::Core.LLVMPtr{Any, 0}, 7::UInt64, 8::UInt64, 9, 10::Bool, 11::Bool, 12::Core.LLVMPtr{UInt64, 0}}, 12::@NamedTuple{1, 2, 3::Core.LLVMPtr{UInt8, 0}, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14::Core.LLVMPtr{UInt8, 0}, 15, 16::Core.LLVMPtr{Core.LLVMPtr{UInt8, 0}, 0}, 17, 18::@NamedTuple{1, 2, 3, 4, 5, 6::UInt64, 7::Core.LLVMPtr{UInt64, 0}, 8::Core.LLVMPtr{UInt64, 0}}, 19, 20, 21, 22::Bool, 23::Bool, 24::UInt64, 25::UInt64, 26::Core.LLVMPtr{UInt8, 0}, 27, 28::Core.LLVMPtr{Core.LLVMPtr{UInt8, 0}, 0}, 29, 30::UInt64, 31::UInt64, 32::Core.LLVMPtr{UInt64, 0}}, 13::@NamedTuple{1}, 14, 15, 16::UInt64}, 2, 3, 4, 5})
  This error has been manually thrown, explicitly, so the method may exist but be intentionally marked as unimplemented.
  
  Closest candidates are:
    (::Enzyme.Compiler.AdjointThunk{PT, FA, RT, TT, Width, TapeT})(::FA, ::Any...) where {PT, FA, Width, RT, TT, TapeT}
     @ Enzyme ~/.julia/packages/Enzyme/EITgk/src/compiler.jl:5372

```