### PR TITLE
Fix forward zero-set warning for non-float types

### DIFF
--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -467,6 +467,11 @@ end
     return nothing
 end
 
+function post_arraycopy_makezero(B, callv, _, _)
+    emit_apply_generic!(B, LLVM.Value[unsafe_to_llvm(B, Enzyme.make_zero!), callv])
+    return nothing
+end
+
 function post_arraycopy_memset(B, callv, _, _)
     i8 = LLVM.IntType(8)
     algn = 0
@@ -503,14 +508,7 @@ end
 
     found, arty, byref = abs_typeof(origops[1])
 
-    if !found && !(eltype(arty) <: Base.IEEEFloat)
-        bt = GPUCompiler.backtrace(orig)
-        btstr = sprint() do io
-            print(io, "\nCaused by:")
-            Base.show_backtrace(io, bt)
-        end
-        GPUCompiler.@safe_warn "TODO forward zero-set of arraycopy of found ($found) eltype ($arty) used memset rather than runtime type $btstr"
-    end
+    needs_runtime_zero = !found && !(eltype(arty) <: Base.IEEEFloat)
 
     shadowres = batch_call_same_with_inverted_arg_if_active!(
         B,
@@ -519,7 +517,7 @@ end
         [shadowin],
         [API.VT_Shadow],
         false;
-        postprocess_const=post_arraycopy_memset
+        postprocess_const = needs_runtime_zero ? post_arraycopy_makezero : post_arraycopy_memset
     )::LLVM.Value #=lookup=#
 
     unsafe_store!(shadowR, shadowres.ref)
@@ -766,6 +764,11 @@ end
     return nothing
 end
 
+function post_genericmemcpy_makezero(B, callv, _, _)
+    emit_apply_generic!(B, LLVM.Value[unsafe_to_llvm(B, Enzyme.make_zero!), callv])
+    return nothing
+end
+
 function post_genericmemcpy_memset(B, callv, args, _)
     _, _, len = args
 
@@ -803,14 +806,7 @@ end
 
     found, arty, byref = abs_typeof(origops[1])
 
-    if !found && !(eltype(arty) <: Base.IEEEFloat)
-        bt = GPUCompiler.backtrace(orig)
-        btstr = sprint() do io
-            print(io, "\nCaused by:")
-            Base.show_backtrace(io, bt)
-        end
-        GPUCompiler.@safe_warn "TODO forward zero-set of memorycopy used memset rather than runtime type $btstr"
-    end
+    needs_runtime_zero = !found && !(eltype(arty) <: Base.IEEEFloat)
 
     shadowres = batch_call_same_with_inverted_arg_if_active!(
         B,
@@ -819,7 +815,7 @@ end
         [shadowin, shadowdata, len],
         [API.VT_Shadow, API.VT_Shadow, API.VT_Primal],
         false;
-        postprocess_const=post_genericmemcpy_memset
+        postprocess_const = needs_runtime_zero ? post_genericmemcpy_makezero : post_genericmemcpy_memset
     ) #=lookup=#
 
     unsafe_store!(shadowR, shadowres.ref)

