### PR TITLE
EnzymeTestUtils: import eval_test_function/eval_test_comparison for Julia 1.13

### DIFF
--- a/lib/EnzymeTestUtils/src/output_control.jl
+++ b/lib/EnzymeTestUtils/src/output_control.jl
@@ -4,6 +4,12 @@
 
 # Test.get_test_result generates code that uses the following so we must import them
 using Test: Returned, Threw, eval_test
+@static if isdefined(Test, :eval_test_function)
+    using Test: eval_test_function
+end
+@static if isdefined(Test, :eval_test_comparison)
+    using Test: eval_test_comparison
+end
 
 "A cunning hack to carry extra message along with the original expression in a test"
 struct ExprAndMsg


### PR DESCRIPTION
Julia 1.13 refactored Test internals so that `get_test_result` now generates
code referencing `eval_test_function` (for plain function calls) and
`eval_test_comparison` (for comparison expressions) instead of `eval_test`.
These symbols must be imported into EnzymeTestUtils so that the code generated
by the `@test_msg` macro can resolve them. `@static if isdefined` guards
preserve compatibility with older Julia versions.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
