### PR TITLE
Update TransformVariables version constraint in Comrade integration

### DIFF
--- a/test/integration/Comrade/Project.toml
+++ b/test/integration/Comrade/Project.toml
@@ -16,7 +16,7 @@ VLBISkyModels = "d6343c73-7174-4e0f-bb64-562643efbeca"
 Comrade = "0.11"
 FiniteDifferences = "0.12"
 Pyehtim = "0.2"
-TransformVariables = "0.8 - 0.8.17"
+TransformVariables = "0.8"
 VLBISkyModels = "0.6"
 
 [sources.Enzyme]


### PR DESCRIPTION
Doesn't fix the correctness error in #2873  but should ensure the more recent version of Comrade is run