--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -8,13 +8,13 @@ macro register_aug(expr)
     expr2 = :(@inline $expr)
     res = quote
         function $cname(
-            B::LLVM.API.LLVMBuilderRef,
-            OrigCI::LLVM.API.LLVMValueRef,
-            gutils::API.EnzymeGradientUtilsRef,
-            normalR::Ptr{LLVM.API.LLVMValueRef},
-            shadowR::Ptr{LLVM.API.LLVMValueRef},
-            tapeR::Ptr{LLVM.API.LLVMValueRef},
-        )::UInt8
+                B::LLVM.API.LLVMBuilderRef,
+                OrigCI::LLVM.API.LLVMValueRef,
+                gutils::API.EnzymeGradientUtilsRef,
+                normalR::Ptr{LLVM.API.LLVMValueRef},
+                shadowR::Ptr{LLVM.API.LLVMValueRef},
+                tapeR::Ptr{LLVM.API.LLVMValueRef},
+            )::UInt8
             return UInt8(
                 $name(
                     LLVM.IRBuilder(B),
@@ -40,11 +40,11 @@ macro register_rev(expr)
     expr2 = :(@inline $expr)
     res = quote
         function $cname(
-            B::LLVM.API.LLVMBuilderRef,
-            OrigCI::LLVM.API.LLVMValueRef,
-            gutils::API.EnzymeGradientUtilsRef,
-            tape::LLVM.API.LLVMValueRef,
-        )::Cvoid
+                B::LLVM.API.LLVMBuilderRef,
+                OrigCI::LLVM.API.LLVMValueRef,
+                gutils::API.EnzymeGradientUtilsRef,
+                tape::LLVM.API.LLVMValueRef,
+            )::Cvoid
             $name(
                 LLVM.IRBuilder(B),
                 LLVM.CallInst(OrigCI),
@@ -66,12 +66,12 @@ macro register_fwd(expr)
     expr2 = :(@inline $expr)
     res = quote
         function $cname(
-            B::LLVM.API.LLVMBuilderRef,
-            OrigCI::LLVM.API.LLVMValueRef,
-            gutils::API.EnzymeGradientUtilsRef,
-            normalR::Ptr{LLVM.API.LLVMValueRef},
-            shadowR::Ptr{LLVM.API.LLVMValueRef},
-        )::UInt8
+                B::LLVM.API.LLVMBuilderRef,
+                OrigCI::LLVM.API.LLVMValueRef,
+                gutils::API.EnzymeGradientUtilsRef,
+                normalR::Ptr{LLVM.API.LLVMValueRef},
+                shadowR::Ptr{LLVM.API.LLVMValueRef},
+            )::UInt8
             return UInt8(
                 $name(
                     LLVM.IRBuilder(B),
@@ -95,20 +95,20 @@ macro register_diffuse(expr)
     expr2 = :(@inline $expr)
     res = quote
         function $cname(
-            OrigCI::LLVM.API.LLVMValueRef,
-            gutils::API.EnzymeGradientUtilsRef,
-            val::LLVM.API.LLVMValueRef,
-            shadow::UInt8,
-            mode::API.CDerivativeMode,
-            useDefault::Ptr{UInt8},
-        )::UInt8
+                OrigCI::LLVM.API.LLVMValueRef,
+                gutils::API.EnzymeGradientUtilsRef,
+                val::LLVM.API.LLVMValueRef,
+                shadow::UInt8,
+                mode::API.CDerivativeMode,
+                useDefault::Ptr{UInt8},
+            )::UInt8
             res = $name(
                 LLVM.CallInst(OrigCI),
                 GradientUtils(gutils),
                 LLVM.Value(val),
                 shadow != 0,
                 mode,
-            )::Tuple{Bool,Bool}
+            )::Tuple{Bool, Bool}
             unsafe_store!(useDefault, UInt8(res[2]))
             return UInt8(res[1])
         end
@@ -129,16 +129,16 @@ include("parallelrules.jl")
             return common_generic_fwd(2, B, orig, gutils, normalR, shadowR)
         end
         if in(
-            name,
-            (
-                "ijl_f__apply_latest",
-                "ijl_f__call_latest",
-                "ijl_f_invokelatest",
-                "jl_f__apply_latest",
-                "jl_f__call_latest",
-                "jl_f_invokelatest",
-            ),
-        )
+                name,
+                (
+                    "ijl_f__apply_latest",
+                    "ijl_f__call_latest",
+                    "ijl_f_invokelatest",
+                    "jl_f__apply_latest",
+                    "jl_f__call_latest",
+                    "jl_f_invokelatest",
+                ),
+            )
             return common_apply_latest_fwd(2, B, orig, gutils, normalR, shadowR)
         end
         if in(name, ("ijl_new_structv", "jl_new_structv"))
@@ -195,11 +195,11 @@ include("parallelrules.jl")
     if shadowR != C_NULL && normal !== nothing
         t_shadow = normal
         width = get_width(gutils)
-        if width != 1 
+        if width != 1
             t_shadow = UndefValue(
                 LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
             )
-            for idx = 1:width
+            for idx in 1:width
                 t_shadow = insert_value!(B, t_shadow, normal, idx - 1)
             end
         end
@@ -224,16 +224,16 @@ end
             return common_generic_augfwd(2, B, orig, gutils, normalR, shadowR, tapeR)
         end
         if in(
-            name,
-            (
-                "ijl_f__apply_latest",
-                "ijl_f__call_latest",
-                "ijl_f_invokelatest",
-                "jl_f__apply_latest",
-                "jl_f__call_latest",
-                "jl_f_invokelatest",
-            ),
-        )
+                name,
+                (
+                    "ijl_f__apply_latest",
+                    "ijl_f__call_latest",
+                    "ijl_f_invokelatest",
+                    "jl_f__apply_latest",
+                    "jl_f__call_latest",
+                    "jl_f_invokelatest",
+                ),
+            )
             return common_apply_latest_augfwd(2, B, orig, gutils, normalR, shadowR, tapeR)
         end
         if in(name, ("ijl_new_structv", "jl_new_structv"))
@@ -295,11 +295,11 @@ end
         end
         t_shadow = t_shadow1
         width = get_width(gutils)
-        if width != 1 
+        if width != 1
             t_shadow = UndefValue(
                 LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(t_shadow1))),
             )
-            for idx = 1:width
+            for idx in 1:width
                 t_shadow = insert_value!(B, t_shadow, t_shadow1, idx - 1)
             end
         end
@@ -318,16 +318,16 @@ end
             return nothing
         end
         if in(
-            name,
-            (
-                "ijl_f__apply_latest",
-                "ijl_f__call_latest",
-                "ijl_f_invokelatest",
-                "jl_f__apply_latest",
-                "jl_f__call_latest",
-                "jl_f_invokelatest",
-            ),
-        )
+                name,
+                (
+                    "ijl_f__apply_latest",
+                    "ijl_f__call_latest",
+                    "ijl_f_invokelatest",
+                    "jl_f__apply_latest",
+                    "jl_f__call_latest",
+                    "jl_f_invokelatest",
+                ),
+            )
             common_apply_latest_rev(2, B, orig, gutils, tape)
             return nothing
         end
@@ -453,7 +453,7 @@ end
     ops = [new_from_original(gutils, o) for o in origops]
 
     shadowin = invert_pointer(gutils, origops[1], B)
