### PR TITLE
Add ForwardModeSplit support

### DIFF
--- a/lib/EnzymeCore/src/EnzymeCore.jl
+++ b/lib/EnzymeCore/src/EnzymeCore.jl
@@ -2,6 +2,7 @@ module EnzymeCore
 
 export Forward, ForwardWithPrimal, Reverse, ReverseWithPrimal, ReverseSplitNoPrimal, ReverseSplitWithPrimal
 export ReverseSplitModified, ReverseSplitWidth, ReverseHolomorphic, ReverseHolomorphicWithPrimal
+export ForwardSplitNoPrimal, ForwardSplitWithPrimal, ForwardSplitWidth, ForwardSplitModified
 export Const, Active, Duplicated, DuplicatedNoNeed, BatchDuplicated, BatchDuplicatedNoNeed, Annotation
 export MixedDuplicated, BatchMixedDuplicated
 export DefaultABI, FFIABI, InlineABI, NonGenABI
@@ -250,6 +251,7 @@ Abstract type for which differentiation mode will be used.
 # Subtypes
 
 - [`ForwardMode`](@ref)
+- [`ForwardModeSplit`](@ref)
 - [`ReverseMode`](@ref)
 - [`ReverseModeSplit`](@ref)
 
@@ -544,6 +546,95 @@ const ForwardWithPrimal = ForwardMode{true, DefaultABI, false, false, false}()
 
 @inline needs_primal(::ForwardMode{ReturnPrimal}) where {ReturnPrimal} = ReturnPrimal
 @inline needs_primal(::Type{<:ForwardMode{ReturnPrimal}}) where {ReturnPrimal} = ReturnPrimal
