### PR TITLE
Official 1.12 support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ steps:
         version:
           - "1.10"
           - "1.11"
+          - "1.12"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,7 @@ jobs:
         version:
           - '1.10'
           - '1.11'
+          - '1.12'
           - 'nightly'
         os:
           - ubuntu-24.04
@@ -74,6 +75,11 @@ jobs:
             libEnzyme: packaged
             version: '1.11'
             assertions: true
+          - os: ubuntu-24.04
+            arch: default
+            libEnzyme: packaged
+            version: '1.12'
+            assertions: true
 
           - os: ubuntu-24.04
             arch: default
@@ -88,12 +94,6 @@ jobs:
             version: '1.11'
             assertions: false
             llvm_args: '--opaque-pointers'
-
-          - os: ubuntu-24.04
-            arch: default
-            libEnzyme: packaged
-            version: '1.12'
-            assertions: true
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
@@ -188,6 +188,7 @@ jobs:
         version:
           - '1.10'
           - '1.11'
+          - '1.12'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -243,6 +244,7 @@ jobs:
         version:
           - '1.10'
           - '1.11'
+          - '1.12'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Enzyme"
 uuid = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.13.127"
+version = "0.13.128"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -42,7 +42,7 @@ BFloat16s = "0.2, 0.3, 0.4, 0.5, 0.6"
 CEnum = "0.4, 0.5"
 ChainRulesCore = "1"
 EnzymeCore = "0.8.16"
-Enzyme_jll = "0.0.248"
+Enzyme_jll = "0.0.249"
 GPUArraysCore = "0.1.6, 0.2"
 GPUCompiler = "1.6.2"
 LLVM = "9.1"

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -1581,20 +1581,4 @@ end
 
 include("precompile.jl")
 
-function __init__()
-    @static if VERSION ≥ v"1.12-"
-        if ccall(:jl_generating_output, Cint, ()) == 1
-            @warn """
-            Enzyme.jl support for Julia 1.12 is presently in progress.
-			For the time being we recommend using 1.11 or LTS (1.10).
-
-            For latest updates, check the status of support for Julia 1.12+ at
-            https://github.com/EnzymeAD/Enzyme.jl/issues/2699.
-            """ maxlog = 1
-        end
-    end
-
-    return nothing
-end
-
 end # module


### PR DESCRIPTION
Note that 1.10 and 1.11 will remain more stable. And fixes in Julia 1.12.5 (not released as of today) are necessary for full support.

Neverthrless this means that by default things should tend to work, and if not please open issues 