### PR TITLE
Enable Molly integration testing on Julia 1.10

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -58,10 +58,6 @@ jobs:
           - MPI
           - Comrade
           - Turing
-        exclude:
-          - version: '1.10'
-            os: linux-x86-n2-32
-            package: Molly
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/test/integration/Molly/Project.toml
+++ b/test/integration/Molly/Project.toml
@@ -14,4 +14,4 @@ EnzymeCore = {path = "../../../lib/EnzymeCore"}
 
 [compat]
 FiniteDifferences = "0.12"
-Molly = "0.23.1"
+Molly = "0.23.3"


### PR DESCRIPTION
The Molly tests now pass on Julia 1.10, this enables them.

The just-released Molly 0.23.3 should also fix the Julia 1.11 error.