### PR TITLE
Bump `DifferentiationInterface` version in integration tests

### DIFF
--- a/test/integration/DifferentiationInterface/Project.toml
+++ b/test/integration/DifferentiationInterface/Project.toml
@@ -13,6 +13,6 @@ EnzymeCore = { path = "../../../lib/EnzymeCore" }
 
 [compat]
 ADTypes = "1.17.0"
-DifferentiationInterface = "=0.7.7"
-DifferentiationInterfaceTest = "=0.10.2"
+DifferentiationInterface = "=0.7.12"
+DifferentiationInterfaceTest = "=0.10.4"
 StaticArrays = "1.9"


### PR DESCRIPTION
Newer version of `DifferentiationInterfaceTest` is compatible with Julia v1.12.  Ref https://github.com/EnzymeAD/Enzyme.jl/pull/2613#issuecomment-3598111331.  CC @gdalle.