### PR TITLE
Update test/integration/SciML for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/test/integration/SciML/Project.toml
+++ b/test/integration/SciML/Project.toml
@@ -7,6 +7,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -17,11 +18,12 @@ Enzyme = {path = "../../.."}
 EnzymeCore = {path = "../../../lib/EnzymeCore"}
 
 [compat]
-DiffEqBase = "6.190"
+DiffEqBase = "6.190, 7"
 ForwardDiff = "0.10.36, 1"
 LinearSolve = "3.12"
-OrdinaryDiffEq = "6.89"
-OrdinaryDiffEqTsit5 = "1.1"
+OrdinaryDiffEq = "6.89, 7"
+OrdinaryDiffEqTsit5 = "1.1, 2"
+SciMLBase = "2, 3"
 SciMLSensitivity = "7.69"
 StaticArrays = "1.9"
 Zygote = "0.7.10"

--- a/test/integration/SciML/runtests.jl
+++ b/test/integration/SciML/runtests.jl
@@ -1,5 +1,5 @@
 using Enzyme, OrdinaryDiffEqTsit5, StaticArrays, DiffEqBase, ForwardDiff, Test
-using OrdinaryDiffEq, SciMLSensitivity, Zygote
+using OrdinaryDiffEq, SciMLBase, SciMLSensitivity, Zygote
 using LinearSolve, LinearAlgebra
 
 @testset "Direct Differentiation of Explicit ODE Solve" begin
@@ -61,7 +61,11 @@ struct senseloss0{T}
 end
 function (f::senseloss0)(u0p)
     prob = ODEProblem{true}(odef, u0p[1:1], (0.0, 1.0), u0p[2:2])
-    sum(solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1))
+    # Use sol.u to iterate over timestep state vectors — forward-compatible with both
+    # RecursiveArrayTools v3 and v4. RAT v4 changed sol[i] (integer index) semantics to
+    # return a scalar element rather than the i-th timestep; sol.u[i] is the stable API.
+    sol = solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1)
+    sum(sum, sol.u)
 end
 
 @testset "SciMLSensitivity Adjoint Interface" begin

--- a/test/integration/SciML/runtests.jl
+++ b/test/integration/SciML/runtests.jl
@@ -9,47 +9,49 @@ using LinearSolve, LinearAlgebra
         du[3] = u[1] * u[2] - (8 / 3) * u[3]
     end
 
-    _saveat =  SA[0.0,0.25,0.5,0.75,1.0,1.25,1.5,1.75,2.0,2.25,2.5,2.75,3.0]
+    _saveat = SA[0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0]
 
     function f_dt(y::Array{Float64}, u0::Array{Float64})
         tspan = (0.0, 3.0)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(lorenz!, u0, tspan)
-        sol = DiffEqBase.solve(prob, Tsit5(), saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol=1e-12, reltol=1e-12)
-        y .= sol[1,:]
+        sol = DiffEqBase.solve(prob, Tsit5(), saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol = 1.0e-12, reltol = 1.0e-12)
+        y .= sol[1, :]
         return nothing
-    end;
+    end
 
     function f_dt(u0)
         tspan = (0.0, 3.0)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(lorenz!, u0, tspan)
-        sol = DiffEqBase.solve(prob, Tsit5(), saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol=1e-12, reltol=1e-12)
-        sol[1,:]
-    end;
+        sol = DiffEqBase.solve(prob, Tsit5(), saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol = 1.0e-12, reltol = 1.0e-12)
+        sol[1, :]
+    end
 
     u0 = [1.0; 0.0; 0.0]
     fdj = ForwardDiff.jacobian(f_dt, u0)
 
-    ezj = stack(map(1:3) do i
-        d_u0 = zeros(3)
-        dy = zeros(13)
-        y  = zeros(13)
-        d_u0[i] = 1.0
-        Enzyme.autodiff(Forward, f_dt,  Duplicated(y, dy), Duplicated(u0, d_u0));
-        dy
-    end)
+    ezj = stack(
+        map(1:3) do i
+            d_u0 = zeros(3)
+            dy = zeros(13)
+            y = zeros(13)
+            d_u0[i] = 1.0
+            Enzyme.autodiff(Forward, f_dt, Duplicated(y, dy), Duplicated(u0, d_u0))
+            dy
+        end
+    )
 
     @test ezj ≈ fdj
 
     function f_dt2(u0)
         tspan = (0.0, 3.0)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(lorenz!, u0, tspan)
-        sol = DiffEqBase.solve(prob, Tsit5(), dt=0.1, saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol=1e-12, reltol=1e-12)
-        sum(sol[1,:])
+        sol = DiffEqBase.solve(prob, Tsit5(), dt = 0.1, saveat = _saveat, sensealg = DiffEqBase.SensitivityADPassThrough(), abstol = 1.0e-12, reltol = 1.0e-12)
+        sum(sol[1, :])
     end
 
     fdg = ForwardDiff.gradient(f_dt2, u0)
     d_u0 = zeros(3)
-    Enzyme.autodiff(Reverse, f_dt2,  Active, Duplicated(u0, d_u0));
+    Enzyme.autodiff(Reverse, f_dt2, Active, Duplicated(u0, d_u0))
 
     @test d_u0 ≈ fdg
 end
@@ -64,8 +66,8 @@ function (f::senseloss0)(u0p)
     # Use sol.u to iterate over timestep state vectors — forward-compatible with both
     # RecursiveArrayTools v3 and v4. RAT v4 changed sol[i] (integer index) semantics to
     # return a scalar element rather than the i-th timestep; sol.u[i] is the stable API.
