### PR TITLE
Fix reverse custom-rule rooting for nested sparse wrappers

### DIFF
--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -456,7 +456,11 @@ function enzyme_custom_setup_args(
         root_ty = nothing
         roots_val = if roots_op !== nothing
             root_ty = convert(LLVMType, AnyArray(roots))
-            new_from_original(gutils, roots_op)
+            roots_val = new_from_original(gutils, roots_op)
+            if reverse && B !== nothing
+                roots_val = lookup_value(gutils, roots_val, B)
+            end
+            roots_val
         end
 
 

--- a/test/rules/internal_rules/sparsearrays_rules.jl
+++ b/test/rules/internal_rules/sparsearrays_rules.jl
@@ -46,6 +46,31 @@ function test_sparse(M, v, α, β)
     return test_reverse(LinearAlgebra.mul!, Const, (C, Const), (M, Const), (v, Const), (α, Active), (β, Active))
 end
 
+struct SparseWrapperScale{T}
+    λ::T
+end
+
+Base.convert(::Type{Number}, x::SparseWrapperScale) = x.λ
+Base.iszero(x::SparseWrapperScale) = iszero(x.λ)
+
+struct SparseWrapperMatrix{A}
+    A::A
+end
+
+struct SparseWrapperScaledMatrix
+    λ::SparseWrapperScale{Float64}
+    L::SparseWrapperMatrix{SparseMatrixCSC{Float64, Int}}
+end
+
+function sparse_wrapper_mul!(w, L::SparseWrapperScaledMatrix, v)
+    iszero(L.λ) && return lmul!(false, w)
+    α = convert(Number, L.λ)
+    return mul!(w, L.L.A, v, α, false)
+end
+
+const sparse_wrapper_matrix = sparse(Float64[0.0 1.0; 0.0 0.0])
+sparse_wrapper_nonconst_m = SparseWrapperMatrix(sparse_wrapper_matrix)
+
 @testset "SparseArrays spmatvec reverse rule" begin
     Ts = ComplexF64
 
@@ -80,6 +105,23 @@ end
         test_reverse(LinearAlgebra.mul!, T, (C, T), (real(M), T), (real(v), T), (real(α), Active), (β, Active))
         test_reverse(LinearAlgebra.mul!, T, (C, T), (M, T), (v, T), (α, Active), (real(β), Active))
     end
+end
+
+@testset "SparseArrays nested wrapper reverse rule" begin
+    function f(p)
+        u = [3.0, 4.0]
+        du = similar(u)
+        L = SparseWrapperScaledMatrix(SparseWrapperScale(-p[1]), sparse_wrapper_nonconst_m)
+        sparse_wrapper_mul!(du, L, u)
+        return sum(du)
+    end
+
+    p = [1.0]
+    dp = Enzyme.make_zero(p)
+
+    @test f(p) == -4.0
+    Enzyme.autodiff(Enzyme.set_runtime_activity(Enzyme.Reverse), f, Active, Duplicated(p, dp))
+    @test dp ≈ [-4.0]
 end
 
 @testset "SparseArrays spmatmat reverse rule" begin


### PR DESCRIPTION
## Summary

- Fixes #3072.
- Remaps rooted argument values when setting up reverse custom-rule arguments, so boxed primal roots are loaded from values that dominate the reverse block.
- Adds a regression test for reverse-mode AD through a nested wrapper around `SparseMatrixCSC` scaled `mul!`.

## Explanation

The failure in #3072 came from reverse custom-rule setup reusing the original rooted argument value when boxing a `Duplicated{SparseMatrixCSC}` argument. In the nested wrapper reproducer, that root pointer was defined along the forward path, so the reverse-generated load for `loaded.roots.primal.SparseMatrixCSC{Float64, Int64}` failed LLVM verification because the definition did not dominate the use.

This updates rooted argument handling to call `lookup_value` for `roots_val` in reverse mode, matching how the primal argument value is remapped before being boxed. That keeps the root load anchored to the reverse-pass value map instead of the original forward-path value.

The new sparse regression exercises the nested active wrapper case from the issue: a scalar wrapper plus a sparse matrix wrapper passed through scaled `mul!` under `set_runtime_activity(Reverse)`. The test checks both the primal result and the expected gradient `dp ≈ [-4.0]`.

## Notes

- The regression fixture uses a concrete nested wrapper type so it exercises the sparse rooting bug without also triggering the unrelated parametric-constructor `_compute_sparams` path under `ParallelTestRunner`.

## Tests

- `julia --project=test -e 'include("test/rules/internal_rules/sparsearrays_rules.jl")'`
  - `SparseArrays spmatvec reverse rule`: 4002 passed
  - `SparseArrays nested wrapper reverse rule`: 2 passed
  - `SparseArrays spmatmat reverse rule`: 1709 passed
- `julia --project=test test/runtests.jl rules/internal_rules/sparsearrays_rules --jobs=1 --quickfail`
  - `Overall`: 5713 passed, 5713 total, `SUCCESS`
- `julia --project=@runic -e 'using Runic; exit(Runic.main(["--inplace", "test/rules/internal_rules/sparsearrays_rules.jl"]))'`
- `git diff --check`