+
+"""
+    struct ForwardModeSplit{
+        ReturnPrimal,
+        ReturnShadow,
+        RuntimeActivity,
+        StrongZero,
+        Width,
+        ModifiedBetween,
+        ABI,
+        ErrIfFuncWritten
+    } <: Mode{ABI,ErrIfFuncWritten,RuntimeActivity,StrongZero}
+
+Subtype of [`Mode`](@ref) for split forward mode differentiation, to use in [`autodiff_thunk`](@ref) and variants.
+
+Returns a pair of thunks: an augmented forward pass that captures intermediate values in a tape,
+and a forward derivative pass that uses the tape to compute derivatives.
+
+# Type parameters
+
+- `ReturnShadow`: whether to return the shadow (derivative) from the derivative pass.
+- `Width`: batch size (pick `0` to derive it automatically)
+- `ModifiedBetween`: `Tuple` of each argument's "modified between" state (pick `true` to derive it automatically).
+- other parameters: see [`ForwardMode`](@ref)
+
+!!! warning
+    The type parameters of `ForwardModeSplit` are not part of the public API and can change without notice.
+    Please use one of the following concrete instantiations instead:
+    - [`ForwardSplitNoPrimal`](@ref)
+    - [`ForwardSplitWithPrimal`](@ref)
+    You can modify them with the following helper functions:
+    - [`WithPrimal`](@ref) / [`NoPrimal`](@ref)
+    - [`set_err_if_func_written`](@ref) / [`clear_err_if_func_written`](@ref)
+    - [`set_runtime_activity`](@ref) / [`clear_runtime_activity`](@ref)
+    - [`set_strong_zero`](@ref) / [`clear_strong_zero`](@ref)
+    - [`set_abi`](@ref)
+    - [`ForwardSplitModified`](@ref), [`ForwardSplitWidth`](@ref)
+"""
+struct ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} <: Mode{ABI, ErrIfFuncWritten, RuntimeActivity, StrongZero} end
+
+"""
+    const ForwardSplitNoPrimal
+
+Default instance of [`ForwardModeSplit`](@ref) that doesn't return the primal
+"""
+const ForwardSplitNoPrimal = ForwardModeSplit{false, true, false, false, 0, true, DefaultABI, false}()
+
+"""
+    const ForwardSplitWithPrimal
+
+Default instance of [`ForwardModeSplit`](@ref) that also returns the primal
+"""
+const ForwardSplitWithPrimal = ForwardModeSplit{true, true, false, false, 0, true, DefaultABI, false}()
+
+"""
+    ForwardSplitModified(::ForwardModeSplit, ::Val{MB})
+
+Return a new instance of [`ForwardModeSplit`](@ref) mode where `ModifiedBetween` is set to `MB`.
+"""
+@inline ForwardSplitModified(::ForwardModeSplit{ReturnPrimal, ReturnShadow, RuntimeActivity, StrongZero, Width, MBO, ABI, ErrIfFuncWritten}, ::Val{MB}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,MB,MBO,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,MB,ABI,ErrIfFuncWritten}()
+
+"""
+    ForwardSplitWidth(::ForwardModeSplit, ::Val{W})
+
+Return a new instance of [`ForwardModeSplit`](@ref) mode where `Width` is set to `W`.
+"""
+@inline ForwardSplitWidth(::ForwardModeSplit{ReturnPrimal, ReturnShadow, RuntimeActivity, StrongZero, WidthO, MB, ABI, ErrIfFuncWritten}, ::Val{Width}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,MB,WidthO,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,MB,ABI,ErrIfFuncWritten}()
+
+@inline set_err_if_func_written(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,true}()
+@inline clear_err_if_func_written(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,false}()
+
+@inline set_abi(::Type{ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,OldABI,ErrIfFuncWritten}}, ::Type{NewABI}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,OldABI,ErrIfFuncWritten,NewABI<:ABI} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,NewABI,ErrIfFuncWritten}
+@inline set_abi(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,OldABI,ErrIfFuncWritten}, ::Type{NewABI}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,OldABI,ErrIfFuncWritten,NewABI<:ABI} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,NewABI,ErrIfFuncWritten}()
+
+@inline set_runtime_activity(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,true,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline set_runtime_activity(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}, rt::Bool) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,rt,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline set_runtime_activity(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}, ::Mode{<:Any, <:Any, RT2}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten,RT2} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RT2,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline clear_runtime_activity(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,false,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+
+@inline set_strong_zero(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,true,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline set_strong_zero(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}, rt::Bool) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,rt,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline set_strong_zero(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}, ::Mode{<:Any, <:Any, <:Any, SZ2}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten,SZ2} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,SZ2,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline clear_strong_zero(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,false,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+
+@inline WithPrimal(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{true,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+@inline NoPrimal(::ForwardModeSplit{ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}) where {ReturnPrimal,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten} = ForwardModeSplit{false,ReturnShadow,RuntimeActivity,StrongZero,Width,ModifiedBetween,ABI,ErrIfFuncWritten}()
+
+@inline needs_primal(::ForwardModeSplit{ReturnPrimal}) where {ReturnPrimal} = ReturnPrimal
+@inline needs_primal(::Type{<:ForwardModeSplit{ReturnPrimal}}) where {ReturnPrimal} = ReturnPrimal
 
 function autodiff end
 function autodiff_deferred end

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -11,10 +11,15 @@ import EnzymeCore:
     ReverseSplitWithPrimal,
     ReverseSplitModified,
     ReverseSplitWidth,
+    ForwardSplitNoPrimal,
+    ForwardSplitWithPrimal,
+    ForwardSplitModified,
+    ForwardSplitWidth,
     Mode,
     ReverseMode,
     ReverseModeSplit,
     ForwardMode,
+    ForwardModeSplit,
     ReverseHolomorphic,
     ReverseHolomorphicWithPrimal
 export Forward,
@@ -25,10 +30,15 @@ export Forward,
     ReverseSplitWithPrimal,
     ReverseSplitModified,
     ReverseSplitWidth,
+    ForwardSplitNoPrimal,
+    ForwardSplitWithPrimal,
+    ForwardSplitModified,
+    ForwardSplitWidth,
     Mode,
     ReverseMode,
     ReverseModeSplit,
     ForwardMode,
+    ForwardModeSplit,
     ReverseHolomorphic,
     ReverseHolomorphicWithPrimal
 
@@ -129,6 +139,7 @@ include("api.jl")
 Base.convert(::Type{API.CDerivativeMode}, ::ReverseMode) = API.DEM_ReverseModeCombined
 Base.convert(::Type{API.CDerivativeMode}, ::ReverseModeSplit) = API.DEM_ReverseModeGradient
 Base.convert(::Type{API.CDerivativeMode}, ::ForwardMode) = API.DEM_ForwardMode
+Base.convert(::Type{API.CDerivativeMode}, ::ForwardModeSplit) = API.DEM_ForwardModeSplit
 
 function guess_activity end
 
@@ -1150,6 +1161,106 @@ forward = autodiff_thunk(Forward, Const{typeof(f)}, Duplicated, Duplicated{Float
         A,
         tt′,
         Val(API.DEM_ForwardMode),
+        Val(width),
+        ModifiedBetween,
+        Val(ReturnPrimal),
+        Val(false),
+        RABI,
+        Val(ErrIfFuncWritten),
+        Val(RuntimeActivity),
+        Val(StrongZero)
+    ) #=ShadowInit=#
+end
+
+"""
+    autodiff_thunk(::ForwardModeSplit, ftype, Activity, argtypes::Type{<:Annotation}...)
+
+Provide the split forward and forward-derivative pass functions for annotated function type
+`ftype` when called with args of type `argtypes` when using split forward mode.
+
+`Activity` is the Activity of the return value, it may be `Const` or `Duplicated`
+(or its variants `BatchDuplicated`, `BatchDuplicatedNoNeed`).
+
+Returns a pair `(forward, derivative)` where:
+- `forward` is an [`AugmentedForwardThunk`](@ref) that runs the primal and captures a tape
+- `derivative` is a [`ForwardModeSplitThunk`](@ref) that takes the same args plus the tape, and returns the shadow (and optionally the primal)
+
+Example:
+
+```jldoctest
+f(x) = x * x
+
+forward, derivative = autodiff_thunk(ForwardSplitWithPrimal, Const{typeof(f)}, Duplicated, Duplicated{Float64})
+
+tape, result, shadow = forward(Const(f), Duplicated(3.14, 1.0))
+shadow2, result2 = derivative(Const(f), Duplicated(3.14, 1.0), tape)
+
+# output
+
+(6.28, 9.8596)
+```
+"""
+@inline function autodiff_thunk(
+    mode::ForwardModeSplit{
+        ReturnPrimal,
+        ReturnShadow,
+        RuntimeActivity,
+        StrongZero,
+        Width,
+        ModifiedBetweenT,
+        RABI,
+        ErrIfFuncWritten,
+    },
+    ::Type{FA},
+    ::Type{A},
+    args::Vararg{Type{<:Annotation},Nargs},
+) where {
+    FA<:Annotation,
+    A<:Annotation,
+    ReturnPrimal,
+    ReturnShadow,
+    Width,
+    ModifiedBetweenT,
+    RABI<:ABI,
+    Nargs,
+    ErrIfFuncWritten,
+    RuntimeActivity,
+    StrongZero,
+}
+    width = if Width == 0
+        w = same_or_one(1, args...)
+        if w == 0
+            throw(ErrorException("Cannot differentiate with a batch size of 0"))
+        end
+        w
+    else
+        Width
+    end
+
+    if A <: Active
+        throw(ErrorException("Active Returns not allowed in forward mode"))
+    end
+
+    if ModifiedBetweenT === true
+        ModifiedBetween = Val(falses_from_args(Nargs + 1))
+    else
+        ModifiedBetween = Val(ModifiedBetweenT)
+    end
+
+    tt = Tuple{map(eltype, args)...}
+
+    tt′ = Tuple{args...}
+    opt_mi = if RABI <: NonGenABI
+        my_methodinstance(Forward, eltype(FA), tt)
+    else
+        Val(0)
+    end
+    Enzyme.Compiler.thunk(
+        opt_mi,
+        FA,
+        A,
+        tt′,
+        Val(API.DEM_ForwardModeSplit),
         Val(width),
         ModifiedBetween,
         Val(ReturnPrimal),

--- a/src/analyses/activity.jl
+++ b/src/analyses/activity.jl
@@ -517,7 +517,7 @@ Base.@assume_effects :removable :foldable :nothrow @inline function Enzyme.guess
     if ActReg == AnyState
         return Const{T}
     end
-    if Mode == API.DEM_ForwardMode
+    if Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit
         return Duplicated{T}
     else
         if ActReg == ActiveState

--- a/src/api.jl
+++ b/src/api.jl
@@ -228,7 +228,8 @@ end
     DEM_ForwardMode = 0,
     DEM_ReverseModePrimal = 1,
     DEM_ReverseModeGradient = 2,
-    DEM_ReverseModeCombined = 3
+    DEM_ReverseModeCombined = 3,
+    DEM_ForwardModeSplit = 4
 )
 
 # Create the derivative function itself.
@@ -335,10 +336,10 @@ function EnzymeCreateForwardDiff(
     additionalArg,
     typeInfo,
     uncacheable_args,
+    aug = C_NULL,
 )
     freeMemory = true
-    aug = C_NULL
-    subsequent_calls_may_write = false
+    subsequent_calls_may_write = mode == DEM_ForwardModeSplit
     ccall(
         (:EnzymeCreateForwardDiff, libEnzyme),
         LLVMValueRef,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -201,8 +201,8 @@ if VERSION >= v"1.11.0-DEV.1552"
             GPUCompiler.method_table(job),
             typeof(job.config.params),
             job.world,
-            job.config.params.mode == API.DEM_ForwardMode,
-            job.config.params.mode != API.DEM_ForwardMode,
+            job.config.params.mode == API.DEM_ForwardMode || job.config.params.mode == API.DEM_ForwardModeSplit,
+            job.config.params.mode != API.DEM_ForwardMode && job.config.params.mode != API.DEM_ForwardModeSplit,
             true
         )
 
@@ -222,7 +222,7 @@ else
     const GLOBAL_FWD_CACHE = GPUCompiler.CodeCache()
     const GLOBAL_REV_CACHE = GPUCompiler.CodeCache()
     function enzyme_ci_cache(job::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams})
-        return if job.config.params.mode == API.DEM_ForwardMode
+        return if job.config.params.mode == API.DEM_ForwardMode || job.config.params.mode == API.DEM_ForwardModeSplit
             GLOBAL_FWD_CACHE
         else
             GLOBAL_REV_CACHE
@@ -387,6 +387,10 @@ struct AdjointThunk{PT,FA,RT,TT,Width,TapeType} <: AbstractThunk{FA,RT,TT,Width}
     adjoint::PT
 end
 
+struct ForwardModeSplitThunk{PT,FA,RT,TT,Width,ReturnPrimal,TapeType} <: AbstractThunk{FA,RT,TT,Width}
+    adjoint::PT
+end
+
 struct PrimalErrorThunk{PT,FA,RT,TT,Width,ReturnPrimal} <: AbstractThunk{FA,RT,TT,Width}
     adjoint::PT
 end
@@ -413,6 +417,7 @@ end
 @inline fn_type(::Type{<:ForwardModeThunk{<:Any,FA}}) where FA = FA
 @inline fn_type(::Type{<:AugmentedForwardThunk{<:Any,FA}}) where FA = FA
 @inline fn_type(::Type{<:AdjointThunk{<:Any,FA}}) where FA = FA
+@inline fn_type(::Type{<:ForwardModeSplitThunk{<:Any,FA}}) where FA = FA
 @inline fn_type(::Type{<:PrimalErrorThunk{<:Any,FA}}) where FA = FA
 
 using .JIT
@@ -526,7 +531,7 @@ include("llvm/passes.jl")
 include("typeutils/make_zero.jl")
 
 function nested_codegen!(mode::API.CDerivativeMode, mod::LLVM.Module, @nospecialize(f), @nospecialize(tt::Type), world::UInt)
-    funcspec = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, typeof(f), tt, world)
+    funcspec = my_methodinstance((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, typeof(f), tt, world)
     nested_codegen!(mode, mod, funcspec, world)
 end
 
@@ -649,7 +654,7 @@ function handle_compiled(state::HandlerState, edges::Vector, run_enzyme::Bool, m
 
     specTypes = Interpreter.simplify_kw(mi.specTypes)
 
-    if mode == API.DEM_ForwardMode
+    if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
         has_custom_rule =
             EnzymeRules.has_frule_from_sig(specTypes; world, method_table)
         if has_custom_rule
@@ -1782,7 +1787,7 @@ function shadow_alloc_rewrite(V::LLVM.API.LLVMValueRef, gutils::API.EnzymeGradie
 	end
     end
 
-    if mode == API.DEM_ForwardMode && (used || idx != 0)
+    if (mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) && (used || idx != 0)
         # Zero any jlvalue_t inner elements of preceeding allocation.
 
         # Specifically in forward mode, you will first run the original allocation,
@@ -2818,6 +2823,98 @@ function enzyme!(
                 runtimeActivity
             )
         end
+    elseif mode == API.DEM_ForwardModeSplit
+        returnUsed = !(isghostty(actualRetType) || Core.Compiler.isconstType(actualRetType))
+        returnUsed &= returnPrimal
+        augmented = API.EnzymeCreateAugmentedPrimal(
+            logic,
+            primalf,
+            retType,
+            args_activity,
+            TA,
+            returnUsed, #=returnUsed=#
+            false,      #=shadowReturnUsed=#
+            typeInfo,
+            uncacheable_args,
+            false,
+            runtimeActivity,
+            strongZero,
+            width,
+            parallel,
+        ) #=atomicAdd=#
+
+        augmented_primalf =
+            LLVM.Function(API.EnzymeExtractFunctionFromAugmentation(augmented))
+        tape = API.EnzymeExtractTapeTypeFromAugmentation(augmented)
+        utape = API.EnzymeExtractUnderlyingTapeTypeFromAugmentation(augmented)
+        if utape != C_NULL
+            TapeType = EnzymeTapeToLoad{Compiler.tape_type(LLVMType(utape))}
+            tape = utape
+        elseif tape != C_NULL
+            TapeType = Compiler.tape_type(LLVMType(tape))
+        else
+            TapeType = Cvoid
+        end
+        if expectedTapeType !== UnknownTapeType
+            @assert expectedTapeType === TapeType
+        end
+
+        if wrap
+            # The augmented forward pass for ForwardModeSplit only computes the primal
+            # and stores the tape — it does not compute the shadow. Use Const rettype
+            # so that create_abi_wrapper (DEM_ReverseModePrimal path) does not expect
+            # a shadow return value from the C function.
+            aug_rt = Const{actualRetType}
+            augmented_primalf = create_abi_wrapper(
+                augmented_primalf,
+                TT,
+                aug_rt,
+                actualRetType,
+                API.DEM_ReverseModePrimal,
+                augmented,
+                width,
+                returnPrimal,
+                shadow_init,
+                world,
+                interp,
+                runtimeActivity,
+            )
+        end
+
+        adjointf = LLVM.Function(
+            API.EnzymeCreateForwardDiff(
+                logic,
+                primalf,
+                retType,
+                args_activity,
+                TA,
+                returnUsed,
+                API.DEM_ForwardModeSplit,
+                runtimeActivity,
+                strongZero,
+                width, #=mode=#
+                tape,
+                typeInfo, #=additionalArg=#
+                uncacheable_args,
+                augmented,
+            ),
+        )
+        if wrap
+            adjointf = create_abi_wrapper(
+                adjointf,
+                TT,
+                rt,
+                actualRetType,
+                API.DEM_ForwardModeSplit,
+                augmented,
+                width,
+                returnPrimal,
+                shadow_init,
+                world,
+                interp,
+                runtimeActivity,
+            )
+        end
     elseif mode == API.DEM_ForwardMode
         returnUsed = !(isghostty(actualRetType) || Core.Compiler.isconstType(actualRetType))
 
@@ -2825,7 +2922,7 @@ function enzyme!(
 
         if !isghostty(literal_rt) && runtimeActivity && GPUCompiler.deserves_argbox(actualRetType) && !GPUCompiler.deserves_argbox(literal_rt)
         else
-            returnUsed &= returnPrimal        
+            returnUsed &= returnPrimal
         end
 
         adjointf = LLVM.Function(
@@ -2947,7 +3044,7 @@ function create_abi_wrapper(
 )
     is_adjoint = Mode == API.DEM_ReverseModeGradient || Mode == API.DEM_ReverseModeCombined
     is_split = Mode == API.DEM_ReverseModeGradient || Mode == API.DEM_ReverseModePrimal
-    needs_tape = Mode == API.DEM_ReverseModeGradient
+    needs_tape = Mode == API.DEM_ReverseModeGradient || Mode == API.DEM_ForwardModeSplit
 
     mod = LLVM.parent(enzymefn)
     ctx = LLVM.context(mod)
@@ -3159,7 +3256,7 @@ function create_abi_wrapper(
             push!(sret_types, literal_rt)
         end
     end
-    if Mode == API.DEM_ForwardMode
+    if Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit
         if !(rettype <: Const)
             if width == 1
                 push!(sret_types, literal_rt)
@@ -3443,7 +3540,7 @@ function create_abi_wrapper(
 		 @assert arg_roots == 0
 	    end
             Func = get_func(T)
-            funcspec = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, Func, Tuple{}, world)
+            funcspec = my_methodinstance((Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, Func, Tuple{}, world)
             llvmf = nested_codegen!(Mode, mod, funcspec, world)
             push!(function_attributes(llvmf), EnumAttribute("alwaysinline", 0))
             Func_RT = return_type(interp, funcspec)
@@ -3618,7 +3715,7 @@ function create_abi_wrapper(
             end
         end
         @assert returnNum == numLLVMReturns
-    elseif Mode == API.DEM_ForwardMode
+    elseif Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit
         count_Sret = 0
         count_llvm_Sret = 0
         if !isghostty(actualRetType)
@@ -5266,10 +5363,10 @@ function GPUCompiler.compile_unhooked(output::Symbol, job::CompilerJob{<:EnzymeT
     ForwardModeTypes = ("s", "d", "c", "z")
     ReverseModeTypes = ("s", "d")
     # Tablegen BLAS does not support forward mode yet
-    if !(mode == API.DEM_ForwardMode && params.runtimeActivity)
-        for ty in (mode == API.DEM_ForwardMode ? ForwardModeTypes : ReverseModeTypes)
+    if !((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) && params.runtimeActivity)
+        for ty in ((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? ForwardModeTypes : ReverseModeTypes)
             for func in (
-                mode == API.DEM_ForwardMode ? ForwardModeDerivatives :
+                (mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? ForwardModeDerivatives :
                 ReverseModeDerivatives
             )
                 for prefix in ("", "cblas_")
@@ -5961,7 +6058,7 @@ end
             ((LLVM.DoubleType(), Float64, ""), (LLVM.FloatType(), Float32, "f"))
             fname = String(name) * pf
             if haskey(functions(mod), fname)
-                funcspec = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, fnty, Tuple{JT}, job.world)
+                funcspec = my_methodinstance((Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, fnty, Tuple{JT}, job.world)
                 llvmf = nested_codegen!(mode, mod, funcspec, job.world)
                 push!(function_attributes(llvmf), StringAttribute("implements", fname))
             end
@@ -6127,6 +6224,22 @@ end
     args...,
 ) #=ReturnPrimal=#
 
+@inline (thunk::ForwardModeSplitThunk{PT,FA,RT,TT,Width,ReturnPrimal,TapeT})(
+    fn,
+    args...,
+) where {PT,FA,Width,RT,TT,ReturnPrimal,TapeT} = enzyme_call(
+    Val(false),
+    thunk.adjoint,
+    ForwardModeSplitThunk{PT,FA,RT,TT,Width,ReturnPrimal,TapeT},
+    Val(Width),
+    Val(ReturnPrimal),
+    TT,
+    RT,
+    fn,
+    TapeT,
+    args...,
+)
+
 @inline (thunk::AugmentedForwardThunk{PT,FA,RT,TT,Width,ReturnPrimal,TapeT})(
     fn,
     args...,
@@ -6194,10 +6307,10 @@ const DumpLLVMCall = Ref(false)
         FA = fn_type(CC)
         F = eltype(FA)
         is_forward =
-            CC <: AugmentedForwardThunk || CC <: ForwardModeThunk || CC <: PrimalErrorThunk
+            CC <: AugmentedForwardThunk || CC <: ForwardModeThunk || CC <: ForwardModeSplitThunk || CC <: PrimalErrorThunk
         is_adjoint = CC <: AdjointThunk || CC <: CombinedAdjointThunk
         is_split = CC <: AdjointThunk || CC <: AugmentedForwardThunk
-        needs_tape = CC <: AdjointThunk
+        needs_tape = CC <: AdjointThunk || CC <: ForwardModeSplitThunk
 
         argtt = tt.parameters[1]
         rettype = rt.parameters[1]
@@ -6503,7 +6616,7 @@ const DumpLLVMCall = Ref(false)
             push!(sret_types, TapeType)
         end
 
-        if returnPrimal && !(CC <: ForwardModeThunk)
+        if returnPrimal && !(CC <: ForwardModeThunk) && !(CC <: ForwardModeSplitThunk)
             push!(sret_types, jlRT)
         end
         if is_forward
@@ -6540,7 +6653,7 @@ const DumpLLVMCall = Ref(false)
             end
         end
 
-        if returnPrimal && (CC <: ForwardModeThunk)
+        if returnPrimal && (CC <: ForwardModeThunk || CC <: ForwardModeSplitThunk)
             push!(sret_types, jlRT)
         end
 
@@ -6953,7 +7066,7 @@ end
     end
     if !run_enzyme
         ErrT = PrimalErrorThunk{typeof(compile_result.adjoint),FA,rt2,TT,width,ReturnPrimal}
-        if Mode == API.DEM_ReverseModePrimal || Mode == API.DEM_ReverseModeGradient
+        if Mode == API.DEM_ReverseModePrimal || Mode == API.DEM_ReverseModeGradient || Mode == API.DEM_ForwardModeSplit
             return (ErrT(compile_result.adjoint), ErrT(compile_result.adjoint))
         else
             return ErrT(compile_result.adjoint)
@@ -6978,6 +7091,30 @@ end
             TapeType,
         }
         return (AugT(compile_result.primal), AdjT(compile_result.adjoint))
+    elseif Mode == API.DEM_ForwardModeSplit
+        TapeType = compile_result.TapeType
+        # The augmented forward pass for ForwardModeSplit does not return a shadow;
+        # use Const{eltype(rt2)} so that enzyme_call agrees with the ABI wrapper.
+        aug_rt2 = Const{eltype(rt2)}
+        AugT = AugmentedForwardThunk{
+            typeof(compile_result.primal),
+            FA,
+            aug_rt2,
+            Tuple{params.TT.parameters[2:end]...},
+            width,
+            ReturnPrimal,
+            TapeType,
+        }
+        FMST = ForwardModeSplitThunk{
+            typeof(compile_result.adjoint),
+            FA,
+            rt2,
+            Tuple{params.TT.parameters[2:end]...},
+            width,
+            ReturnPrimal,
+            TapeType,
+        }
+        return (AugT(compile_result.primal), FMST(compile_result.adjoint))
     elseif Mode == API.DEM_ReverseModeCombined
         CAdjT = CombinedAdjointThunk{
             typeof(compile_result.adjoint),
@@ -7076,15 +7213,15 @@ function thunk_generator(world::UInt, source::Union{Method, LineNumberNode}, @no
     min_world = Ref{UInt}(typemin(UInt))
     max_world = Ref{UInt}(typemax(UInt))
     
-    mi = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, ft, primal_tt, world, min_world, max_world)
-    
+    mi = my_methodinstance((Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, ft, primal_tt, world, min_world, max_world)
+
     mi === nothing && return stub(world, source, :(throw(MethodError($ft, $primal_tt, $world))))
- 
+
     check_activity_cache_invalidations(world)
 
     edges = Any[]
     add_edge!(edges, mi)
-    
+
     ts_ctx = JuliaContext()
     ctx = context(ts_ctx)
     activate(ctx)
@@ -7116,13 +7253,13 @@ function thunk_generator(world::UInt, source::Union{Method, LineNumberNode}, @no
 
 
 
-    if Mode == API.DEM_ForwardMode
+    if Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit
         fwd_sig = Tuple{typeof(EnzymeRules.forward), <:EnzymeRules.FwdConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
         add_edge!(edges, fwd_sig)
     else
         rev_sig = Tuple{typeof(EnzymeRules.augmented_primal), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
         add_edge!(edges, rev_sig)
-        
+
         rev_sig = Tuple{typeof(EnzymeRules.reverse), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Union{Type{<:Enzyme.EnzymeCore.Annotation}, Enzyme.EnzymeCore.Active}, Any, Vararg{Enzyme.EnzymeCore.Annotation}}
         add_edge!(edges, rev_sig)
     end
@@ -7195,13 +7332,13 @@ function deferred_id_generator(world::UInt, source::Union{Method, LineNumberNode
     min_world = Ref{UInt}(typemin(UInt))
     max_world = Ref{UInt}(typemax(UInt))
  
-    mi = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, ft, primal_tt, world, min_world, max_world)
-    
+    mi = my_methodinstance((Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, ft, primal_tt, world, min_world, max_world)
+
     mi === nothing && return stub(world, source, :(throw(MethodError($ft, $primal_tt, $world))))
-    
+
     target = EnzymeTarget()
     rt2 = if A isa UnionAll
-        rrt = primal_return_type_world(Mode == API.DEM_ForwardMode ? Forward : Reverse, world, mi)
+        rrt = primal_return_type_world((Mode == API.DEM_ForwardMode || Mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, world, mi)
 
         # Don't error here but default to nothing return since in cuda context we don't use the device overrides
         if rrt == Union{}

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -203,7 +203,7 @@ EnzymeInterpreter(
     broadcast_rewrite::Bool = true,
     within_autodiff_rewrite::Bool = true,
     handler = nothing
-) = EnzymeInterpreter(cache_or_token, mt, world, mode == API.DEM_ForwardMode, mode == API.DEM_ReverseModeCombined || mode == API.DEM_ReverseModePrimal || mode == API.DEM_ReverseModeGradient, inactive_rules, broadcast_rewrite, within_autodiff_rewrite, handler)
+) = EnzymeInterpreter(cache_or_token, mt, world, mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit, mode == API.DEM_ReverseModeCombined || mode == API.DEM_ReverseModePrimal || mode == API.DEM_ReverseModeGradient, inactive_rules, broadcast_rewrite, within_autodiff_rewrite, handler)
 
 function EnzymeInterpreter(interp::EnzymeInterpreter;
     cache_or_token = (@static if HAS_INTEGRATED_CACHE

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -27,14 +27,14 @@ function get_job(
         world=Base.get_world_counter()
     end
 
-    primal = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, Core.Typeof(func), tt, world)
-    rt = Compiler.primal_return_type_world(mode == API.DEM_ForwardMode ? Forward : Reverse, world, Core.Typeof(func), tt)
+    primal = my_methodinstance((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, Core.Typeof(func), tt, world)
+    rt = Compiler.primal_return_type_world((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, world, Core.Typeof(func), tt)
 
     @assert primal !== nothing
     rt = A{rt}
     target = Compiler.EnzymeTarget()
     if modifiedBetween === nothing
-        defaultMod = mode != API.DEM_ReverseModeCombined && mode != API.DEM_ForwardMode
+        defaultMod = mode != API.DEM_ReverseModeCombined && mode != API.DEM_ForwardMode && mode != API.DEM_ForwardModeSplit
         modifiedBetween = (defaultMod, (defaultMod for _ in types.parameters)...)
     end
     params = Compiler.EnzymeCompilerParams(
@@ -100,7 +100,7 @@ function enzyme_code_llvm(
     dump_module::Bool = false,
     mode = API.DEM_ReverseModeCombined,
 )
-    if mode == API.DEM_ForwardMode
+    if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
         if A <: Active
             throw(AssertionError("Active not allowed in forward mode"))
         end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -56,12 +56,12 @@ function code_typed_helper(mi::Core.MethodInstance, world::UInt, mode::Enzyme.AP
             GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
             EnzymeCompilerParams,
             world,
-            mode == API.DEM_ForwardMode,
-            mode != API.DEM_ForwardMode,
+            mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit,
+            mode != API.DEM_ForwardMode && mode != API.DEM_ForwardModeSplit,
             true
         )
     else
-        if mode == API.DEM_ForwardMode
+        if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
             GLOBAL_FWD_CACHE
         else
             GLOBAL_REV_CACHE
@@ -1369,12 +1369,12 @@ function julia_error(
 		     ( isa(cur, LLVM.ConstantExpr) || isa(cur, LLVM.GlobalVariable)) &&
                    cur == data2
                     if width == 1
-                        if mode == API.DEM_ForwardMode
+                        if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
                             instance = make_zero(obj)
                             return unsafe_to_llvm(prevbb, instance)
                         else
-                            res = emit_allocobj!(prevbb, Base.RefValue{TT}) 
-			    T_int8 = LLVM.Int8Type() 
+                            res = emit_allocobj!(prevbb, Base.RefValue{TT})
+			    T_int8 = LLVM.Int8Type()
 			    T_size_t = convert(LLVM.LLVMType, UInt)
 			    LLVM.memset!(prevbb, bitcast!(prevbb, res, LLVM.PointerType(T_int8, 10)),  LLVM.ConstantInt(T_int8, 0), LLVM.ConstantInt(T_size_t, sizeof(TT)), 0)
                             push!(created, res)
@@ -1385,7 +1385,7 @@ function julia_error(
                             LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(cur))),
                         )
                         for idx = 1:width
-                            res = if mode == API.DEM_ForwardMode
+                            res = if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
                                 instance = make_zero(obj)
                                 unsafe_to_llvm(prevbb, instance)
                             else

--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -399,7 +399,7 @@ function enzyme_custom_setup_args(
 
         activep = API.EnzymeGradientUtilsGetDiffeType(gutils, op, false) #=isforeign=#
 	orig_activep = activep
-	any_active_data = mode != API.DEM_ForwardMode && (activity_state == ActiveState || activity_state == MixedState)
+	any_active_data = mode != API.DEM_ForwardMode && mode != API.DEM_ForwardModeSplit && (activity_state == ActiveState || activity_state == MixedState)
 
         roots_activep = nothing
 
@@ -863,7 +863,7 @@ function enzyme_custom_setup_ret(
         cmode = API.DEM_ReverseModePrimal
     end
     activep =
-        if mode == API.DEM_ForwardMode ||
+        if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit ||
            API.EnzymeGradientUtilsGetUncacheableArgs(
             gutils,
             orig,
@@ -893,7 +893,7 @@ function enzyme_custom_setup_ret(
     cv = LLVM.called_operand(orig)
     swiftself = has_swiftself(cv)
 
-    may_have_active_reg = mode != API.DEM_ForwardMode && !guaranteed_nonactive(RealRt, world)
+    may_have_active_reg = mode != API.DEM_ForwardMode && mode != API.DEM_ForwardModeSplit && !guaranteed_nonactive(RealRt, world)
 
     if sret !== nothing
         activep = API.EnzymeGradientUtilsGetDiffeType(gutils, operands(orig)[1+swiftself], false) #=isforeign=#
@@ -1435,7 +1435,7 @@ end
 end
 
 @inline function has_rule(orig::LLVM.CallInst, gutils::GradientUtils)::Bool
-    if get_mode(gutils) == API.DEM_ForwardMode
+    if get_mode(gutils) == API.DEM_ForwardMode || get_mode(gutils) == API.DEM_ForwardModeSplit
        tup = fwd_mi(orig, gutils)
         if tup[1] === nothing
            return false

--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -223,13 +223,13 @@ end
 
     # TODO actually do modifiedBetween
     e_tt = Tuple{Const{Int}}
-    modifiedBetween = (mode != API.DEM_ForwardMode, false)
+    modifiedBetween = (mode != API.DEM_ForwardMode && mode != API.DEM_ForwardModeSplit, false)
 
     world = enzyme_extract_world(LLVM.parent(position(B)))
 
     pfuncT = funcT
 
-    mi2 = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
+    mi2 = my_methodinstance((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
     @assert mi2 !== nothing
 
     refed = false
@@ -255,7 +255,7 @@ end
 
     dFT = (dupClosure ? (width == 1 ? Duplicated : (BatchDuplicated{T, Int(width)} where T)) : Const){funcT}
 
-    if mode == API.DEM_ForwardMode
+    if mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit
         if fwdmodenm === nothing
             etarget = Compiler.EnzymeTarget()
             eparams = Compiler.EnzymeCompilerParams(
@@ -309,7 +309,7 @@ end
                 funcT = Core.Typeof(referenceCaller)
                 dupClosure = false
                 modifiedBetween = (false, modifiedBetween...)
-                mi2 = my_methodinstance(mode == API.DEM_ForwardMode ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
+                mi2 = my_methodinstance((mode == API.DEM_ForwardMode || mode == API.DEM_ForwardModeSplit) ? Forward : Reverse, funcT, Tuple{map(eltype, e_tt.parameters)...}, world)
                 @assert mi2 !== nothing
     		dFT = (dupClosure ? (width == 1 ? Duplicated : (BatchDuplicated{T, Int(width)} where T)) : Const){funcT}
             end

--- a/test/forwardmodesplit.jl
+++ b/test/forwardmodesplit.jl
@@ -1,0 +1,245 @@
+using Enzyme
+using Test
+
+import Enzyme: API
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+# Finite-difference first derivative for real scalars
+function fd(f, x; h = 1e-5)
+    (f(x + h) - f(x - h)) / (2h)
+end
+
+# ── basic scalar tests ────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – scalar NoPrimal" begin
+    f(x) = x * x
+
+    aug, deriv = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(f)},
+        Duplicated,
+        Duplicated{Float64},
+    )
+
+    for x in [0.0, 1.0, -2.5, 3.14]
+        tape, _, _ = aug(Const(f), Duplicated(x, 1.0))
+        (shadow,) = deriv(Const(f), Duplicated(x, 1.0), tape)
+        @test shadow ≈ fd(f, x)
+    end
+end
+
+@testset "ForwardModeSplit – scalar WithPrimal" begin
+    f(x) = x * x
+
+    aug, deriv = autodiff_thunk(
+        ForwardSplitWithPrimal,
+        Const{typeof(f)},
+        Duplicated,
+        Duplicated{Float64},
+    )
+
+    for x in [0.0, 1.0, -2.5, 3.14]
+        tape, primal_aug, _ = aug(Const(f), Duplicated(x, 1.0))
+        @test primal_aug ≈ f(x)
+
+        shadow, primal_deriv = deriv(Const(f), Duplicated(x, 1.0), tape)
+        @test shadow      ≈ fd(f, x)
+        @test primal_deriv ≈ f(x)
+    end
+end
+
+@testset "ForwardModeSplit – matches plain ForwardMode" begin
+    f(x) = sin(x) * exp(x / 2)
+
+    aug, deriv = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(f)},
+        Duplicated,
+        Duplicated{Float64},
+    )
+
+    for x in [-2.0, 0.0, 0.5, 1.0, 3.0]
+        # Reference from plain Forward mode
+        ref_shadow = autodiff(Forward, f, Duplicated(x, 1.0))[1]
+
+        tape, _, _ = aug(Const(f), Duplicated(x, 1.0))
+        (shadow,) = deriv(Const(f), Duplicated(x, 1.0), tape)
+
+        @test shadow ≈ ref_shadow
+    end
+end
+
+# ── multi-argument ────────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – multi-argument" begin
+    g(x, y) = x * y + y^2
+
+    # Differentiate w.r.t. x (y is Const)
+    aug_x, deriv_x = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(g)},
+        Duplicated,
+        Duplicated{Float64},
+        Const{Float64},
+    )
+
+    for (x, y) in [(2.0, 3.0), (-1.0, 4.0), (0.0, 1.0)]
+        tape, _, _ = aug_x(Const(g), Duplicated(x, 1.0), Const(y))
+        (dg_dx,) = deriv_x(Const(g), Duplicated(x, 1.0), Const(y), tape)
+        @test dg_dx ≈ y  # ∂g/∂x = y
+    end
+
+    # Differentiate w.r.t. y (x is Const)
+    aug_y, deriv_y = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(g)},
+        Duplicated,
+        Const{Float64},
+        Duplicated{Float64},
+    )
+
+    for (x, y) in [(2.0, 3.0), (-1.0, 4.0), (0.0, 1.0)]
+        tape, _, _ = aug_y(Const(g), Const(x), Duplicated(y, 1.0))
+        (dg_dy,) = deriv_y(Const(g), Const(x), Duplicated(y, 1.0), tape)
+        @test dg_dy ≈ x + 2y  # ∂g/∂y = x + 2y
+    end
+end
+
+# ── Const return (no shadow) ─────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – Const return" begin
+    h(x) = 42.0  # constant function
+
+    aug, deriv = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(h)},
+        Const,
+        Duplicated{Float64},
+    )
+
+    tape, _, _ = aug(Const(h), Duplicated(1.0, 1.0))
+    res = deriv(Const(h), Duplicated(1.0, 1.0), tape)
+    # Const return → nothing returned from derivative pass (empty tuple or nothing)
+    @test res === nothing || res === (nothing,) || res == (nothing,) || isempty(res)
+end
+
+# ── mutating function (tape correctness) ─────────────────────────────────────
+
+@testset "ForwardModeSplit – mutating primal" begin
+    function fill_sq!(y, x)
+        y[1] = x[1]^2
+        y[2] = x[1] * x[2]
+        return nothing
+    end
+
+    y    = [0.0, 0.0]
+    dy   = [0.0, 0.0]
+    x    = [3.0, 4.0]
+    dx   = [1.0, 0.0]  # seed: d/dx[1]
+
+    aug, deriv = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(fill_sq!)},
+        Const,
+        Duplicated{Vector{Float64}},
+        Duplicated{Vector{Float64}},
+    )
+
+    tape, _, _ = aug(
+        Const(fill_sq!),
+        Duplicated(y, dy),
+        Duplicated(x, dx),
+    )
+    deriv(
+        Const(fill_sq!),
+        Duplicated(y, dy),
+        Duplicated(x, dx),
+        tape,
+    )
+
+    # dy/dx[1]: d(x[1]^2)/dx[1] = 2*x[1] = 6, d(x[1]*x[2])/dx[1] = x[2] = 4
+    @test dy[1] ≈ 6.0
+    @test dy[2] ≈ 4.0
+end
+
+# ── thunk caching ─────────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – thunk caching" begin
+    f(x) = x^3
+
+    aug1, deriv1 = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(f)},
+        Duplicated,
+        Duplicated{Float64},
+    )
+    aug2, deriv2 = autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(f)},
+        Duplicated,
+        Duplicated{Float64},
+    )
+
+    # Same thunk types (cached)
+    @test typeof(aug1)   === typeof(aug2)
+    @test typeof(deriv1) === typeof(deriv2)
+
+    # Still produces correct results
+    tape, _, _ = aug1(Const(f), Duplicated(2.0, 1.0))
+    (shadow,)  = deriv1(Const(f), Duplicated(2.0, 1.0), tape)
+    @test shadow ≈ 3 * 2.0^2  # f'(2) = 12
+end
+
+# ── guess_activity ────────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – guess_activity" begin
+    @test Enzyme.guess_activity(Float64,  ForwardSplitNoPrimal)  == Duplicated{Float64}
+    @test Enzyme.guess_activity(Float32,  ForwardSplitNoPrimal)  == Duplicated{Float32}
+    @test Enzyme.guess_activity(Int,      ForwardSplitNoPrimal)  == Const{Int}
+    @test Enzyme.guess_activity(String,   ForwardSplitNoPrimal)  == Const{String}
+end
+
+# ── error cases ───────────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – Active return errors" begin
+    f(x) = x^2
+    @test_throws ErrorException autodiff_thunk(
+        ForwardSplitNoPrimal,
+        Const{typeof(f)},
+        Active,  # Active not allowed in forward mode
+        Duplicated{Float64},
+    )
+end
+
+# ── ForwardSplitWidth ─────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – width-2 batch" begin
+    f(x) = x^2
+
+    mode2 = ForwardSplitWidth(ForwardSplitNoPrimal, Val(2))
+
+    aug, deriv = autodiff_thunk(
+        mode2,
+        Const{typeof(f)},
+        BatchDuplicated,
+        BatchDuplicated{Float64, 2},
+    )
+
+    x   = 3.0
+    dx  = (1.0, 2.0)  # two simultaneous seeds
+
+    tape, _, _ = aug(Const(f), BatchDuplicated(x, dx))
+    (shadows,) = deriv(Const(f), BatchDuplicated(x, dx), tape)
+
+    # f'(x) = 2x = 6; batch: (1*6, 2*6) = (6, 12)
+    @test shadows[1] ≈ 6.0
+    @test shadows[2] ≈ 12.0
+end
+
+# ── convert mode ─────────────────────────────────────────────────────────────
+
+@testset "ForwardModeSplit – convert to CDerivativeMode" begin
+    @test convert(API.CDerivativeMode, ForwardSplitNoPrimal)  === API.DEM_ForwardModeSplit
+    @test convert(API.CDerivativeMode, ForwardSplitWithPrimal) === API.DEM_ForwardModeSplit
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -66,6 +66,21 @@ import Enzyme: API
     @test d.dval[1] ≈ 5.0
     @test d.dval[2] ≈ 3.0
 
+    # ForwardModeSplit internal thunk tests
+    fwd_split, deriv_split = Enzyme.Compiler.thunk(Val(0), Const{typeof(f0)}, Duplicated, Tuple{Duplicated{Float64}}, Val(Enzyme.API.DEM_ForwardModeSplit), Val(1), Val((false, false)), Val(false), Val(false), DefaultABI, Val(false), Val(false), Val(false))
+
+    tape_fs, _, _ = fwd_split(Const(f0), Duplicated(2.0, 1.0))
+    @test tape_fs === nothing  # f0(x) = 1+x needs no tape
+    (shadow_fs,) = deriv_split(Const(f0), Duplicated(2.0, 1.0), tape_fs)
+    @test shadow_fs ≈ 1.0  # f0'(x) = 1
+
+    fwd_split2, deriv_split2 = Enzyme.Compiler.thunk(Val(0), Const{typeof(mul2)}, Duplicated, Tuple{Duplicated{Vector{Float64}}}, Val(Enzyme.API.DEM_ForwardModeSplit), Val(1), Val((false, true)), Val(false), Val(false), DefaultABI, Val(false), Val(false), Val(false))
+
+    d2 = Duplicated([3.0, 5.0], [1.0, 0.0])
+    tape_fs2, _, _ = fwd_split2(Const(mul2), d2)
+    (shadow_fs2,) = deriv_split2(Const(mul2), d2, tape_fs2)
+    @test shadow_fs2 ≈ 5.0  # d(x[1]*x[2])/dx[1] = x[2] = 5
+
     # @test thunk_split.primal !== C_NULL
     # @test thunk_split.primal !== thunk_split.adjoint
     # @test thunk_a.adjoint !== thunk_split.adjoint


### PR DESCRIPTION
Implements DEM_ForwardModeSplit (value 4 in CApi.h) which splits forward
mode AD into two separate LLVM functions — an augmented forward pass
(runs primal, stores tape) and a forward derivative pass (takes tape,
returns shadow) — mirroring ReverseModeSplit for the reverse case.

Changes:
- EnzymeCore: add ForwardModeSplit mode type, ForwardSplitNoPrimal /
  ForwardSplitWithPrimal constants, and ForwardSplitWidth/Modified helpers
- api.jl: DEM_ForwardModeSplit = 4, extend EnzymeCreateForwardDiff with
  aug parameter for split mode
- compiler.jl: ForwardModeSplitThunk struct; thunkbase branch calling
  EnzymeCreateAugmentedPrimal then EnzymeCreateForwardDiff(split);
  ABI wrapper and enzyme_call flags; fix AugmentedForwardThunk rettype to
  Const{actualRetType} so the primal-only augmented forward wrapper does
  not attempt to extract a shadow
- interpreter.jl, reflection.jl: treat DEM_ForwardModeSplit like
  DEM_ForwardMode (forward rules, Forward dispatch)
- Enzyme.jl: autodiff_thunk(::ForwardModeSplit, ...) returning
  (AugmentedForwardThunk, ForwardModeSplitThunk)
- errors.jl, customrules.jl, parallelrules.jl, activity.jl: extend all
  DEM_ForwardMode-only checks to also cover DEM_ForwardModeSplit
- test/forwardmodesplit.jl: new test file (42 tests)
- test/tests.jl: internal thunk tests for DEM_ForwardModeSplit

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
