### PR TITLE
Compiler.deferred_codegen: hide ccall behind @generated shell (#3091)

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7462,7 +7462,20 @@ end
     @nospecialize(strongzero::Val)
 )
     id = deferred_id_codegen(fa, a, tt, mode, width, modifiedbetween, returnprimal, shadowinit, expectedtapetype, erriffuncwritten, runtimeactivity, strongzero)
-    ccall("extern deferred_codegen", llvmcall, Ptr{Cvoid}, (UInt,), id)
+    return _deferred_codegen_call(Val(id))
+end
+
+# `@generated` shell so the `ccall("extern deferred_codegen", …)` body
+# isn't a static method body that AOT despecialization
+# (sysimage `compile=all`, juliac, PrecompileTools) trips on — fixes
+# EnzymeAD/Enzyme.jl#3091. Same pattern as
+# `GPUCompiler.deferred_codegen(::Val{ft}, ::Val{tt})`.
+@generated function _deferred_codegen_call(::Val{id}) where {id}
+    id_lit = reinterpret(UInt, id)
+    return quote
+        Base.@_inline_meta
+        ccall("extern deferred_codegen", llvmcall, Ptr{Cvoid}, (UInt,), $id_lit)
+    end
 end
 
 include("compiler/reflection.jl")


### PR DESCRIPTION
Fixes #3091.

## Summary

`Compiler.deferred_codegen`'s body was `ccall("extern deferred_codegen", llvmcall, Ptr{Cvoid}, (UInt,), id)`. The `deferred_codegen` symbol is provided at runtime by `GPUCompiler.register_deferred_codegen` (OrcV2 `absolute_symbols`); on JIT this resolves fine, but AOT linkers (sysimage `compile=all`, juliac, PrecompileTools) walk `jl_compile_all_defs` into this body and fail to resolve the undefined symbol, breaking sysimage builds.

Move the ccall into a thin `@generated` helper. `@generated` functions have no static body until something forces a specialization, so AOT walks during precompile have nothing to despecialize unless the user actually invoked the code — the undefined ccall doesn't leak into the sysimage. JIT behavior is unchanged: at each real call site the generator splices `$id` as a literal into the existing `ccall("extern deferred_codegen", llvmcall, …)`, producing the same IR the old code did.

Mirrors [`GPUCompiler.deferred_codegen(::Val{ft}, ::Val{tt})`](https://github.com/JuliaGPU/GPUCompiler.jl/blob/master/src/driver.jl)'s pattern, which avoids the same issue by keeping its `ccall("extern …)` body behind a generator.

## Test plan

- [ ] CI — Runic formatting, build, unit tests
- [ ] Verified locally on Julia 1.12:
  - `PackageCompiler.create_sysimage([:Enzyme]; incremental=false)` (the AOT path that originally broke) succeeds ✓
  - `nm -D` on the resulting sysimage: `deferred_codegen` is no longer in undefined symbols (only `gpu_malloc`/`gpu_report_oom` from [JuliaGPU/GPUCompiler.jl#611](https://github.com/JuliaGPU/GPUCompiler.jl/issues/611) remain — already fixed in [JuliaGPU/GPUCompiler.jl#808](https://github.com/JuliaGPU/GPUCompiler.jl/pull/808) upstream, out of scope) ✓
  - `Enzyme.autodiff(Reverse, x³, Active(2.0))` → `(12.0,)` ✓
  - Higher-order forward-over-reverse HVP (`test/advanced.jl:1535`, the test the previous attempt regressed) → `[-1.0]` ✓
  - Full `basic` test pattern: 294/294 ✓
  - Full `advanced` test pattern: 221 pass + 2 pre-existing broken ✓

## Files

| File | Change |
|---|---|
| `src/compiler.jl` | Wrap the existing 12-arg `deferred_codegen` body to delegate to a `@generated _deferred_codegen_call(::Val{id})` helper. Helper splices `id` as a literal into the existing `ccall("extern deferred_codegen", llvmcall, …)`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)