### PR TITLE
trsm is not actually implemented yet

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5074,7 +5074,7 @@ function GPUCompiler.compile_unhooked(output::Symbol, job::CompilerJob{<:EnzymeT
         "trmv",
         "syrk",
         "trmm",
-        "trsm",
+        # "trsm", Not actually implemented yet
         "potrf",
     )
     ForwardModeTypes = ("s", "d", "c", "z")


### PR DESCRIPTION
Partial fix to #2813

The crux is that Julia used a different function and while `trsm` is defined in Enzyme proper there aren't currently any rules attached https://github.com/EnzymeAD/Enzyme/blob/a13f632e2fbaed1f971de015f15e8f4b353e66cb/enzyme/Enzyme/BlasDerivatives.td#L705-L713