-    
+
     batch_call_same_with_inverted_arg_if_active!(
         B,
         gutils,
@@ -461,7 +461,7 @@ end
         [shadowin],
         [API.VT_Primal for _ in 1:length(origops)],
         true;
-        need_result=false
+        need_result = false
     )
 
     return nothing
@@ -481,7 +481,7 @@ function post_arraycopy_memset(B, callv, _, _)
     len = get_array_len(B, callv)
     length = LLVM.mul!(B, len, elSize)
 
-    LLVM.memset!(
+    return LLVM.memset!(
         B,
         get_array_data(B, callv),
         LLVM.ConstantInt(i8, 0, false),
@@ -526,8 +526,8 @@ end
 
 # Optionally takes a length if requested
 # If this is a memory, pass memoryptr=<underlying data>
-function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothing, memoryptr=nothing)
-	memory = memoryptr != nothing
+function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len = nothing, memoryptr = nothing)
+    memory = memoryptr != nothing
     needsShadowP = Ref{UInt8}(0)
     needsPrimalP = Ref{UInt8}(0)
     activep = API.EnzymeGradientUtilsGetReturnDiffeType(
@@ -550,13 +550,13 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
     tt = TypeTree(API.EnzymeGradientUtilsAllocAndGetTypeTree(gutils, orig))
     mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
     dl = string(LLVM.datalayout(mod))
-	# memory stores the data pointer after a length
-	if memory
-    	API.EnzymeTypeTreeLookupEq(tt, 2*sizeof(Int), dl)
-		API.EnzymeTypeTreeShiftIndiciesEq(tt, dl, sizeof(Int), sizeof(Int), 0)
-	else
-    	API.EnzymeTypeTreeLookupEq(tt, sizeof(Int), dl)
-	end
+    # memory stores the data pointer after a length
+    if memory
+        API.EnzymeTypeTreeLookupEq(tt, 2 * sizeof(Int), dl)
+        API.EnzymeTypeTreeShiftIndiciesEq(tt, dl, sizeof(Int), sizeof(Int), 0)
+    else
+        API.EnzymeTypeTreeLookupEq(tt, sizeof(Int), dl)
+    end
     data0!(tt)
     ct = API.EnzymeTypeTreeInner0(tt)
 
@@ -568,7 +568,7 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
         emit_error(
             B,
             orig,
-            "Enzyme: Unknown concrete type in arraycopy_common. tt: " * string(tt)* " " * string(orig) * " " * string(abs_typeof(orig)),
+            "Enzyme: Unknown concrete type in arraycopy_common. tt: " * string(tt) * " " * string(orig) * " " * string(abs_typeof(orig)),
         )
         return nothing
     end
@@ -596,35 +596,35 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
         while isa(nextInst, LLVM.PHIInst)
             nextInst = LLVM.Instruction(LLVM.API.LLVMGetNextInstruction(nextInst))
         end
-		if len != nothing
-			nextInst = new_from_original(gutils, orig)
-		end
+        if len != nothing
+            nextInst = new_from_original(gutils, orig)
+        end
         position!(B0, nextInst)
     end
 
     elSize = if memory
-		get_memory_elsz(B0, actualOp)
-	else
-		get_array_elsz(B0, actualOp)
-	end
+        get_memory_elsz(B0, actualOp)
+    else
+        get_array_elsz(B0, actualOp)
+    end
 
     elSize = LLVM.zext!(B0, elSize, LLVM.IntType(8 * sizeof(Csize_t)))
 
-	if len == nothing
-		if memory
-			len = get_memory_len(B0, actualOp)
-		else
-			len = get_array_len(B0, actualOp)
-		end
-	elseif !fwd
+    if len == nothing
+        if memory
+            len = get_memory_len(B0, actualOp)
+        else
+            len = get_array_len(B0, actualOp)
+        end
+    elseif !fwd
         # len = lookup_value(gutils, len, B)
-	end
+    end
 
-	if memory
-		length = LLVM.mul!(B0, len, elSize)
-	else
-		length = LLVM.mul!(B0, len, elSize)
-	end
+    if memory
+        length = LLVM.mul!(B0, len, elSize)
+    else
+        length = LLVM.mul!(B0, len, elSize)
+    end
 
     isVolatile = LLVM.ConstantInt(LLVM.IntType(1), 0)
 
@@ -637,22 +637,22 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
     end
 
 
-	lookup_src = true
+    lookup_src = true
 
-	if memory
-		if fwd
-			lookup_src = false
-		    shadowsrc = invert_pointer(gutils, memoryptr, B)
-		else
-		    shadowsrc = invert_pointer(gutils, shadowsrc, B)
+    if memory
+        if fwd
+            lookup_src = false
+            shadowsrc = invert_pointer(gutils, memoryptr, B)
+        else
+            shadowsrc = invert_pointer(gutils, shadowsrc, B)
             shadowsrc = lookup_value(gutils, shadowsrc, B)
-		end
-	else
-		shadowsrc = invert_pointer(gutils, shadowsrc, B)
-		if !fwd
-			shadowsrc = lookup_value(gutils, shadowsrc, B)
-		end
-	end
+        end
+    else
+        shadowsrc = invert_pointer(gutils, shadowsrc, B)
+        if !fwd
+            shadowsrc = lookup_value(gutils, shadowsrc, B)
+        end
+    end
 
     width = get_width(gutils)
 
@@ -672,40 +672,40 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
     shadowsrcs = LLVM.Value[]
     shadowdsts = LLVM.Value[]
 
-	for i = 1:width
+    for i in 1:width
 
-		evsrc = if width == 1
-			shadowsrc
-		else
-			extract_value!(B, shadowsrc, i - 1)
-		end
-		evdst = if width == 1
-			shadowdst
-		else
-			extract_value!(B, shadowdst, i - 1)
-		end
+        evsrc = if width == 1
+            shadowsrc
+        else
+            extract_value!(B, shadowsrc, i - 1)
+        end
+        evdst = if width == 1
+            shadowdst
+        else
+            extract_value!(B, shadowdst, i - 1)
+        end
 
-		# src already has done the lookup from the argument
-		shadowsrc0 = if lookup_src
-			if memory
+        # src already has done the lookup from the argument
+        shadowsrc0 = if lookup_src
+            if memory
                 # TODO this may not be at the same offset as the start of the copy, e.g. get_memory_data(src) != memoryptr
-				get_memory_data(B, evsrc)
-			else
-				get_array_data(B, evsrc)
-			end
-		else
-			inttoptr!(B, evsrc, LLVM.PointerType(LLVM.IntType(8)))
-		end
+                get_memory_data(B, evsrc)
+            else
+                get_array_data(B, evsrc)
+            end
+        else
+            inttoptr!(B, evsrc, LLVM.PointerType(LLVM.IntType(8)))
+        end
 
-		shadowdst0 = if memory
-			get_memory_data(B, evdst)
-		else
-			get_array_data(B, evdst)
-		end
+        shadowdst0 = if memory
+            get_memory_data(B, evdst)
+        else
+            get_array_data(B, evdst)
+        end
 
-		if fwd && secretty != nothing
-			LLVM.memset!(B, shadowdst0, LLVM.ConstantInt(i8, 0, false), length, algn)
-		end
+        if fwd && secretty != nothing
+            LLVM.memset!(B, shadowdst0, LLVM.ConstantInt(i8, 0, false), length, algn)
+        end
 
         push!(shadowsrcs, shadowsrc0)
         push!(shadowdsts, shadowdst0)
@@ -715,25 +715,25 @@ function arraycopy_common(fwd, B, orig, shadowsrc, gutils, shadowdst; len=nothin
         shadowsrc0 = shadowsrcs[i]
         shadowdst0 = shadowdsts[i]
 
-		API.sub_transfer(
-			gutils,
-			fwd ? API.DEM_ReverseModePrimal : API.DEM_ReverseModeGradient,
-			secretty,
-			intrinsic,
-			1,
-			1,
-			0,
-			false,
-			shadowdst0,
-			false,
-			shadowsrc0,
-			length,
-			isVolatile,
-			orig,
-			allowForward,
-			!fwd,
-		) #=shadowsLookedUp=#
-	end
+        API.sub_transfer(
+            gutils,
+            fwd ? API.DEM_ReverseModePrimal : API.DEM_ReverseModeGradient,
+            secretty,
+            intrinsic,
+            1,
+            1,
+            0,
+            false,
+            shadowdst0,
+            false,
+            shadowsrc0,
+            length,
+            isVolatile,
+            orig,
+            allowForward,
+            !fwd,
+        ) #=shadowsLookedUp=#
+    end
 
     return nothing
 end
@@ -764,11 +764,6 @@ end
     return nothing
 end
 
-function post_genericmemcpy_makezero(B, callv, _, _)
-    emit_apply_generic!(B, LLVM.Value[unsafe_to_llvm(B, Enzyme.make_zero!), callv])
-    return nothing
-end
-
 function post_genericmemcpy_memset(B, callv, args, _)
     _, _, len = args
 
@@ -779,7 +774,7 @@ function post_genericmemcpy_memset(B, callv, args, _)
     i8 = LLVM.IntType(8)
     algn = 0
 
-    LLVM.memset!(
+    return LLVM.memset!(
         B,
         get_memory_data(B, callv),
         LLVM.ConstantInt(i8, 0, false),
@@ -815,7 +810,7 @@ end
         [shadowin, shadowdata, len],
         [API.VT_Shadow, API.VT_Shadow, API.VT_Primal],
         false;
-        postprocess_const = needs_runtime_zero ? post_genericmemcpy_makezero : post_genericmemcpy_memset
+        postprocess_const = needs_runtime_zero ? post_arraycopy_makezero : post_genericmemcpy_memset
     ) #=lookup=#
 
     unsafe_store!(shadowR, shadowres.ref)
@@ -833,8 +828,8 @@ end
     if !is_constant_value(gutils, origops[1]) && !is_constant_value(gutils, orig)
         shadowres = LLVM.Value(unsafe_load(shadowR))
 
-		len = new_from_original(gutils, origops[3])
-		memoryptr = origops[2]
+        len = new_from_original(gutils, origops[3])
+        memoryptr = origops[2]
         arraycopy_common(true, B, orig, origops[1], gutils, shadowres; len, memoryptr)
     end
 
@@ -844,8 +839,8 @@ end
 @register_rev function genericmemory_copy_slice_rev(B, orig, gutils, tape)
     origops = LLVM.operands(orig)
     if !is_constant_value(gutils, origops[1]) && !is_constant_value(gutils, orig)
-		len = new_from_original(gutils, origops[3])
-		memoryptr = origops[2]
+        len = new_from_original(gutils, origops[3])
+        memoryptr = origops[2]
         arraycopy_common(false, B, orig, origops[1], gutils, nothing; len, memoryptr)
     end
 
@@ -873,7 +868,7 @@ end
 
     shadowres =
         UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-    for idx = 1:width
+    for idx in 1:width
         ev = if width == 1
             shadowin
         else
@@ -939,31 +934,31 @@ end
         return true
     end
     if unsafe_load(shadowR) != C_NULL
-	    origops = LLVM.operands(orig)
-	    if is_constant_value(gutils, origops[2])
-    		emit_error(B, orig, "Enzyme: reshape array has active return, but inactive input")
-	    end
+        origops = LLVM.operands(orig)
+        if is_constant_value(gutils, origops[2])
+            emit_error(B, orig, "Enzyme: reshape array has active return, but inactive input")
+        end
 
-	    width = get_width(gutils)
+        width = get_width(gutils)
 
-	    shadowin = invert_pointer(gutils, origops[2], B)
+        shadowin = invert_pointer(gutils, origops[2], B)
 
-	    args = LLVM.Value[
-		    new_from_original(gutils, origops[1])
+        args = LLVM.Value[
+            new_from_original(gutils, origops[1])
             shadowin
             new_from_original(gutils, origops[3])
-	    ]
+        ]
 
-		shadowres = batch_call_same_with_inverted_arg_if_active!(
-			B,
-			gutils,
-			orig,
-			args,
-			[API.VT_Primal, API.VT_Shadow, API.VT_Primal],
-			false;
+        shadowres = batch_call_same_with_inverted_arg_if_active!(
+            B,
+            gutils,
+            orig,
+            args,
+            [API.VT_Primal, API.VT_Shadow, API.VT_Primal],
+            false;
             cmpidx = 2
-		    ) #=lookup=#
-	    unsafe_store!(shadowR, shadowres.ref)
+        ) #=lookup=#
+        unsafe_store!(shadowR, shadowres.ref)
     end
     return false
 end
@@ -1005,7 +1000,7 @@ end
     shadowin2 = invert_pointer(gutils, origops[2], B)
     args = LLVM.Value[
         shadowin1,
-        shadowin2
+        shadowin2,
     ]
     shadowres = batch_call_same_with_inverted_arg_if_active!(
         B,
@@ -1054,7 +1049,7 @@ end
     else
         shadowres =
             UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             args = LLVM.Value[extract_value!(B, s, idx - 1) for s in shadowsin]
             tmp = LLVM.call!(B, called_type(orig), LLVM.called_operand(orig), args)
             callconv!(tmp, callconv(orig))
@@ -1092,7 +1087,7 @@ end
         shadowres = obj
     else
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, flt)))
-        for idx = 1:width
+        for idx in 1:width
             obj = emit_allocobj!(B, Base.RefValue{TT})
             o2 = bitcast!(B, obj, LLVM.PointerType(flt, addrspace(value_type(obj))))
             store!(B, ConstantFP(flt, 0.0), o2)
@@ -1131,7 +1126,7 @@ end
         end
     else
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, flt)))
-        for idx = 1:width
+        for idx in 1:width
             ipc = extract_value!(B, ip, idx - 1)
             ipc = bitcast!(B, ipc, LLVM.PointerType(flt, addrspace(value_type(orig))))
             ld = load!(B, flt, ipc)
