### PR TITLE
Fix: `Vararg{<:AbstractFloat}` -> `Vararg{AbstractFloat}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Enzyme"
 uuid = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.13.107"
+version = "0.13.108"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -182,7 +182,7 @@ end
     return (one(x),)
 end
 
-@inline function onehot(x::Tuple{Vararg{<:AbstractFloat}})
+@inline function onehot(x::Tuple{Vararg{AbstractFloat}})
     ntuple(Val(length(x))) do i
         Base.@_inline_meta
         ntuple(Val(length(x))) do idx


### PR DESCRIPTION
Fixes https://github.com/EnzymeAD/Enzyme.jl/actions/runs/19623837183/job/56188979383#step:12:218:

```julia
┌ Enzyme
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
│  To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
└
```