### PR TITLE
Fix jvp again and add more tests

### DIFF
--- a/lib/EnzymeTestUtils/src/finite_difference_calls.jl
+++ b/lib/EnzymeTestUtils/src/finite_difference_calls.jl
@@ -71,7 +71,11 @@ function j′vp(fdm, f_vec, ȳ, x)
         end
     end
   end
-  mat = isempty(ẏs) ? similar(x, 0) : transpose(reduce(hcat, ẏs))
+  mat = if isempty(ẏs)
+          similar(x, 0, length(ȳ))
+        else
+          transpose(reduce(hcat, ẏs))
+        end
   result = zero(x)
   for i in 1:length(ȳ)
     tp = @inbounds ȳ[i] 

--- a/lib/EnzymeTestUtils/test/test_fd.jl
+++ b/lib/EnzymeTestUtils/test/test_fd.jl
@@ -7,4 +7,8 @@ using FiniteDifferences
     # we can make f_vec here identity since it cannot be
     # reached if x is itself empty
     @test isempty(j′vp(FiniteDifferences.central_fdm(5, 1), identity, Float32[], Float32[]))
+    # test also the real case
+    @test isempty(j′vp(FiniteDifferences.central_fdm(5, 1), identity, Float32[0.26], Float32[]))
+    # test also the complex case
+    @test isempty(j′vp(FiniteDifferences.central_fdm(5, 1), identity, Float32[0.26, 0.14], Float32[]))
 end


### PR DESCRIPTION
Sorry this one is 100% on me. The `similar(x, 0)` thing doesn't work if `ȳ` is not empty (e.g. if the underlying function returns a scalar), that's now fixed, and I've added tests to catch this in the future