@@ -1159,7 +1154,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -1179,7 +1174,7 @@ function error_if_active(::Type{T}) where {T}
             AssertionError("Found unhandled active variable in tuple splat, jl_eqtable $T"),
         )
     end
-    nothing
+    return nothing
 end
 
 @register_aug function eqtableget_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
@@ -1213,25 +1208,25 @@ end
             B,
             orig,
             "Enzyme: Not yet implemented constant table in jl_eqtable_get " *
-            string(origh) *
-            " " *
-            string(orig) *
-            " result: " *
-            string(absint(orig)) *
-            " " *
-            string(abs_typeof(orig, true)) *
-            " dict: " *
-            string(absint(origh)) *
-            " " *
-            string(abs_typeof(origh, true)) *
-            " key " *
-            string(absint(origkey)) *
-            " " *
-            string(abs_typeof(origkey, true)) *
-            " dflt " *
-            string(absint(origdflt)) *
-            " " *
-            string(abs_typeof(origdflt, true)),
+                string(origh) *
+                " " *
+                string(orig) *
+                " result: " *
+                string(absint(orig)) *
+                " " *
+                string(abs_typeof(orig, true)) *
+                " dict: " *
+                string(absint(origh)) *
+                " " *
+                string(abs_typeof(origh, true)) *
+                " key " *
+                string(absint(origkey)) *
+                " " *
+                string(abs_typeof(origkey, true)) *
+                " dflt " *
+                string(absint(origdflt)) *
+                " " *
+                string(abs_typeof(origdflt, true)),
         )
     end
 
