### PR TITLE
Fix loading on Julia 1.14 nightly (Compiler.InferenceCache)

### DIFF
--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -62,7 +62,11 @@ struct EnzymeInterpreter{T} <: AbstractInterpreter
     method_table::Core.Compiler.MethodTableView
 
     # Cache of inference results for this particular interpreter
-    local_cache::Vector{InferenceResult}
+    local_cache::@static if isdefined(Core.Compiler, :InferenceCache)
+        Core.Compiler.InferenceCache
+    else
+        Vector{InferenceResult}
+    end
     # The world age we're working inside of
     world::UInt
 
@@ -177,7 +181,11 @@ function EnzymeInterpreter(
     mt == nothing ? Core.Compiler.InternalMethodTable(world) : Core.Compiler.OverlayMethodTable(world, mt),
 
         # Initially empty cache
-        Vector{InferenceResult}(),
+        (@static if isdefined(Core.Compiler, :InferenceCache)
+            Core.Compiler.InferenceCache()
+        else
+            Vector{InferenceResult}()
+        end),
 
         # world age counter
         world,


### PR DESCRIPTION
## Summary

- Julia 1.14 introduced `Compiler.InferenceCache` as a structured wrapper around `Vector{InferenceResult}`, replacing it as the required second argument to `OverlayCodeCache`
- `EnzymeInterpreter.local_cache` and its constructor initialization now use `Core.Compiler.InferenceCache` on 1.14+, guarded by `isdefined(Core.Compiler, :InferenceCache)` for backwards compatibility

Without this fix, `using Enzyme` fails on Julia nightly with:
```
MethodError: no method matching Compiler.OverlayCodeCache(::Compiler.InternalCodeCache, ::Vector{Compiler.InferenceResult})
```

## Test plan

- [ ] `using Enzyme` loads without error on `julia +nightly`
- [ ] Basic autodiff works: `autodiff(Reverse, x -> x^2, Active, Active(3.0))` returns `((6.0,),)`
- [ ] Existing tests continue to pass on Julia 1.11/1.12/1.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)