### PR TITLE
Turn RunAttributor into a compile-time preference

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -779,3 +779,23 @@ but finalizers are often used for resource management (like manually allocating 
 to the shadow object. Instead, we define finalizers to be inactive (contain no instructions that are relevant with respect to AD),
 yet we must attach them to the shadow object to release resources attached to them. 
 
+## Attributor pass
+
+Enzyme optionally runs an LLVM [Attributor](https://llvm.org/docs/AttributorProgressStatus.html) pass before differentiation. The Attributor infers function attributes (e.g. `readonly`, `nofree`, `nosync`) that allow Enzyme to avoid caching values that are provably unused in the reverse pass, potentially reducing memory usage and improving performance.
+
+The pass is disabled by default because it can interact poorly with Julia's GC and calling conventions on Julia 1.12 and later. It may still be useful on older Julia versions or in specific workloads.
+
+The setting is a compile-time preference (via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl)) and requires restarting Julia after changing it.
+
+```julia
+using Enzyme
+
+# Check the current setting (false by default)
+Enzyme.run_attributor()
+
+# Enable the attributor pass
+Enzyme.set_run_attributor!(true)
+```
+
+See also [`run_attributor`](@ref) and [`set_run_attributor!`](@ref).
+

--- a/lib/EnzymeTestUtils/test/test_forward.jl
+++ b/lib/EnzymeTestUtils/test/test_forward.jl
@@ -116,7 +116,7 @@ end
                 atol = rtol = sqrt(eps(real(T)))
 
                 # Test that require the attributor on 1.11
-                if v"1.11.0" <= VERSION < v"1.12.0" && Enzyme.run_attributor()
+                if v"1.11.0" <= VERSION < v"1.12.0" && !Enzyme.run_attributor()
                     if Tx == Const &&(T == ComplexF32 || T == ComplexF64)
                         Ta == Duplicated || Ta == BatchDuplicated || continue
                     end

--- a/lib/EnzymeTestUtils/test/test_forward.jl
+++ b/lib/EnzymeTestUtils/test/test_forward.jl
@@ -115,9 +115,16 @@ end
                 a = randn(T)
                 atol = rtol = sqrt(eps(real(T)))
 
-	        @test !fails() do
-	        	test_forward(f_multiarg, Tret, (x, Tx), (a, Ta); atol, rtol)
-	        end
+                # Test that require the attributor on 1.11
+                if v"1.11.0" <= VERSION < v"1.12.0" && Enzyme.run_attributor()
+                    if Tx == Const &&(T == ComplexF32 || T == ComplexF64)
+                        Ta == Duplicated || Ta == BatchDuplicated || continue
+                    end
+                end
+
+                @test !fails() do
+                    test_forward(f_multiarg, Tret, (x, Tx), (a, Ta); atol, rtol)
+                end
             end
         end
         

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -113,6 +113,7 @@ export autodiff,
 
 export jacobian, gradient, gradient!, hvp, hvp!, hvp_and_gradient!
 export batch_size, onehot, chunkedonehot
+export run_attributor, set_run_attributor!
 
 using LinearAlgebra
 import SparseArrays
@@ -122,6 +123,7 @@ export EnzymeRules
 
 # Independent code, must be loaded before "compiler.jl"
 include("pmap.jl")
+include("preferences.jl")
 
 import LLVM
 include("api.jl")

--- a/src/compiler/optimize.jl
+++ b/src/compiler/optimize.jl
@@ -11,7 +11,8 @@ LLVM.@module_pass "enzyme-fixup-julia" FixupJuliaCallingConventionPass
 LLVM.@module_pass "enzyme-fixup-julia-sret" FixupJuliaCallingConventionSRetPass
 LLVM.@module_pass "enzyme-fixup-batched-julia" FixupBatchedJuliaCallingConventionPass
 
-const RunAttributor = Ref(VERSION < v"1.12")
+import ..Enzyme: run_attributor
+const RunAttributor = run_attributor()
 
 function enzyme_attributor_pass!(mod::LLVM.Module)
     ccall(

--- a/src/llvm/transforms.jl
+++ b/src/llvm/transforms.jl
@@ -2723,8 +2723,8 @@ function removeDeadArgs!(mod::LLVM.Module, tm::LLVM.TargetMachine, post_gc_fixup
         LLVM.run!(pb, mod)
     end
     propagate_returned!(mod)
-    pre_attr!(mod, RunAttributor[])
-    if RunAttributor[]
+    pre_attr!(mod, RunAttributor)
+    if RunAttributor
         API.EnzymeDetectReadonlyOrThrow(mod)
         LLVM.@dispose pb = NewPMPassBuilder() begin
             register!(pb, EnzymeAttributorPass())
@@ -2747,7 +2747,7 @@ function removeDeadArgs!(mod::LLVM.Module, tm::LLVM.TargetMachine, post_gc_fixup
                 add!(fpm, RestoreAllocaType())
                 add!(fpm, SROAPass())
             end
-            if RunAttributor[]
+            if RunAttributor
                 add!(mpm, EnzymeAttributorPass())
             end
             add!(mpm, NewPMFunctionPassManager()) do fpm
@@ -2757,7 +2757,7 @@ function removeDeadArgs!(mod::LLVM.Module, tm::LLVM.TargetMachine, post_gc_fixup
         LLVM.run!(pb, mod)
     end
     API.EnzymeDetectReadonlyOrThrow(mod)
-    post_attr!(mod, RunAttributor[])
+    post_attr!(mod, RunAttributor)
     propagate_returned!(mod)
     
 

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,0 +1,25 @@
+using Preferences
+
+"""
+    run_attributor() -> Bool
+
+Return whether the Enzyme attributor pass is enabled. This is a compile-time
+preference that requires restarting Julia to take effect after being changed.
+
+The attributor pass can improve differentiation quality but may cause issues on
+Julia 1.12 and later. Defaults to `false`.
+
+See also [`set_run_attributor!`](@ref).
+"""
+run_attributor() = @load_preference("run_attributor", false)
+
+"""
+    set_run_attributor!(val::Bool)
+
+Set whether the Enzyme attributor pass is enabled. This is a compile-time
+preference stored via `Preferences.jl`; a restart of Julia is required for
+the change to take effect.
+
+See also [`run_attributor`](@ref).
+"""
+set_run_attributor!(val::Bool) = @set_preferences!("run_attributor" => val)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -6,12 +6,13 @@ using Preferences
 Return whether the Enzyme attributor pass is enabled. This is a compile-time
 preference that requires restarting Julia to take effect after being changed.
 
-The attributor pass can improve differentiation quality but may cause issues on
-Julia 1.12 and later. Defaults to `false`.
+!!! note
+    The attributor pass can improve differentiation quality but may cause issues on
+    Julia 1.11 and later. Defaults to `true` on Julia 1.10 and `false` on 1.11 and later.
 
 See also [`set_run_attributor!`](@ref).
 """
-run_attributor() = @load_preference("run_attributor", false)
+run_attributor() = @load_preference("run_attributor", VERSION < v"1.11")
 
 """
     set_run_attributor!(val::Bool)

--- a/test/preferences.jl
+++ b/test/preferences.jl
@@ -1,0 +1,19 @@
+using Enzyme, Test
+
+@testset "run_attributor preference" begin
+    # Default is false
+    @test run_attributor() isa Bool
+
+    current = run_attributor()
+
+    # Setter round-trips the value
+    set_run_attributor!(!current)
+    @test run_attributor() == !current
+
+    # Restore original value
+    set_run_attributor!(current)
+    @test run_attributor() == current
+
+    # RunAttributor compile-time constant reflects the preference at load time
+    @test Enzyme.Compiler.RunAttributor isa Bool
+end


### PR DESCRIPTION
Attributor yet again seems to be the cause of some illegal code transformation,
and I would like my last few days of investigating https://github.com/EnzymeAD/Enzyme.jl/issues/3041#issuecomment-4333046367 back.

This PR turns running it into an preference flag (so that folks who want it don't need to remember passing an environment flag),
but turns it off by default.