@@ -1242,9 +1237,9 @@ end
             Base.unsafe_convert(
                 Cstring,
                 "Mixed activity for default of jl_eqtable_get " *
-                string(orig) *
-                " " *
-                string(origdflt),
+                    string(orig) *
+                    " " *
+                    string(origdflt),
             ),
             orig.ref,
             API.ET_MixedActivityError,
@@ -1261,7 +1256,7 @@ end
             else
                 ST = LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(nop)))
                 shadowm = LLVM.UndefValue(ST)
-                for j = 1:width
+                for j in 1:width
                     shadowm = insert_value!(B, shadowm, nop, j - 1)
                 end
                 shadowm
@@ -1315,7 +1310,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -1356,9 +1351,9 @@ end
             Base.unsafe_convert(
                 Cstring,
                 "Mixed activity for val of jl_eqtable_put " *
-                string(orig) *
-                " " *
-                string(origval),
+                    string(orig) *
+                    " " *
+                    string(origval),
             ),
             orig.ref,
             API.ET_MixedActivityError,
@@ -1375,7 +1370,7 @@ end
             else
                 ST = LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(nop)))
                 shadowm = LLVM.UndefValue(ST)
-                for j = 1:width
+                for j in 1:width
                     shadowm = insert_value!(B, shadowm, nop, j - 1)
                 end
                 shadowm
