### PR TITLE
EnzymeRules: bind free TypeVars in `has_{f,r}rule_from_sig` query type

### DIFF
--- a/lib/EnzymeCore/src/rules.jl
+++ b/lib/EnzymeCore/src/rules.jl
@@ -332,35 +332,30 @@ end
     return augmented_rule_return_type(rct, RT.parameters[1])
 end
 
-function _annotate(@nospecialize(T))
+function _annotate(@nospecialize(T), tvars::Vector{TypeVar})
     if isvarargtype(T)
         VA = T
-        T = _annotate(Core.Compiler.unwrapva(VA))
-        if isdefined(VA, :N)
-            return Vararg{T, VA.N}
-        else
-            return Vararg{T}
-        end
-    else
-        return TypeVar(gensym(), Annotation{T})
+        T = _annotate(Core.Compiler.unwrapva(VA), tvars)
+        return isdefined(VA, :N) ? Vararg{T, VA.N} : Vararg{T}
     end
+    tv = TypeVar(gensym(), Annotation{T})
+    push!(tvars, tv)
+    return tv
 end
 function _annotate_tt(@nospecialize(TT0))
     TT = Base.unwrap_unionall(TT0)
-    ft = TT.parameters[1]
-    tt = []
-    for TTp in TT.parameters[2:end]
-        push!(tt, _annotate(Base.rewrap_unionall(TTp, TT0)))
-    end
-    return ft, tt
+    ft = Base.rewrap_unionall(TT.parameters[1], TT0)
+    tvars = TypeVar[]
+    tt = Any[_annotate(Base.rewrap_unionall(TTp, TT0), tvars) for TTp in TT.parameters[2:end]]
+    return ft, tt, tvars
 end
 
 function has_frule_from_sig(@nospecialize(TT);
                             world::UInt=Base.get_world_counter(),
                             method_table::Union{Nothing,Core.Compiler.MethodTableView}=nothing,
                             caller::Union{Nothing,Core.MethodInstance}=nothing)::Bool
-    ft, tt = _annotate_tt(TT)
-    TT = Tuple{<:FwdConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}
+    ft, tt, tvars = _annotate_tt(TT)
+    TT = foldr(UnionAll, tvars; init=Tuple{<:FwdConfig, <:Annotation{ft}, Type{<:Annotation}, tt...})
     return isapplicable(forward, TT; world, method_table, caller)
 end
 
@@ -368,8 +363,8 @@ function has_rrule_from_sig(@nospecialize(TT);
                             world::UInt=Base.get_world_counter(),
                             method_table::Union{Nothing,Core.Compiler.MethodTableView}=nothing,
                             caller::Union{Nothing,Core.MethodInstance}=nothing)::Bool
-    ft, tt = _annotate_tt(TT)
-    TT = Tuple{<:RevConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}
+    ft, tt, tvars = _annotate_tt(TT)
+    TT = foldr(UnionAll, tvars; init=Tuple{<:RevConfig, <:Annotation{ft}, Type{<:Annotation}, tt...})
     return isapplicable(augmented_primal, TT; world, method_table, caller)
 end
 

--- a/src/compiler/tfunc.jl
+++ b/src/compiler/tfunc.jl
@@ -3,16 +3,16 @@ import EnzymeCore.EnzymeRules: FwdConfig, RevConfig, forward, augmented_primal, 
 
 function has_frule_from_sig(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
     @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState, partialedge::Bool=true)::Bool
-    ft, tt = _annotate_tt(TT)
-    TT = Tuple{<:FwdConfig,<:Annotation{ft},Type{<:Annotation},tt...}
+    ft, tt, tvars = _annotate_tt(TT)
+    TT = foldr(UnionAll, tvars; init=Tuple{<:FwdConfig,<:Annotation{ft},Type{<:Annotation},tt...})
     fwd_sig = Tuple{typeof(EnzymeRules.forward), <:EnzymeRules.FwdConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
     return isapplicable(interp, forward, TT, sv, fwd_sig)
 end
 
 function has_rrule_from_sig(@nospecialize(interp::Core.Compiler.AbstractInterpreter),
     @nospecialize(TT::Type), sv::Core.Compiler.AbsIntState, partialedge::Bool=true)::Bool
-    ft, tt = _annotate_tt(TT)
-    TT = Tuple{<:RevConfig,<:Annotation{ft},Type{<:Annotation},tt...}
+    ft, tt, tvars = _annotate_tt(TT)
+    TT = foldr(UnionAll, tvars; init=Tuple{<:RevConfig,<:Annotation{ft},Type{<:Annotation},tt...})
     rev_sig = Tuple{typeof(EnzymeRules.augmented_primal), <:EnzymeRules.RevConfig, <:Enzyme.EnzymeCore.Annotation, Type{<:Enzyme.EnzymeCore.Annotation},Vararg{Enzyme.EnzymeCore.Annotation}}
     return isapplicable(interp, augmented_primal, TT, sv, rev_sig)
 end


### PR DESCRIPTION
`_annotate_tt` synthesizes a method-table query like `Tuple{<:FwdConfig, <:Annotation{ft}, Type{<:Annotation}, tt...}` from the caller's signature. The `tt...` entries came from `_annotate`, which builds fresh `TypeVar`s but never wraps them in a `UnionAll`; `ft` (the first parameter of `unwrap_unionall(TT0)`) likewise could contain `TypeVar`s bound by `TT0`'s outer `where` clauses. Both sources left the constructed query with free `TypeVar`s, which used to be tolerated by Julia's subtype/intersection but no longer is under JuliaLang/julia#61876 (free `TypeVar`s now compare by identity, so e.g. `typeintersect(Tuple{…,Const{Float64}}, Tuple{…,V<:Annotation{Float64}})` collapses to `Union{}`).

`_annotate_tt` now returns the new `TypeVar`s alongside `ft, tt`, with `ft` rewrapped in `TT0`'s `UnionAll` chain. Each `has_*_from_sig` caller wraps the constructed query in a `UnionAll` per fresh `TypeVar` via `foldr(UnionAll, …)`. The internal callers in `Enzyme.Compiler.tfunc` are updated to the new return shape.

The behavior of free TypeVars in subtyping was previously undefined (in effect a bug); JuliaLang/julia#61876 makes them well-defined singleton identities, which is what surfaces this latent issue.

This change was AI-generated and should be reviewed carefully before merging.