### PR TITLE
Ignore all Manifest.toml files in docs/ from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lib/EnzymeCore/Manifest.toml
 /Manifest-v*.toml
 /test/Manifest.toml
 /docs/Manifest.toml
+/docs/Manifest-v*.toml
+/docs/**/Manifest.toml
 /docs/build/
 /docs/src/generated/
 test/integration/**/Manifest.toml


### PR DESCRIPTION
Julia 1.12 has errors with Enzyme on Windows, so using versioned Manifest.toml to track differences. Also don't need the notebook Manifest.toml since that's an artifact of the build process.