@@ -1390,14 +1385,16 @@ end
     newvals = API.CValueType[API.VT_Shadow, API.VT_Primal, API.VT_Shadow, API.VT_None]
 
     newops = LLVM.Value[
-      shadowh,
-      new_from_original(gutils, origkey),
-      shadowval,
-      LLVM.null(value_type(originserted)),
+        shadowh,
+        new_from_original(gutils, origkey),
+        shadowval,
+        LLVM.null(value_type(originserted)),
     ]
 
-    shadowres = batch_call_same_with_inverted_arg_if_active!(B, gutils, orig, newops, newvals, false;
-        preprocess=eqtable_shadow_active) #=lookup=#
+    shadowres = batch_call_same_with_inverted_arg_if_active!(
+        B, gutils, orig, newops, newvals, false;
+        preprocess = eqtable_shadow_active
+    ) #=lookup=#
 
     unsafe_store!(shadowR, shadowres.ref)
     return false
@@ -1422,7 +1419,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -1452,7 +1449,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -1516,7 +1513,7 @@ function post_shadow_array_grow!(B, _, args, pre)
 
     toset = get_array_data(B, anti)
     toset = gep!(B, i8, toset, LLVM.Value[off])
-    mcall = LLVM.memset!(B, toset, LLVM.ConstantInt(i8, 0, false), tot, al)
+    return mcall = LLVM.memset!(B, toset, LLVM.ConstantInt(i8, 0, false), tot, al)
 
 end
 
@@ -1541,8 +1538,8 @@ end
         args,
         [API.VT_Shadow, API.VT_Primal],
         false;
-        preprocess=pre_shadow_array_grow!,
-        postprocess=post_shadow_array_grow!,
+        preprocess = pre_shadow_array_grow!,
+        postprocess = post_shadow_array_grow!,
         need_result = false
     ) #=lookup=#
 
@@ -1574,7 +1571,7 @@ end
 
         endB = nothing
 
-        for idx = 1:width
+        for idx in 1:width
             args = LLVM.Value[
                 shadowin
                 offset
@@ -1586,12 +1583,12 @@ end
             if get_runtime_activity(gutils) && endB === nothing
                 cond = icmp!(B, LLVM.API.LLVMIntNE, fval, args[1])
 
-	        currentBlock = Base.position(B)
-        	ogname = LLVM.name(currentBlock)
+                currentBlock = Base.position(B)
+                ogname = LLVM.name(currentBlock)
 
-                nextB = add_reverse_block!(gutils, currentBlock, ogname*"_active")
+                nextB = add_reverse_block!(gutils, currentBlock, ogname * "_active")
 
-                endB = add_reverse_block!(gutils, nextB, ogname*"_end", true, false)
+                endB = add_reverse_block!(gutils, nextB, ogname * "_end", true, false)
 
                 br!(B, cond, nextB, endB)
 
@@ -1648,7 +1645,7 @@ end
 
         endB = nothing
 
-        for idx = 1:width
+        for idx in 1:width
             anti = if width == 1
                 shadowin
             else
@@ -1657,13 +1654,13 @@ end
 
             if get_runtime_activity(gutils)
                 cond = icmp!(B, LLVM.API.LLVMIntNE, fval, anti)
-        
-		currentBlock = Base.position(B)
-		ogname = LLVM.name(currentBlock)
 
-                nextB = add_reverse_block!(gutils, currentBlock, ogname*"_active")
+                currentBlock = Base.position(B)
+                ogname = LLVM.name(currentBlock)
 
-                endB = add_reverse_block!(gutils, nextB, ogname*"_end", true, false)
+                nextB = add_reverse_block!(gutils, currentBlock, ogname * "_active")
+
+                endB = add_reverse_block!(gutils, nextB, ogname * "_end", true, false)
 
                 br!(B, cond, nextB, endB)
 
@@ -1690,11 +1687,11 @@ end
             length = LLVM.mul!(B, len, elSize)
 
             if !found && !(eltype(arty) <: Base.IEEEFloat)
-        		bt = GPUCompiler.backtrace(orig)
-        		btstr = sprint() do io
-        		    print(io, "\nCaused by:")
-        		    Base.show_backtrace(io, bt)
-        		end
+                bt = GPUCompiler.backtrace(orig)
+                btstr = sprint() do io
+                    print(io, "\nCaused by:")
+                    Base.show_backtrace(io, bt)
+                end
                 GPUCompiler.@safe_warn "TODO reverse jl_array_del_end zero-set used memset rather than runtime type of $((found, arty)) in $(string(origops[1])) $btstr"
             end
             toset = get_array_data(B, anti)
@@ -1719,7 +1716,7 @@ end
     ops = arg_operands_view(orig)
 
     args = LLVM.Value[]
-    for a in ops[1:end-1]
+    for a in ops[1:(end - 1)]
         v = invert_pointer(gutils, a, B)
         push!(args, v)
     end
@@ -1732,8 +1729,10 @@ end
         API.VT_Primal,
     ]
 