-    sol = solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1)
-    sum(sum, sol.u)
+    sol = solve(prob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = 0.1)
+    return sum(sum, sol.u)
 end
 
 @testset "SciMLSensitivity Adjoint Interface" begin
@@ -77,12 +79,12 @@ end
     @test du0p ≈ dup
 end
 
-  @testset "LinearSolve Adjoints" begin
+@testset "LinearSolve Adjoints" begin
     n = 4
-    A = rand(n, n);
-    dA = zeros(n, n);
-    b1 = rand(n);
-    db1 = zeros(n);
+    A = rand(n, n)
+    dA = zeros(n, n)
+    b1 = rand(n)
+    db1 = zeros(n)
 
     function f(A, b1; alg = LUFactorization())
         prob = LinearProblem(A, b1)


### PR DESCRIPTION
## Summary

The OrdinaryDiffEq v7 / SciMLBase v3 / RecursiveArrayTools v4 ecosystem just released. This PR updates `test/integration/SciML/` — the self-contained SciML integration test subdir — to work against both the new v7 stack and the existing v6 stack. Core Enzyme source is not touched.

Relevant upstream references:
- SciML/OrdinaryDiffEq.jl#3562 (v7 release)
- SciML/OrdinaryDiffEq.jl#3565 (OrdinaryDiffEqCore v5 revert — core stays at v4)
- [OrdinaryDiffEq.jl NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)

---

## Compat changes (`test/integration/SciML/Project.toml`)

| Package | Old bound | New bound | Reason |
|---|---|---|---|
| `DiffEqBase` | `"6.190"` | `"6.190, 7"` | DiffEqBase migrated into OrdinaryDiffEq.jl monorepo; v7 ships together with ODEq v7 |
| `OrdinaryDiffEq` | `"6.89"` | `"6.89, 7"` | Major v7 release |
| `OrdinaryDiffEqTsit5` | `"1.1"` | `"1.1, 2"` | v2 sub-library ships alongside OrdinaryDiffEq v7 |
| `SciMLBase` | *(not in [compat])* | `"2, 3"` | Added to `[deps]` + `[compat]`; `SciMLBase.FullSpecialize` is used directly in three `ODEProblem` constructions, so the dep should be explicit. SciMLBase v3 is required by ODEq v7. |

Existing lower bounds are preserved — the compat ranges accept both v6 and v7 ecosystems.

---

## Source migrations (`test/integration/SciML/runtests.jl`)

### 1. Explicit `using SciMLBase` — cleanup / explicit dep hygiene

**File:** `runtests.jl`, line 2  
**Change:** added `SciMLBase` to the `using` block  
**NEWS theme:** general dep-hygiene: `SciMLBase.FullSpecialize` appears in three `ODEProblem{true, SciMLBase.FullSpecialize}(...)` calls. The type was previously reachable via `DiffEqBase`'s `@reexport using SciMLBase`. With `SciMLBase` now listed in `[deps]`, the import should be explicit.

### 2. `sum(sol)` → `sum(sum, sol.u)` — RAT v4 element-first array semantics

**File:** `runtests.jl`, `senseloss0` callable (formerly lines 62–65, now 62–69)  
**NEWS theme:** *RecursiveArrayTools v4 — `AbstractVectorOfArray <: AbstractArray`*

**Before:**
```julia
sum(solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1))
```

**After:**
```julia
sol = solve(prob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = 0.1)
sum(sum, sol.u)
```

**Why:** In RecursiveArrayTools v3, `AbstractVectorOfArray` had a custom `sum` override that reduced over `sol.u` (i.e., iterated timestep state vectors). For a 1D state (`u0p[1:1]`), this returned a 1-element `Vector{Float64}`. In v4, `AbstractVectorOfArray <: AbstractArray` and `sum` is inherited from `AbstractArray`, so it reduces over all scalar elements — for a 1D state, this returns a `Float64` (a `Number`).

The test on the next line, `@test senseloss0(...) isa Number`, makes clear the intent is a scalar return. Using `sum(sum, sol.u)` makes this explicit and forward-compatible:
- **v3:** `sol.u::Vector{Vector{Float64}}`; `sum` maps inner `sum` over each 1-element vector (yields a scalar), outer `sum` combines → scalar `Float64`
- **v4:** identical — `sol.u` semantics are unchanged; only array-indexing on `sol` itself changed

`sol.u[i]` is the stable API for per-timestep access in both v3 and v4 (the migration shortcut recommended by the NEWS).

**Not migrated:** `sol[1,:]` (lines 18, 26, 47) — this is 2D matrix-style indexing (row 1, all timesteps). RAT v4's breaking change only affects single-integer `sol[i]` access; two-argument `[row, :]` works the same way in both versions since `sol` is now a proper `AbstractArray`.

---

## Test plan

- [ ] `test/integration/SciML/runtests.jl` instantiates cleanly against the v7 stack (`OrdinaryDiffEq v7.0.0`, `DiffEqBase v7.1.0`, `OrdinaryDiffEqTsit5 v2.0.0`, `SciMLBase v3.7.1`) — verified locally
- [ ] All three testsets pass: "Direct Differentiation of Explicit ODE Solve", "SciMLSensitivity Adjoint Interface", "LinearSolve Adjoints"
- [ ] CI "Integration" job (which runs `test/integration/SciML/runtests.jl`) passes

## Scope

This PR is scoped exclusively to `test/integration/SciML/` — `Project.toml` and `runtests.jl`. No core Enzyme source, no other integration suites, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)