### PR TITLE
Update Molly integration test for new version

### DIFF
--- a/test/integration/Molly/Project.toml
+++ b/test/integration/Molly/Project.toml
@@ -14,4 +14,4 @@ EnzymeCore = {path = "../../../lib/EnzymeCore"}
 
 [compat]
 FiniteDifferences = "0.12"
-Molly = "0.23"
+Molly = "0.23.1"

--- a/test/integration/Molly/runtests.jl
+++ b/test/integration/Molly/runtests.jl
@@ -52,7 +52,7 @@ end
     AT = Array
     ff = MolecularForceField(
         T,
-        joinpath.(ff_dir, ["ff99SBildn.xml", "tip3p_standard.xml", "his.xml"])...,
+        joinpath.(ff_dir, ["ff99SBildn.xml", "tip3p_standard.xml"])...,
         units=false,
     )
     sys = System(
@@ -317,7 +317,7 @@ end
 
 @testset "Differentiable protein" begin
     function create_sys(AT)
-        ff = MolecularForceField(joinpath.(ff_dir, ["ff99SBildn.xml", "his.xml"])...; units=false)
+        ff = MolecularForceField(joinpath.(ff_dir, ["ff99SBildn.xml"])...; units=false)
         return System(
             joinpath(data_dir, "6mrr_nowater.pdb"),
             ff;


### PR DESCRIPTION
With the release of Molly v0.23.1, this file is no longer required for testing and has been removed.