-    batch_call_same_with_inverted_arg_if_active!(B, gutils, orig, args, valTys, false;
-            need_result = false) #=lookup=#
+    batch_call_same_with_inverted_arg_if_active!(
+        B, gutils, orig, args, valTys, false;
+        need_result = false
+    ) #=lookup=#
 
     return false
 end
@@ -1758,14 +1757,14 @@ end
         API.VT_Primal,
     ]
 
-	args = LLVM.Value[
-	        new_from_original(gutils, operands(orig)[1]),
-	        shadowin, # data
-	        new_from_original(gutils, operands(orig)[3]),
-	        new_from_original(gutils, operands(orig)[4]),
-	]
+    args = LLVM.Value[
+        new_from_original(gutils, operands(orig)[1]),
+        shadowin, # data
+        new_from_original(gutils, operands(orig)[3]),
+        new_from_original(gutils, operands(orig)[4]),
+    ]
 
-    shadowres = batch_call_same_with_inverted_arg_if_active!(B, gutils, orig, args, valTys, false; cmpidx=2)::LLVM.Value
+    shadowres = batch_call_same_with_inverted_arg_if_active!(B, gutils, orig, args, valTys, false; cmpidx = 2)::LLVM.Value
 
     unsafe_store!(shadowR, shadowres.ref)
 
@@ -1784,11 +1783,11 @@ end
         return true
     end
     width = get_width(gutils)
-    
+
     legal, dest_ty, _ = abs_typeof(first(operands(orig)))
 
     if !legal
-        emit_error(B, orig, "Enzyme: could not deduce element type of value within generic_memory_copyto of " * string(first(operands(orig))) * " within "*string(orig))
+        emit_error(B, orig, "Enzyme: could not deduce element type of value within generic_memory_copyto of " * string(first(operands(orig))) * " within " * string(orig))
     else
         dest_ty = Vector{Any}
     end
@@ -1823,9 +1822,9 @@ end
     else
         shadowres =
             UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             vargs = LLVM.Value[]
-	    for a in args[1:end-1]
+            for a in args[1:(end - 1)]
                 push!(vargs, extract_value!(B, a, idx - 1))
             end
             push!(vargs, args[end])
