### PR TITLE
Try to reduce overspecialization of annotations

### DIFF
--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -348,7 +348,10 @@ end
 function _annotate_tt(@nospecialize(TT0))
     TT = Base.unwrap_unionall(TT0)
     ft = TT.parameters[1]
-    tt = map(_annotate ∘ Base.Fix2(Base.rewrap_unionall, TT0), TT.parameters[2:end])
+    tt = []
+    for TTp in TT.parameters[2:end]
+        push!(tt, _annotate(Base.rewrap_unionall(TTp, TT0)))
+    end
     return ft, tt
 end
 

--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -348,7 +348,7 @@ end
 function _annotate_tt(@nospecialize(TT0))
     TT = Base.unwrap_unionall(TT0)
     ft = TT.parameters[1]
-    tt = Type[]
+    tt = TypeVar[]
     for TTp in TT.parameters[2:end]
         push!(tt, _annotate(Base.rewrap_unionall(TTp, TT0)))
     end

--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -348,7 +348,7 @@ end
 function _annotate_tt(@nospecialize(TT0))
     TT = Base.unwrap_unionall(TT0)
     ft = TT.parameters[1]
-    tt = TypeVar[]
+    tt = []
     for TTp in TT.parameters[2:end]
         push!(tt, _annotate(Base.rewrap_unionall(TTp, TT0)))
     end

--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -348,7 +348,7 @@ end
 function _annotate_tt(@nospecialize(TT0))
     TT = Base.unwrap_unionall(TT0)
     ft = TT.parameters[1]
-    tt = []
+    tt = Type[]
     for TTp in TT.parameters[2:end]
         push!(tt, _annotate(Base.rewrap_unionall(TTp, TT0)))
     end


### PR DESCRIPTION
Seems to have helped https://github.com/EnzymeAD/Enzyme.jl/issues/3036 a little bit. Even the `Fix2` version was not inheriting the `@nospecialize`...