@@ -1868,7 +1867,7 @@ end
     else
         shadowres =
             UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             args = LLVM.Value[
                 extract_value!(B, shadowin, idx - 1)
                 new_from_original(gutils, operands(orig)[2])
@@ -1910,7 +1909,7 @@ end
             shadowres = UndefValue(
                 LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
             )
-            for idx = 1:width
+            for idx in 1:width
                 shadowres = insert_value!(B, shadowres, normal, idx - 1)
             end
         end
@@ -1954,12 +1953,12 @@ end
     API.moveBefore(newo, cmp, B)
 
     if unsafe_load(shadowR) != C_NULL
-	valTys = API.CValueType[]
-	args = LLVM.Value[]
-	for i in 1:(length(operands(orig))-1)    
-	    push!(valTys, API.VT_Primal)
-	    push!(args, new_from_original(gutils, operands(orig)[i]))
-	end
+        valTys = API.CValueType[]
+        args = LLVM.Value[]
+        for i in 1:(length(operands(orig)) - 1)
+            push!(valTys, API.VT_Primal)
+            push!(args, new_from_original(gutils, operands(orig)[i]))
+        end
         normal = call_samefunc_with_inverted_bundles!(B, gutils, orig, args, valTys, false) #=lookup=#
         width = get_width(gutils)
         if width == 1
@@ -1968,7 +1967,7 @@ end
             shadowres = UndefValue(
                 LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
             )
-            for idx = 1:width
+            for idx in 1:width
                 shadowres = insert_value!(B, shadowres, normal, idx - 1)
             end
         end
@@ -2016,7 +2015,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -2044,7 +2043,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -2085,7 +2084,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -2113,7 +2112,7 @@ end
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
+        for idx in 1:width
             if width == 1
                 shadowres = normal
             else
@@ -2146,67 +2145,76 @@ function register_handler!(variants, augfwd_handler, rev_handler, fwd_handler = 
             API.EnzymeRegisterFwdCallHandler(variant, fwd_handler)
         end
     end
+    return
 end
 
 macro augfunc(f)
     cname = Symbol(string(f) * "_cfunc")
-    :(@cfunction(
-        $cname,
-        UInt8,
-        (
-            LLVM.API.LLVMBuilderRef,
-            LLVM.API.LLVMValueRef,
-            API.EnzymeGradientUtilsRef,
-            Ptr{LLVM.API.LLVMValueRef},
-            Ptr{LLVM.API.LLVMValueRef},
-            Ptr{LLVM.API.LLVMValueRef},
+    return :(
+        @cfunction(
+            $cname,
+            UInt8,
+            (
+                LLVM.API.LLVMBuilderRef,
+                LLVM.API.LLVMValueRef,
+                API.EnzymeGradientUtilsRef,
+                Ptr{LLVM.API.LLVMValueRef},
+                Ptr{LLVM.API.LLVMValueRef},
+                Ptr{LLVM.API.LLVMValueRef},
+            )
         )
-    ))
+    )
 end
 
 macro revfunc(f)
     cname = Symbol(string(f) * "_cfunc")
-    :(@cfunction(
-        $cname,
-        Cvoid,
-        (
-            LLVM.API.LLVMBuilderRef,
-            LLVM.API.LLVMValueRef,
-            API.EnzymeGradientUtilsRef,
-            LLVM.API.LLVMValueRef,
+    return :(
+        @cfunction(
+            $cname,
+            Cvoid,
+            (
+                LLVM.API.LLVMBuilderRef,
+                LLVM.API.LLVMValueRef,
+                API.EnzymeGradientUtilsRef,
+                LLVM.API.LLVMValueRef,
+            )
         )
-    ))
+    )
 end
 
 macro fwdfunc(f)
     cname = Symbol(string(f) * "_cfunc")
-    :(@cfunction(
-        $cname,
-        UInt8,
-        (
-            LLVM.API.LLVMBuilderRef,
-            LLVM.API.LLVMValueRef,
-            API.EnzymeGradientUtilsRef,
-            Ptr{LLVM.API.LLVMValueRef},
-            Ptr{LLVM.API.LLVMValueRef},
+    return :(
+        @cfunction(
+            $cname,
+            UInt8,
+            (
+                LLVM.API.LLVMBuilderRef,
+                LLVM.API.LLVMValueRef,
+                API.EnzymeGradientUtilsRef,
+                Ptr{LLVM.API.LLVMValueRef},
+                Ptr{LLVM.API.LLVMValueRef},
+            )
         )
-    ))
+    )
 end
 
 macro diffusefunc(f)
     cname = Symbol(string(f) * "_cfunc")
-    :(@cfunction(
-        Compiler.$cname,
-        UInt8,
-        (
-            LLVM.API.LLVMValueRef,
-            API.EnzymeGradientUtilsRef,
-            LLVM.API.LLVMValueRef,
+    return :(
+        @cfunction(
+            Compiler.$cname,
             UInt8,
-            API.CDerivativeMode,
-            Ptr{UInt8},
+            (
+                LLVM.API.LLVMValueRef,
+                API.EnzymeGradientUtilsRef,
+                LLVM.API.LLVMValueRef,
+                UInt8,
+                API.CDerivativeMode,
+                Ptr{UInt8},
+            )
         )
-    ))
+    )
 end
 
 @noinline function register_llvm_rules()
@@ -2377,9 +2385,10 @@ end
         @fwdfunc(new_structt_fwd),
     )
     register_handler!(
-        ("jl_get_binding_or_error", "ijl_get_binding_or_error",
-	 "jl_get_binding_value_seqcst", "ijl_get_binding_value_seqcst",
-	 ),
+        (
+            "jl_get_binding_or_error", "ijl_get_binding_or_error",
+            "jl_get_binding_value_seqcst", "ijl_get_binding_value_seqcst",
+        ),
         @augfunc(get_binding_or_error_augfwd),
         @revfunc(get_binding_or_error_rev),
         @fwdfunc(get_binding_or_error_fwd),
@@ -2443,7 +2452,7 @@ end
         @revfunc(jl_ptr_to_array_rev),
         @fwdfunc(jl_ptr_to_array_fwd),
     )
-    register_handler!(
+    return register_handler!(
         (),
         @augfunc(jl_unhandled_augfwd),
         @revfunc(jl_unhandled_rev),

--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -481,13 +481,14 @@ function post_arraycopy_memset(B, callv, _, _)
     len = get_array_len(B, callv)
     length = LLVM.mul!(B, len, elSize)
 
-    return LLVM.memset!(
+    LLVM.memset!(
         B,
         get_array_data(B, callv),
         LLVM.ConstantInt(i8, 0, false),
         length,
         algn,
     )
+    return nothing
 end
 
 @register_fwd function arraycopy_fwd(B, orig, gutils, normalR, shadowR)


### PR DESCRIPTION
The Enzyme compiler previously emitted a warning during forward mode AD when doing an arraycopy or genericmemory_copy_slice on an inactive value that had an active return (necessitating zero-initialization of the shadow memory). When the precise runtime type of the underlying array couldn't be definitively determined at compile time (or if it was not a basic Float array), the compiler was falling back to emitting a raw memset to zero out the memory.

This patch introduces post_arraycopy_makezero and post_genericmemcpy_makezero which dynamically use Enzyme.make_zero! to zero initialize the arrays safely if they are not plain floats.

Co-authored-by: Antigravity <antigravity@google.com>

fixes #1790 
