### PR TITLE
Add linalg support via GPUArrays extension

### DIFF
--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -2,7 +2,8 @@ module EnzymeGPUArraysCoreExt
 
 using GPUArraysCore
 using Enzyme
-using LinearAlgebra: LinearAlgebra, mul!, dot, Transpose, Adjoint, adjoint
+using LinearAlgebra: LinearAlgebra, mul!, dot, Transpose, Adjoint, adjoint,
+    UpperTriangular, LowerTriangular, Symmetric, Hermitian, triu, tril, diag, diagind
 using Enzyme.EnzymeCore: EnzymeCore
 using Enzyme.EnzymeCore.EnzymeRules:
     EnzymeRules,
@@ -54,13 +55,65 @@ end
 _project(::Type{<:Real}, x) = real(x)
 _project(::Type, x) = x
 
-# A GPU array or a (lazy) transpose/adjoint of one; the operand types that show
-# up in `A * B` matmuls, including `transpose(X) * y`.
+# A GPU array, or a structured/lazy wrapper of one; the operand types that show
+# up in `A * B` matmuls (`transpose(X) * y`, `Symmetric(A) * x`, ...). CUBLAS /
+# rocBLAS dispatch these to specialized kernels (trmm/symm/hemm), and the reverse
+# pass projects the cotangent back onto each wrapper's stored entries (see
+# `_accumulate_operand!`). UnitTriangular is intentionally excluded: its diagonal
+# is structurally fixed, so it cannot represent a tangent/cotangent.
 const MaybeWrappedGPU = Union{
     AbstractGPUArray,
     Transpose{<:Any, <:AbstractGPUArray},
     Adjoint{<:Any, <:AbstractGPUArray},
+    UpperTriangular{<:Any, <:AbstractGPUArray},
+    LowerTriangular{<:Any, <:AbstractGPUArray},
+    Symmetric{<:Any, <:AbstractGPUArray},
+    Hermitian{<:Any, <:AbstractGPUArray},
 }
+
+#=
+Accumulate `factor .* G` into the shadow `s` of a matmul operand, where `G` is
+the dense cotangent (`dY·B'` or `A'·dY`). For dense / transpose / adjoint shadows
+the cotangent is added directly. For structured shadows only the stored entries
+are free parameters, so `G` is projected onto that structure:
+
+  UpperTriangular  : keep `triu(G)`
+  LowerTriangular  : keep `tril(G)`
+  Symmetric(uplo)  : off-diagonal (i,j) collects `G[i,j] + G[j,i]`, diagonal `G[i,i]`
+  Hermitian(uplo)  : same with conjugation; the diagonal is real
+=#
+@inline function _accumulate_operand!(s, G, factor)
+    s .+= factor .* G
+    return nothing
+end
+
+function _accumulate_operand!(s::UpperTriangular, G, factor)
+    parent(s) .+= factor .* triu(G)
+    return nothing
+end
+
+function _accumulate_operand!(s::LowerTriangular, G, factor)
+    parent(s) .+= factor .* tril(G)
+    return nothing
+end
+
+function _accumulate_operand!(s::Symmetric, G, factor)
+    p = parent(s)
+    H = G .+ transpose(G)
+    p .+= factor .* (s.uplo == 'U' ? triu(H, 1) : tril(H, -1))
+    dg = view(p, diagind(p))
+    dg .+= factor .* diag(G)
+    return nothing
+end
+
+function _accumulate_operand!(s::Hermitian, G, factor)
+    p = parent(s)
+    H = G .+ adjoint(G)
+    p .+= factor .* (s.uplo == 'U' ? triu(H, 1) : tril(H, -1))
+    dg = view(p, diagind(p))
+    dg .+= factor .* real.(diag(G))
+    return nothing
+end
 
 #=
 mul!(C, A, B, α, β):  C = α·A·B + β·C₀
@@ -190,10 +243,10 @@ function EnzymeRules.reverse(
             Base.@_inline_meta
             dC = _bget(C.dval, Val(N), i)
             if !(A isa Const)
-                _bget(A.dval, Val(N), i) .+= αc .* (dC * adjoint(Bval))
+                _accumulate_operand!(_bget(A.dval, Val(N), i), dC * adjoint(Bval), αc)
             end
             if !(B isa Const)
-                _bget(B.dval, Val(N), i) .+= αc .* (adjoint(Aval) * dC)
+                _accumulate_operand!(_bget(B.dval, Val(N), i), adjoint(Aval) * dC, αc)
             end
             dC .*= βc
             nothing
@@ -291,10 +344,10 @@ function EnzymeRules.reverse(
             Base.@_inline_meta
             dYi = _bget(dY, Val(N), i)
             if !(A isa Const)
-                _bget(A.dval, Val(N), i) .+= dYi * adjoint(cache_B)
+                _accumulate_operand!(_bget(A.dval, Val(N), i), dYi * adjoint(cache_B), true)
             end
             if !(B isa Const)
-                _bget(B.dval, Val(N), i) .+= adjoint(cache_A) * dYi
+                _accumulate_operand!(_bget(B.dval, Val(N), i), adjoint(cache_A) * dYi, true)
             end
             fill!(dYi, zero(eltype(dYi)))
             nothing

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -2,6 +2,18 @@ module EnzymeGPUArraysCoreExt
 
 using GPUArraysCore
 using Enzyme
+using LinearAlgebra: LinearAlgebra, mul!, dot, Transpose, Adjoint, adjoint
+using Enzyme.EnzymeCore: EnzymeCore
+using Enzyme.EnzymeCore.EnzymeRules:
+    EnzymeRules,
+    FwdConfig,
+    RevConfig,
+    Annotation,
+    AugmentedReturn,
+    needs_primal,
+    needs_shadow,
+    overwritten,
+    width
 
 function Enzyme.zerosetfn(x::AbstractGPUArray, i::Int)
     res = zero(x)
@@ -33,6 +45,396 @@ end
         @allowscalar @inbounds res[i + start - 1] = 1
         return res
     end
+end
+
+@inline _bget(x, ::Val{1}, ::Int) = x
+@inline _bget(x, ::Val{N}, i::Int) where {N} = x[i]
+
+# Project an accumulated cotangent onto the (possibly real) parameter type.
+_project(::Type{<:Real}, x) = real(x)
+_project(::Type, x) = x
+
+# A GPU array or a (lazy) transpose/adjoint of one; the operand types that show
+# up in `A * B` matmuls, including `transpose(X) * y`.
+const MaybeWrappedGPU = Union{
+    AbstractGPUArray,
+    Transpose{<:Any, <:AbstractGPUArray},
+    Adjoint{<:Any, <:AbstractGPUArray},
+}
+
+#=
+mul!(C, A, B, α, β):  C = α·A·B + β·C₀
+
+JVP:      dC = α·(dA·B + A·dB) + β·dC₀   (+ dα·A·B + dβ·C₀)
+Pullback: dA += conj(α)·dC·B'
+          dB += conj(α)·A'·dC
+          dC := conj(β)·dC                (cotangent w.r.t. C₀)
+          dα  = conj(⟨dC, A·B⟩)
+          dβ  = conj(⟨dC, C₀⟩)
+=#
+
+function EnzymeRules.forward(
+        config::FwdConfig,
+        func::Const{typeof(mul!)},
+        RT::Type{<:Annotation},
+        C::Annotation{<:AbstractGPUArray},
+        A::Annotation,
+        B::Annotation,
+        α::Annotation{<:Number},
+        β::Annotation{<:Number},
+    )
+    N = width(config)
+    if !(C isa Const)
+        # Update each output tangent from the old tangent values
+        # before the in-place primal overwrites C.val.
+        ntuple(Val(N)) do b
+            Base.@_inline_meta
+            dC = _bget(C.dval, Val(N), b)
+            tmp = β.val .* dC
+            if !(A isa Const)
+                tmp = tmp .+ α.val .* (_bget(A.dval, Val(N), b) * B.val)
+            end
+            if !(B isa Const)
+                tmp = tmp .+ α.val .* (A.val * _bget(B.dval, Val(N), b))
+            end
+            if !(α isa Const)
+                tmp = tmp .+ _bget(α.dval, Val(N), b) .* (A.val * B.val)
+            end
+            if !(β isa Const)
+                tmp = tmp .+ _bget(β.dval, Val(N), b) .* C.val
+            end
+            copyto!(dC, tmp)
+            nothing
+        end
+    end
+
+    func.val(C.val, A.val, B.val, α.val, β.val)
+
+    if needs_primal(config) && needs_shadow(config)
+        return N == 1 ? Duplicated(C.val, C.dval) : BatchDuplicated(C.val, C.dval)
+    elseif needs_shadow(config)
+        return C.dval
+    elseif needs_primal(config)
+        return C.val
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(mul!)},
+        ::Type{RT},
+        C::Annotation{<:AbstractGPUArray},
+        A::Annotation,
+        B::Annotation,
+        α::Annotation{<:Number},
+        β::Annotation{<:Number},
+    ) where {RT}
+    # C₀ is needed for dβ; copy it before the primal overwrites C.val.
+    cache_C = !(β isa Const) ? copy(C.val) : nothing
+
+    func.val(C.val, A.val, B.val, α.val, β.val)
+
+    primal = needs_primal(config) ? C.val : nothing
+    shadow = needs_shadow(config) ? C.dval : nothing
+
+    # A is needed for dB, B for dA; cache them only if overwritten before reverse.
+    cache_A = (overwritten(config)[3] && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
+    cache_B = (overwritten(config)[4] && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
+    cache_α = !(α isa Const) ? A.val * B.val : nothing
+
+    return AugmentedReturn(primal, shadow, (cache_C, cache_A, cache_B, cache_α))
+end
+
+function EnzymeRules.reverse(
+        config::RevConfig,
+        func::Const{typeof(mul!)},
+        ::Type{RT},
+        tape,
+        C::Annotation{<:AbstractGPUArray},
+        A::Annotation,
+        B::Annotation,
+        α::Annotation{<:Number},
+        β::Annotation{<:Number},
+    ) where {RT}
+    cache_C, cache_A, cache_B, cache_α = tape
+    Cval = cache_C !== nothing ? cache_C : C.val
+    Aval = cache_A !== nothing ? cache_A : A.val
+    Bval = cache_B !== nothing ? cache_B : B.val
+    N = width(config)
+
+    if !(C isa Const)
+        dα = if !(α isa Const)
+            if N == 1
+                _project(typeof(α.val), conj(dot(C.dval, cache_α)))
+            else
+                ntuple(i -> _project(typeof(α.val), conj(dot(C.dval[i], cache_α))), Val(N))
+            end
+        else
+            nothing
+        end
+        dβ = if !(β isa Const)
+            if N == 1
+                _project(typeof(β.val), conj(dot(C.dval, Cval)))
+            else
+                ntuple(i -> _project(typeof(β.val), conj(dot(C.dval[i], Cval))), Val(N))
+            end
+        else
+            nothing
+        end
+
+        αc = conj(α.val)
+        βc = conj(β.val)
+        ntuple(Val(N)) do i
+            Base.@_inline_meta
+            dC = _bget(C.dval, Val(N), i)
+            if !(A isa Const)
+                _bget(A.dval, Val(N), i) .+= αc .* (dC * adjoint(Bval))
+            end
+            if !(B isa Const)
+                _bget(B.dval, Val(N), i) .+= αc .* (adjoint(Aval) * dC)
+            end
+            dC .*= βc
+            nothing
+        end
+    else
+        dα = !(α isa Const) ? (N == 1 ? zero(α.val) : ntuple(Returns(zero(α.val)), Val(N))) : nothing
+        dβ = !(β isa Const) ? (N == 1 ? zero(β.val) : ntuple(Returns(zero(β.val)), Val(N))) : nothing
+    end
+
+    return (nothing, nothing, nothing, dα, dβ)
+end
+
+#=
+A * B:  allocating matmul (matrix or matrix-vector)
+
+Unlike the in-place `mul!` rule above, `*` allocates its result, so the rule
+owns the output shadow: `augmented_primal` returns a zeroed shadow and
+`reverse` zeroes it again after reading. Without this, the freshly-allocated
+result's shadow is uninitialized and downstream `+=` accumulates onto garbage.
+
+JVP:      dY = dA·B + A·dB
+Pullback: dA += dY·B'
+          dB += A'·dY
+=#
+
+# dY_i = dA_i·B + A·dB_i  (factored out so inference sees a concrete array type)
+@inline function _matmul_jvp(A::Annotation, B::Annotation, ::Val{N}, i::Int) where {N}
+    if A isa Const
+        return A.val * _bget(B.dval, Val(N), i)
+    elseif B isa Const
+        return _bget(A.dval, Val(N), i) * B.val
+    else
+        return _bget(A.dval, Val(N), i) * B.val .+ A.val * _bget(B.dval, Val(N), i)
+    end
+end
+
+function EnzymeRules.forward(
+        config::FwdConfig,
+        func::Const{typeof(*)},
+        RT::Type{<:Annotation},
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
+    )
+    if RT <: Const
+        return needs_primal(config) ? A.val * B.val : nothing
+    end
+
+    N = width(config)
+    if N == 1
+        dY = _matmul_jvp(A, B, Val(1), 1)
+        return RT <: DuplicatedNoNeed ? dY : Duplicated(A.val * B.val, dY)
+    else
+        dY = ntuple(i -> _matmul_jvp(A, B, Val(N), i), Val(N))
+        return RT <: BatchDuplicatedNoNeed ? dY : BatchDuplicated(A.val * B.val, dY)
+    end
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(*)},
+        ::Type{RT},
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
+    ) where {RT}
+    Y = A.val * B.val
+    primal = needs_primal(config) ? Y : nothing
+
+    N = width(config)
+    dY = if RT <: Duplicated || RT <: DuplicatedNoNeed
+        zero(Y)
+    elseif RT <: BatchDuplicated || RT <: BatchDuplicatedNoNeed
+        ntuple(_ -> zero(Y), Val(N))
+    else
+        nothing
+    end
+
+    cache_A = (overwritten(config)[2] && !(B isa Const)) ? copy(A.val) : A.val
+    cache_B = (overwritten(config)[3] && !(A isa Const)) ? copy(B.val) : B.val
+
+    return AugmentedReturn(primal, dY, (dY, cache_A, cache_B))
+end
+
+function EnzymeRules.reverse(
+        config::RevConfig,
+        func::Const{typeof(*)},
+        ::Type{RT},
+        tape,
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
+    ) where {RT}
+    dY, cache_A, cache_B = tape
+    if dY !== nothing
+        N = width(config)
+        ntuple(Val(N)) do i
+            Base.@_inline_meta
+            dYi = _bget(dY, Val(N), i)
+            if !(A isa Const)
+                _bget(A.dval, Val(N), i) .+= dYi * adjoint(cache_B)
+            end
+            if !(B isa Const)
+                _bget(B.dval, Val(N), i) .+= adjoint(cache_A) * dYi
+            end
+            fill!(dYi, zero(eltype(dYi)))
+            nothing
+        end
+    end
+    return (nothing, nothing)
+end
+
+#=
+dot(a, b):  scalar inner product
+
+JVP:      dr  = ⟨da, b⟩ + ⟨a, db⟩
+Pullback: da += dr̄·b
+          db += dr̄·a   (real convention; targets real GPU workloads)
+=#
+
+function EnzymeRules.forward(
+        config::FwdConfig,
+        func::Const{typeof(dot)},
+        RT::Type{<:Annotation},
+        a::Annotation{<:AbstractGPUArray},
+        b::Annotation{<:AbstractGPUArray},
+    )
+    if needs_shadow(config)
+        N = width(config)
+        z = zero(promote_type(eltype(a.val), eltype(b.val)))
+        if N == 1
+            dr = (a isa Const ? z : dot(a.dval, b.val)) + (b isa Const ? z : dot(a.val, b.dval))
+            return needs_primal(config) ? Duplicated(dot(a.val, b.val), dr) : dr
+        else
+            dr = ntuple(
+                i -> (a isa Const ? z : dot(_bget(a.dval, Val(N), i), b.val)) +
+                    (b isa Const ? z : dot(a.val, _bget(b.dval, Val(N), i))),
+                Val(N),
+            )
+            return needs_primal(config) ? BatchDuplicated(dot(a.val, b.val), dr) : dr
+        end
+    elseif needs_primal(config)
+        return dot(a.val, b.val)
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(dot)},
+        ::Type,
+        a::Annotation{<:AbstractGPUArray},
+        b::Annotation{<:AbstractGPUArray},
+    )
+    primal = needs_primal(config) ? dot(a.val, b.val) : nothing
+    cache_a = (overwritten(config)[2] && !(b isa Const)) ? copy(a.val) : nothing
+    cache_b = (overwritten(config)[3] && !(a isa Const)) ? copy(b.val) : nothing
+    return AugmentedReturn(primal, nothing, (cache_a, cache_b))
+end
+
+function EnzymeRules.reverse(
+        config::RevConfig,
+        func::Const{typeof(dot)},
+        dret,
+        tape,
+        a::Annotation{<:AbstractGPUArray},
+        b::Annotation{<:AbstractGPUArray},
+    )
+    if !(dret isa Const)
+        cache_a, cache_b = tape
+        av = cache_a !== nothing ? cache_a : a.val
+        bv = cache_b !== nothing ? cache_b : b.val
+        N = width(config)
+        ntuple(Val(N)) do i
+            Base.@_inline_meta
+            dr = _bget(dret.val, Val(N), i)
+            if !(a isa Const)
+                _bget(a.dval, Val(N), i) .+= dr .* bv
+            end
+            if !(b isa Const)
+                _bget(b.dval, Val(N), i) .+= dr .* av
+            end
+            nothing
+        end
+    end
+    return (nothing, nothing)
+end
+
+#=
+sum(x):  scalar reduction
+
+JVP:      dr  = sum(dx)
+Pullback: dx += dr̄        (scalar broadcast over every element)
+=#
+
+function EnzymeRules.forward(
+        config::FwdConfig,
+        func::Const{typeof(sum)},
+        RT::Type{<:Annotation},
+        x::Annotation{<:AbstractGPUArray},
+    )
+    if needs_shadow(config)
+        N = width(config)
+        if N == 1
+            dr = x isa Const ? zero(eltype(x.val)) : sum(x.dval)
+            return needs_primal(config) ? Duplicated(sum(x.val), dr) : dr
+        else
+            dr = ntuple(i -> x isa Const ? zero(eltype(x.val)) : sum(_bget(x.dval, Val(N), i)), Val(N))
+            return needs_primal(config) ? BatchDuplicated(sum(x.val), dr) : dr
+        end
+    elseif needs_primal(config)
+        return sum(x.val)
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(sum)},
+        ::Type,
+        x::Annotation{<:AbstractGPUArray},
+    )
+    primal = needs_primal(config) ? sum(x.val) : nothing
+    return AugmentedReturn(primal, nothing, nothing)
+end
+
+function EnzymeRules.reverse(
+        config::RevConfig,
+        func::Const{typeof(sum)},
+        dret,
+        tape,
+        x::Annotation{<:AbstractGPUArray},
+    )
+    if !(dret isa Const) && !(x isa Const)
+        N = width(config)
+        ntuple(Val(N)) do i
+            Base.@_inline_meta
+            _bget(x.dval, Val(N), i) .+= _bget(dret.val, Val(N), i)
+            nothing
+        end
+    end
+    return (nothing,)
 end
 
 end # module

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -78,8 +78,8 @@ function EnzymeRules.forward(
         func::Const{typeof(mul!)},
         RT::Type{<:Annotation},
         C::Annotation{<:AbstractGPUArray},
-        A::Annotation,
-        B::Annotation,
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
         α::Annotation{<:Number},
         β::Annotation{<:Number},
     )
@@ -126,8 +126,8 @@ function EnzymeRules.augmented_primal(
         func::Const{typeof(mul!)},
         ::Type{RT},
         C::Annotation{<:AbstractGPUArray},
-        A::Annotation,
-        B::Annotation,
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
         α::Annotation{<:Number},
         β::Annotation{<:Number},
     ) where {RT}
@@ -153,8 +153,8 @@ function EnzymeRules.reverse(
         ::Type{RT},
         tape,
         C::Annotation{<:AbstractGPUArray},
-        A::Annotation,
-        B::Annotation,
+        A::Annotation{<:MaybeWrappedGPU},
+        B::Annotation{<:MaybeWrappedGPU},
         α::Annotation{<:Number},
         β::Annotation{<:Number},
     ) where {RT}

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -55,8 +55,22 @@ end
 _project(::Type{<:Real}, x) = real(x)
 _project(::Type, x) = x
 
-# A GPU array, or a structured/lazy wrapper of one; the operand types that show
-# up in `A * B` matmuls (`transpose(X) * y`, `Symmetric(A) * x`, ...). CUBLAS /
+#=
+Cotangent for an `Active` scalar argument: a single value at width 1, an
+N-tuple when batched. `f(i)` gives the raw (possibly complex) contribution for
+batch element `i`, which is then projected onto `T`, the scalar's own type.
+
+Dispatching on `Val{N}` matters: branching on `N == 1` at run time makes the
+result infer as `Any`, and reverse rules must return exactly the argument's
+type (`Tuple{…, Float32, …}`), so an inexact match is a hard error.
+=#
+@inline _dscalar(::Val{1}, ::Type{T}, f::F) where {T, F} = _project(T, f(1))::T
+@inline function _dscalar(::Val{N}, ::Type{T}, f::F) where {N, T, F}
+    return ntuple(i -> _project(T, f(i))::T, Val(N))
+end
+
+# A GPU array, or a structured/lazy wrapper of one; the `mul!` operand types that
+# show up in matmuls (`transpose(X) * y`, `Symmetric(A) * x`, ...). CUBLAS /
 # rocBLAS dispatch these to specialized kernels (trmm/symm/hemm), and the reverse
 # pass projects the cotangent back onto each wrapper's stored entries (see
 # `_accumulate_operand!`). UnitTriangular is intentionally excluded: its diagonal
@@ -218,24 +232,12 @@ function EnzymeRules.reverse(
     N = width(config)
 
     if !(C isa Const)
-        dα = if !(α isa Const)
-            if N == 1
-                _project(typeof(α.val), conj(dot(C.dval, cache_α)))
-            else
-                ntuple(i -> _project(typeof(α.val), conj(dot(C.dval[i], cache_α))), Val(N))
-            end
-        else
+        dα = !(α isa Const) ?
+            _dscalar(Val(N), typeof(α.val), i -> conj(dot(_bget(C.dval, Val(N), i), cache_α))) :
             nothing
-        end
-        dβ = if !(β isa Const)
-            if N == 1
-                _project(typeof(β.val), conj(dot(C.dval, Cval)))
-            else
-                ntuple(i -> _project(typeof(β.val), conj(dot(C.dval[i], Cval))), Val(N))
-            end
-        else
+        dβ = !(β isa Const) ?
+            _dscalar(Val(N), typeof(β.val), i -> conj(dot(_bget(C.dval, Val(N), i), Cval))) :
             nothing
-        end
 
         αc = conj(α.val)
         βc = conj(β.val)
@@ -252,8 +254,8 @@ function EnzymeRules.reverse(
             nothing
         end
     else
-        dα = !(α isa Const) ? (N == 1 ? zero(α.val) : ntuple(Returns(zero(α.val)), Val(N))) : nothing
-        dβ = !(β isa Const) ? (N == 1 ? zero(β.val) : ntuple(Returns(zero(β.val)), Val(N))) : nothing
+        dα = !(α isa Const) ? _dscalar(Val(N), typeof(α.val), _ -> zero(α.val)) : nothing
+        dβ = !(β isa Const) ? _dscalar(Val(N), typeof(β.val), _ -> zero(β.val)) : nothing
     end
 
     return (nothing, nothing, nothing, dα, dβ)
@@ -266,6 +268,16 @@ Unlike the in-place `mul!` rule above, `*` allocates its result, so the rule
 owns the output shadow: `augmented_primal` returns a zeroed shadow and
 `reverse` zeroes it again after reading. Without this, the freshly-allocated
 result's shadow is uninitialized and downstream `+=` accumulates onto garbage.
+
+`A * B` does lower to `mul!(similar(...), A, B, true, false)`, so it is tempting
+to drop this rule and let the `mul!` one above cover it. That is not safe: it
+holds for CuArrays (every pattern covered below was re-checked on a GPU with
+this rule removed, and all still passed) but NOT for AbstractGPUArray in
+general. On JLArrays, dropping it makes `A * UpperTriangular(X)` return a wrong
+cotangent, because the shadow of the array `*` allocates via `similar` is not
+zeroed -- whereas the same operands passed to an explicit 5-arg `mul!` are
+differentiated correctly. So the allocation, not the multiply, is what this
+rule is really for.
 
 JVP:      dY = dA·B + A·dB
 Pullback: dA += dY·B'
@@ -357,11 +369,15 @@ function EnzymeRules.reverse(
 end
 
 #=
-dot(a, b):  scalar inner product
+dot(a, b) = Σ conj(aᵢ)·bᵢ :  scalar inner product
 
 JVP:      dr  = ⟨da, b⟩ + ⟨a, db⟩
-Pullback: da += dr̄·b
-          db += dr̄·a   (real convention; targets real GPU workloads)
+Pullback: da += conj(dr)·b   (`a` enters conjugated)
+          db += dr·a
+
+The conjugation on `da` is a no-op for real eltypes but required for complex
+ones; both directions are checked against Enzyme's own (rule-free) CPU path in
+test/ext/jlarrays.jl.
 =#
 
 function EnzymeRules.forward(
@@ -422,7 +438,9 @@ function EnzymeRules.reverse(
             Base.@_inline_meta
             dr = _bget(dret.val, Val(N), i)
             if !(a isa Const)
-                _bget(a.dval, Val(N), i) .+= dr .* bv
+                # `a` enters `dot` conjugated, so its cotangent picks up conj(dr).
+                # No-op for real eltypes.
+                _bget(a.dval, Val(N), i) .+= conj(dr) .* bv
             end
             if !(b isa Const)
                 _bget(b.dval, Val(N), i) .+= dr .* av

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -50,9 +50,28 @@ end
 @inline _bget(x, ::Val{1}, ::Int) = x
 @inline _bget(x, ::Val{N}, i::Int) where {N} = x[i]
 
-# Project an accumulated cotangent onto the (possibly real) parameter type.
-_project(::Type{<:Real}, x) = real(x)
-_project(::Type, x) = x
+#=
+The cotangent of an `Active` return. Batching splits this differently from a
+shadow: it is one `Active` at width 1 but an N-tuple *of* `Active`s above it,
+not an `Active` holding a tuple, so the unwrap has to happen per element.
+=#
+@inline _dret(dret, w::Val, i::Int) = _bget(dret, w, i).val
+
+#=
+An operand contributes no cotangent when it is `Const`, and also when runtime
+activity hands us a `Duplicated` whose shadow is the primal itself -- writing to
+that would corrupt the value the augmented pass just computed.
+=#
+@inline _isconst(_, ::Const) = true
+@inline _isconst(config, x::Annotation) =
+    EnzymeRules.runtime_activity(config) && x.dval === x.val
+
+# Every rule here returns its output argument and stashes a tape.
+@inline _augreturn(config, out::Annotation, tape) = AugmentedReturn(
+    needs_primal(config) ? out.val : nothing,
+    needs_shadow(config) ? out.dval : nothing,
+    tape,
+)
 
 #=
 Cotangent of an `Active` scalar argument: `f(i)`'s raw (possibly complex)
@@ -60,9 +79,9 @@ contribution projected onto `T`, bare at width 1 and an N-tuple when batched.
 Dispatch on `Val{N}` rather than branching on `N == 1`, which infers as `Any` --
 a reverse rule that misses the argument's exact type is a hard error.
 =#
-@inline _dscalar(::Val{1}, ::Type{T}, f::F) where {T, F} = _project(T, f(1))::T
+@inline _dscalar(::Val{1}, ::Type{T}, f::F) where {T, F} = Enzyme._project(T, f(1))::T
 @inline function _dscalar(::Val{N}, ::Type{T}, f::F) where {N, T, F}
-    return ntuple(i -> _project(T, f(i))::T, Val(N))
+    return ntuple(i -> Enzyme._project(T, f(i))::T, Val(N))
 end
 
 #=
@@ -105,103 +124,79 @@ else
         LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, α, β)
 end
 
+#=
+The ops a char can name -- identity, transpose, conj, adjoint -- form a group
+under composition, so write one as the pair of flags (transposed, conjugated)
+and the pullbacks stop needing a lookup table: `adjoint` flips both flags,
+`transpose` flips the first, and applying either to a product also swaps its two
+operands. `wrap`'s chars cover three of the four combinations; the fourth, a
+bare conj, has to be materialized (`_opdata`), and only for complex eltypes.
+=#
 @inline _plain(t::AbstractChar) = (k = uppercase(t); k == 'N' || k == 'T' || k == 'C')
+@inline _opflags(t::AbstractChar) =
+    (k = uppercase(t); k == 'N' ? (false, false) : k == 'T' ? (true, false) : (true, true))
+@inline _adjop(f::Tuple{Bool, Bool}) = (!f[1], !f[2])
+@inline _transop(f::Tuple{Bool, Bool}) = (!f[1], f[2])
+@inline _opchar(f::Tuple{Bool, Bool}) = f[1] ? (f[2] ? 'C' : 'T') : 'N'
+@inline _opdata(X, f::Tuple{Bool, Bool}) = (!f[1] && f[2]) ? _conj(X) : X
 
 #=
-Accumulate `factor .* G` into the shadow of an operand the primal read as
-`wrap(X, t)`, `G` being the cotangent of that wrapped operand. 'T'/'C' only
+Accumulate `G` into the shadow of an operand the primal read as `wrap(X, t)`,
+`G` being the (already scaled) cotangent of that wrapped operand. 'T'/'C' only
 transpose it. 'S'/'H' need a projection: one triangle is stored and each of its
 entries feeds two positions of the wrapped matrix, so (i,j) collects
 G[i,j] + G[j,i] and the diagonal collects G[i,i]. Hermitian keeps only the real
 part there, its diagonal being real by construction.
+
+`G` has to arrive scaled by conj(α) rather than scaled here, because the
+Hermitian projection is not linear in that factor: it conjugates one of the two
+terms it sums, and takes the real part of the diagonal.
 =#
-function _accumulate_operand!(dX, t::AbstractChar, G, factor)
+function _accumulate_operand!(dX, t::AbstractChar, G)
     kind = uppercase(t)
     if kind == 'N'
-        dX .+= factor .* G
+        dX .+= G
     elseif kind == 'T'
-        dX .+= factor .* transpose(G)
+        dX .+= transpose(G)
     elseif kind == 'C'
-        dX .+= factor .* adjoint(G)
+        dX .+= adjoint(G)
     else
         H = kind == 'S' ? G .+ transpose(G) : G .+ adjoint(G)
-        dX .+= factor .* (_stored_upper(t) ? triu(H, 1) : tril(H, -1))
+        dX .+= _stored_upper(t) ? triu(H, 1) : tril(H, -1)
         dg = view(dX, diagind(dX))
-        dg .+= factor .* (kind == 'S' ? diag(G) : real.(diag(G)))
+        dg .+= kind == 'S' ? diag(G) : real.(diag(G))
     end
     return nothing
+end
+
+# Scale a cotangent we just allocated, in place, skipping the no-op α = 1 case.
+@inline function _scale!(G, factor)
+    isone(factor) || (G .*= factor)
+    return G
 end
 
 #=
-`dA += factor·dC·op(B)'`, projected back through op(A).
+`dX += factor · op(L, fL) · op(R, fR)`, projected back through the operand's own
+op `tX`. Both cotangents of a matmul have that shape -- `dC·op(B)'` for the left
+operand, `op(A)'·dC` for the right -- so both go back through
+`generic_matmatmul!` with β = 1, which is the accumulation: no temporary, no
+elementwise pass. Undoing `tX` rewrites the product rather than transposing its
+result, which is where the operand swap comes from.
 
-Both halves of that are themselves a matmul with a transposition, so as long as
-'N'/'T'/'C' describe both operands the whole thing is one more trip through
-`generic_matmatmul!` with β = 1: the accumulation is the rule's own β argument,
-no temporary and no elementwise pass. Which chars come out of rearranging
-`(dC·op(B)')` into a single gemm:
-
-    tA = 'N'    factor·dC·op(B)'          op(B)' is 'C'/conj/'N' for tB N/T/C
-    tA = 'T'    factor·conj(op(B))·dCᵀ    conj(op(B)) is conj/'C'/'T'
-    tA = 'C'    factor·op(B)·dC'          op(B) is tB itself
-
-The two `conj` slots are the only ones no char covers, and they cost a
-materialized conjugate for complex eltypes only. Symmetric/Hermitian can't play:
-`adjoint(Symmetric(B))` is not a gemm operand and the cotangent needs projecting
-onto a triangle either way, so those fall back to forming `G` and accumulating.
+Symmetric/Hermitian can't play: `adjoint(Symmetric(B))` is not a gemm operand,
+and the cotangent has to be projected onto a triangle regardless, so those form
+the product and hand it to `_accumulate_operand!`.
 =#
-function _pullback_left!(dA, tA::AbstractChar, tB::AbstractChar, dC, B, factor)
-    if !(_plain(tA) && _plain(tB))
-        _accumulate_operand!(dA, tA, dC * _wrap_adjoint(B, tB), factor)
-    elseif uppercase(tA) == 'N'
-        kb = uppercase(tB)
-        if kb == 'N'
-            _gemm!(dA, 'N', 'C', dC, B, factor, true)
-        elseif kb == 'C'
-            _gemm!(dA, 'N', 'N', dC, B, factor, true)
-        else
-            _gemm!(dA, 'N', 'N', dC, _conj(B), factor, true)
-        end
-    elseif uppercase(tA) == 'T'
-        kb = uppercase(tB)
-        if kb == 'N'
-            _gemm!(dA, 'N', 'T', _conj(B), dC, factor, true)
-        elseif kb == 'T'
-            _gemm!(dA, 'C', 'T', B, dC, factor, true)
-        else
-            _gemm!(dA, 'T', 'T', B, dC, factor, true)
-        end
+function _pullback!(dX, tX::AbstractChar, L, fL, R, fR, factor)
+    kind = uppercase(tX)
+    if kind == 'N'
+        _gemm!(dX, _opchar(fL), _opchar(fR), _opdata(L, fL), _opdata(R, fR), factor, true)
+    elseif kind == 'T'
+        gL, gR = _transop(fL), _transop(fR)
+        _gemm!(dX, _opchar(gR), _opchar(gL), _opdata(R, gR), _opdata(L, gL), factor, true)
     else
-        _gemm!(dA, tB, 'C', B, dC, factor, true)
-    end
-    return nothing
-end
-
-# `dB += factor·op(A)'·dC`, projected back through op(B): the mirror of
-# `_pullback_left!`, with the same fallback for Symmetric/Hermitian.
-function _pullback_right!(dB, tA::AbstractChar, tB::AbstractChar, A, dC, factor)
-    if !(_plain(tA) && _plain(tB))
-        _accumulate_operand!(dB, tB, _wrap_adjoint(A, tA) * dC, factor)
-    elseif uppercase(tB) == 'N'
-        ka = uppercase(tA)
-        if ka == 'N'
-            _gemm!(dB, 'C', 'N', A, dC, factor, true)
-        elseif ka == 'C'
-            _gemm!(dB, 'N', 'N', A, dC, factor, true)
-        else
-            _gemm!(dB, 'N', 'N', _conj(A), dC, factor, true)
-        end
-    elseif uppercase(tB) == 'T'
-        ka = uppercase(tA)
-        if ka == 'N'
-            _gemm!(dB, 'T', 'N', dC, _conj(A), factor, true)
-        elseif ka == 'T'
-            _gemm!(dB, 'T', 'C', dC, A, factor, true)
-        else
-            _gemm!(dB, 'T', 'T', dC, A, factor, true)
-        end
-    else
-        _gemm!(dB, 'C', tA, dC, A, factor, true)
+        gL, gR = _adjop(fL), _adjop(fR)
+        _gemm!(dX, _opchar(gR), _opchar(gL), _opdata(R, gR), _opdata(L, gL), factor, true)
     end
     return nothing
 end
@@ -222,8 +217,7 @@ combination:
     dβ  = conj(⟨dC, C₀⟩)
 
 The first two are matmuls with a transposition, so they go back through this
-same function with β = 1 and nothing is accumulated by hand -- see
-`_pullback_left!`.
+same function with β = 1 and nothing is accumulated by hand -- see `_pullback!`.
 
 3-arg `mul!` lands here with α = true, β = false, so `dC` gets zeroed, as it
 must: that form overwrites `C` instead of accumulating into it.
@@ -233,17 +227,20 @@ before that, so the rules are version-gated wrappers over the two helpers below.
 =#
 
 @inline function _matmul_caches(
-        C::Annotation, tA::AbstractChar, tB::AbstractChar, A::Annotation, B::Annotation,
+        config, C::Annotation, tA::AbstractChar, tB::AbstractChar, A::Annotation, B::Annotation,
         ovw_A::Bool, ovw_B::Bool, ::Val{α_active}, ::Val{β_active},
     ) where {α_active, β_active}
     #=
-    dβ needs C₀, dB needs A and dA needs B; copy each only when the reverse pass
-    reads it and something has overwritten it by then.
+    dβ needs C₀, dα the product, dB needs A and dA needs B. A `Const` C means the
+    reverse pass returns early and reads none of them, and `cache_prod` costs a
+    second matmul, so gate everything on the cotangent actually being wanted.
     =#
-    cache_C = β_active ? copy(C.val) : nothing
-    cache_A = (ovw_A && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
-    cache_B = (ovw_B && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
-    cache_prod = α_active ? LinearAlgebra.wrap(A.val, tA) * LinearAlgebra.wrap(B.val, tB) : nothing
+    c_const = _isconst(config, C)
+    cache_C = (β_active && !c_const) ? copy(C.val) : nothing
+    cache_A = (ovw_A && !_isconst(config, B) && !c_const) ? copy(A.val) : nothing
+    cache_B = (ovw_B && !_isconst(config, A) && !c_const) ? copy(B.val) : nothing
+    cache_prod = (α_active && !c_const) ?
+        LinearAlgebra.wrap(A.val, tA) * LinearAlgebra.wrap(B.val, tB) : nothing
     return (cache_C, cache_A, cache_B, cache_prod)
 end
 
@@ -252,10 +249,10 @@ end
         αval::Number, βval::Number, tape, ::Val{α_active}, ::Val{β_active},
     ) where {α_active, β_active}
     N = width(config)
-    if C isa Const
+    if _isconst(config, C)
         # Without C's shadow there is nothing to pull back from.
-        dα = α_active ? _dscalar(Val(N), typeof(αval), _ -> zero(αval)) : nothing
-        dβ = β_active ? _dscalar(Val(N), typeof(βval), _ -> zero(βval)) : nothing
+        dα = α_active ? _dscalar(Val(N), typeof(αval), Returns(zero(αval))) : nothing
+        dβ = β_active ? _dscalar(Val(N), typeof(βval), Returns(zero(βval))) : nothing
         return (dα, dβ)
     end
 
@@ -273,16 +270,26 @@ end
 
     αc = conj(αval)
     βc = conj(βval)
+    fA = _opflags(tA)
+    fB = _opflags(tB)
+    a_const = _isconst(config, A)
+    b_const = _isconst(config, B)
+    plain = _plain(tA) && _plain(tB)
     ntuple(Val(N)) do i
         Base.@_inline_meta
         dC = _bget(C.dval, Val(N), i)
-        if !(A isa Const)
-            _pullback_left!(_bget(A.dval, Val(N), i), tA, tB, dC, Bval, αc)
+        if !a_const
+            dA = _bget(A.dval, Val(N), i)
+            plain ? _pullback!(dA, tA, dC, (false, false), Bval, _adjop(fB), αc) :
+                _accumulate_operand!(dA, tA, _scale!(dC * _wrap_adjoint(Bval, tB), αc))
         end
-        if !(B isa Const)
-            _pullback_right!(_bget(B.dval, Val(N), i), tA, tB, Aval, dC, αc)
+        if !b_const
+            dB = _bget(B.dval, Val(N), i)
+            plain ? _pullback!(dB, tB, Aval, _adjop(fA), dC, (false, false), αc) :
+                _accumulate_operand!(dB, tB, _scale!(_wrap_adjoint(Aval, tA) * dC, αc))
         end
-        dC .*= βc
+        # β = 1 is the accumulate-into-C case, where this would be a no-op kernel.
+        isone(βc) || (dC .*= βc)
         nothing
     end
 
@@ -313,15 +320,13 @@ end
         ) where {RT}
         active = Val(!(add isa Const))
         tape = _matmul_caches(
-            C, tA.val, tB.val, A, B,
+            config, C, tA.val, tB.val, A, B,
             overwritten(config)[5], overwritten(config)[6], active, active,
         )
 
         func.val(C.val, tA.val, tB.val, A.val, B.val, add.val)
 
-        primal = needs_primal(config) ? C.val : nothing
-        shadow = needs_shadow(config) ? C.dval : nothing
-        return AugmentedReturn(primal, shadow, tape)
+        return _augreturn(config, C, tape)
     end
 
     function EnzymeRules.reverse(
@@ -358,15 +363,13 @@ end
         ) where {RT}
         active = Val(!(add isa Const))
         tape = _matmul_caches(
-            y, tA.val, 'N', A, x,
+            config, y, tA.val, 'N', A, x,
             overwritten(config)[4], overwritten(config)[5], active, active,
         )
 
         func.val(y.val, tA.val, A.val, x.val, add.val)
 
-        primal = needs_primal(config) ? y.val : nothing
-        shadow = needs_shadow(config) ? y.dval : nothing
-        return AugmentedReturn(primal, shadow, tape)
+        return _augreturn(config, y, tape)
     end
 
     function EnzymeRules.reverse(
@@ -405,16 +408,14 @@ else
             β::Annotation{<:Number},
         ) where {RT}
         tape = _matmul_caches(
-            C, tA.val, tB.val, A, B,
+            config, C, tA.val, tB.val, A, B,
             overwritten(config)[5], overwritten(config)[6],
             Val(!(α isa Const)), Val(!(β isa Const)),
         )
 
         func.val(C.val, tA.val, tB.val, A.val, B.val, α.val, β.val)
 
-        primal = needs_primal(config) ? C.val : nothing
-        shadow = needs_shadow(config) ? C.dval : nothing
-        return AugmentedReturn(primal, shadow, tape)
+        return _augreturn(config, C, tape)
     end
 
     function EnzymeRules.reverse(
@@ -449,16 +450,14 @@ else
             β::Annotation{<:Number},
         ) where {RT}
         tape = _matmul_caches(
-            y, tA.val, 'N', A, x,
+            config, y, tA.val, 'N', A, x,
             overwritten(config)[4], overwritten(config)[5],
             Val(!(α isa Const)), Val(!(β isa Const)),
         )
 
         func.val(y.val, tA.val, A.val, x.val, α.val, β.val)
 
-        primal = needs_primal(config) ? y.val : nothing
-        shadow = needs_shadow(config) ? y.dval : nothing
-        return AugmentedReturn(primal, shadow, tape)
+        return _augreturn(config, y, tape)
     end
 
     function EnzymeRules.reverse(
@@ -548,15 +547,13 @@ function EnzymeRules.augmented_primal(
     ) where {RT}
     # `lmul!(T, B)` arrives as C === B, so the primal overwrites the B that dA needs.
     aliased = C.val === B.val
-    cache_A = (overwritten(config)[6] && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
-    cache_B = ((aliased || overwritten(config)[7]) && !(A isa Const) && !(C isa Const)) ?
+    cache_A = (overwritten(config)[6] && !_isconst(config, B) && !_isconst(config, C)) ? copy(A.val) : nothing
+    cache_B = ((aliased || overwritten(config)[7]) && !_isconst(config, A) && !_isconst(config, C)) ?
         copy(B.val) : nothing
 
     func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
 
-    primal = needs_primal(config) ? C.val : nothing
-    shadow = needs_shadow(config) ? C.dval : nothing
-    return AugmentedReturn(primal, shadow, (cache_A, cache_B, aliased))
+    return _augreturn(config, C, (cache_A, cache_B, aliased))
 end
 
 function EnzymeRules.reverse(
@@ -571,24 +568,24 @@ function EnzymeRules.reverse(
         A::Annotation{<:AbstractGPUMatrix},
         B::Annotation{<:AbstractGPUVecOrMat},
     ) where {RT}
-    if !(C isa Const)
+    if !_isconst(config, C)
         cache_A, cache_B, aliased = tape
         Aval = cache_A !== nothing ? cache_A : A.val
         Bval = cache_B !== nothing ? cache_B : B.val
-        M′ = (B isa Const) ? nothing :
+        M′ = _isconst(config, B) ? nothing :
             _triangular_adjoint(Aval, uploc.val, isunitc.val, tfun.val)
         N = width(config)
         ntuple(Val(N)) do i
             Base.@_inline_meta
             dC = _bget(C.dval, Val(N), i)
             # dA first: when the shadows alias, dB below overwrites dC.
-            if !(A isa Const)
+            if !_isconst(config, A)
                 _accumulate_triangular!(
                     _bget(A.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
                     dC * adjoint(Bval),
                 )
             end
-            if !(B isa Const)
+            if !_isconst(config, B)
                 dB = _bget(B.dval, Val(N), i)
                 G = LinearAlgebra.mul!(zero(dC), M′, dC)
                 # Replace when C === B: dB is dC, and C's cotangent is spent here.
@@ -614,15 +611,13 @@ function EnzymeRules.augmented_primal(
     ) where {RT}
     # `rmul!(A, T)` lands here as C === A.
     aliased = C.val === A.val
-    cache_A = ((aliased || overwritten(config)[6]) && !(B isa Const) && !(C isa Const)) ?
+    cache_A = ((aliased || overwritten(config)[6]) && !_isconst(config, B) && !_isconst(config, C)) ?
         copy(A.val) : nothing
-    cache_B = (overwritten(config)[7] && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
+    cache_B = (overwritten(config)[7] && !_isconst(config, A) && !_isconst(config, C)) ? copy(B.val) : nothing
 
     func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
 
-    primal = needs_primal(config) ? C.val : nothing
-    shadow = needs_shadow(config) ? C.dval : nothing
-    return AugmentedReturn(primal, shadow, (cache_A, cache_B, aliased))
+    return _augreturn(config, C, (cache_A, cache_B, aliased))
 end
 
 function EnzymeRules.reverse(
@@ -637,24 +632,24 @@ function EnzymeRules.reverse(
         A::Annotation{<:AbstractGPUMatrix},
         B::Annotation{<:AbstractGPUMatrix},
     ) where {RT}
-    if !(C isa Const)
+    if !_isconst(config, C)
         cache_A, cache_B, aliased = tape
         Aval = cache_A !== nothing ? cache_A : A.val
         Bval = cache_B !== nothing ? cache_B : B.val
-        M′ = (A isa Const) ? nothing :
+        M′ = _isconst(config, A) ? nothing :
             _triangular_adjoint(Bval, uploc.val, isunitc.val, tfun.val)
         N = width(config)
         ntuple(Val(N)) do i
             Base.@_inline_meta
             dC = _bget(C.dval, Val(N), i)
             # dB first: when the shadows alias, dA below overwrites dC.
-            if !(B isa Const)
+            if !_isconst(config, B)
                 _accumulate_triangular!(
                     _bget(B.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
                     adjoint(Aval) * dC,
                 )
             end
-            if !(A isa Const)
+            if !_isconst(config, A)
                 dA = _bget(A.dval, Val(N), i)
                 G = LinearAlgebra.mul!(zero(dC), dC, M′)
                 # Replace when C === A: dA is dC, and C's cotangent is spent here.
@@ -681,8 +676,8 @@ function EnzymeRules.augmented_primal(
         b::Annotation{<:AbstractGPUArray},
     )
     primal = needs_primal(config) ? dot(a.val, b.val) : nothing
-    cache_a = (overwritten(config)[2] && !(b isa Const)) ? copy(a.val) : nothing
-    cache_b = (overwritten(config)[3] && !(a isa Const)) ? copy(b.val) : nothing
+    cache_a = (overwritten(config)[2] && !_isconst(config, b)) ? copy(a.val) : nothing
+    cache_b = (overwritten(config)[3] && !_isconst(config, a)) ? copy(b.val) : nothing
     return AugmentedReturn(primal, nothing, (cache_a, cache_b))
 end
 
@@ -701,12 +696,12 @@ function EnzymeRules.reverse(
         N = width(config)
         ntuple(Val(N)) do i
             Base.@_inline_meta
-            dr = _bget(dret.val, Val(N), i)
-            if !(a isa Const)
+            dr = _dret(dret, Val(N), i)
+            if !_isconst(config, a)
                 # `a` entered conjugated, so its cotangent picks up conj(dr).
                 _bget(a.dval, Val(N), i) .+= conj(dr) .* bv
             end
-            if !(b isa Const)
+            if !_isconst(config, b)
                 _bget(b.dval, Val(N), i) .+= dr .* av
             end
             nothing
@@ -734,11 +729,11 @@ function EnzymeRules.reverse(
         tape,
         x::Annotation{<:AbstractGPUArray},
     )
-    if !(dret isa Const) && !(x isa Const)
+    if !(dret isa Const) && !_isconst(config, x)
         N = width(config)
         ntuple(Val(N)) do i
             Base.@_inline_meta
-            _bget(x.dval, Val(N), i) .+= _bget(dret.val, Val(N), i)
+            _bget(x.dval, Val(N), i) .+= _dret(dret, Val(N), i)
             nothing
         end
     end

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -2,8 +2,8 @@ module EnzymeGPUArraysCoreExt
 
 using GPUArraysCore
 using Enzyme
-using LinearAlgebra: LinearAlgebra, mul!, dot, Transpose, Adjoint, adjoint,
-    UpperTriangular, LowerTriangular, Symmetric, Hermitian, triu, tril, diag, diagind
+using LinearAlgebra: LinearAlgebra, dot, Symmetric, Hermitian, UpperTriangular,
+    LowerTriangular, UnitUpperTriangular, UnitLowerTriangular, triu, tril, diag, diagind
 using Enzyme.EnzymeCore: EnzymeCore
 using Enzyme.EnzymeCore.EnzymeRules:
     EnzymeRules,
@@ -55,245 +55,622 @@ _project(::Type{<:Real}, x) = real(x)
 _project(::Type, x) = x
 
 #=
-Cotangent for an `Active` scalar argument: a single value at width 1, an
-N-tuple when batched. `f(i)` gives the raw (possibly complex) contribution for
-batch element `i`, which is then projected onto `T`, the scalar's own type.
-
-Dispatching on `Val{N}` matters: branching on `N == 1` at run time makes the
-result infer as `Any`, and reverse rules must return exactly the argument's
-type (`Tuple{…, Float32, …}`), so an inexact match is a hard error.
+Cotangent of an `Active` scalar argument: `f(i)`'s raw (possibly complex)
+contribution projected onto `T`, bare at width 1 and an N-tuple when batched.
+Dispatch on `Val{N}` rather than branching on `N == 1`, which infers as `Any` --
+a reverse rule that misses the argument's exact type is a hard error.
 =#
 @inline _dscalar(::Val{1}, ::Type{T}, f::F) where {T, F} = _project(T, f(1))::T
 @inline function _dscalar(::Val{N}, ::Type{T}, f::F) where {N, T, F}
     return ntuple(i -> _project(T, f(i))::T, Val(N))
 end
 
-# A GPU array, or a structured/lazy wrapper of one; the `mul!` operand types that
-# show up in matmuls (`transpose(X) * y`, `Symmetric(A) * x`, ...). CUBLAS /
-# rocBLAS dispatch these to specialized kernels (trmm/symm/hemm), and the reverse
-# pass projects the cotangent back onto each wrapper's stored entries (see
-# `_accumulate_operand!`). UnitTriangular is intentionally excluded: its diagonal
-# is structurally fixed, so it cannot represent a tangent/cotangent.
-const MaybeWrappedGPU = Union{
-    AbstractGPUArray,
-    Transpose{<:Any, <:AbstractGPUArray},
-    Adjoint{<:Any, <:AbstractGPUArray},
-    UpperTriangular{<:Any, <:AbstractGPUArray},
-    LowerTriangular{<:Any, <:AbstractGPUArray},
-    Symmetric{<:Any, <:AbstractGPUArray},
-    Hermitian{<:Any, <:AbstractGPUArray},
-}
+#=
+Before anything reaches the GPU, `mul!` and `*` strip the wrapper off each
+operand and pass a char for how to read the bare array: 'N' plain, 'T'
+transposed, 'C' adjoint, 'S' Symmetric, 'H' Hermitian, the case naming the
+stored triangle ('S' upper, 's' lower). Julia ≥1.11 sends a `WrapperChar`, which
+holds the case in its own field, so go through `Char` to get the triangle back.
+=#
+@inline _stored_upper(t::AbstractChar) = isuppercase(Char(t))
+
+# `conj`, materialized; a no-op for real eltypes.
+@inline _conj(X) = eltype(X) <: Real ? X : conj.(X)
 
 #=
-Accumulate `factor .* G` into the shadow `s` of a matmul operand, where `G` is
-the dense cotangent (`dY·B'` or `A'·dY`). For dense / transpose / adjoint shadows
-the cotangent is added directly. For structured shadows only the stored entries
-are free parameters, so `G` is projected onto that structure:
-
-  UpperTriangular  : keep `triu(G)`
-  LowerTriangular  : keep `tril(G)`
-  Symmetric(uplo)  : off-diagonal (i,j) collects `G[i,j] + G[j,i]`, diagonal `G[i,i]`
-  Hermitian(uplo)  : same with conjugation; the diagonal is real
+`adjoint(wrap(X, t))`, leaving at most one lazy wrapper on the array. The
+backends peel off a single layer, so a nested `adjoint(transpose(X))` (or
+`adjoint(Symmetric(X))` when complex) matches no method and scalar-indexes.
 =#
-@inline function _accumulate_operand!(s, G, factor)
-    s .+= factor .* G
-    return nothing
+@inline function _wrap_adjoint(X, t::AbstractChar)
+    kind = uppercase(t)
+    return if kind == 'N'
+        adjoint(X)
+    elseif kind == 'T'
+        _conj(X)
+    elseif kind == 'C'
+        X
+    elseif kind == 'S'
+        Symmetric(_conj(X), _stored_upper(t) ? :U : :L)
+    else
+        Hermitian(X, _stored_upper(t) ? :U : :L)
+    end
 end
 
-function _accumulate_operand!(s::UpperTriangular, G, factor)
-    parent(s) .+= factor .* triu(G)
-    return nothing
+@static if VERSION < v"1.12.0-DEV"
+    @inline _gemm!(C, tA::AbstractChar, tB::AbstractChar, A, B, α::Number, β::Number) =
+        LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, LinearAlgebra.MulAddMul(α, β))
+else
+    @inline _gemm!(C, tA::AbstractChar, tB::AbstractChar, A, B, α::Number, β::Number) =
+        LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, α, β)
 end
 
-function _accumulate_operand!(s::LowerTriangular, G, factor)
-    parent(s) .+= factor .* tril(G)
-    return nothing
-end
+@inline _plain(t::AbstractChar) = (k = uppercase(t); k == 'N' || k == 'T' || k == 'C')
 
-function _accumulate_operand!(s::Symmetric, G, factor)
-    p = parent(s)
-    H = G .+ transpose(G)
-    p .+= factor .* (s.uplo == 'U' ? triu(H, 1) : tril(H, -1))
-    dg = view(p, diagind(p))
-    dg .+= factor .* diag(G)
-    return nothing
-end
-
-function _accumulate_operand!(s::Hermitian, G, factor)
-    p = parent(s)
-    H = G .+ adjoint(G)
-    p .+= factor .* (s.uplo == 'U' ? triu(H, 1) : tril(H, -1))
-    dg = view(p, diagind(p))
-    dg .+= factor .* real.(diag(G))
+#=
+Accumulate `factor .* G` into the shadow of an operand the primal read as
+`wrap(X, t)`, `G` being the cotangent of that wrapped operand. 'T'/'C' only
+transpose it. 'S'/'H' need a projection: one triangle is stored and each of its
+entries feeds two positions of the wrapped matrix, so (i,j) collects
+G[i,j] + G[j,i] and the diagonal collects G[i,i]. Hermitian keeps only the real
+part there, its diagonal being real by construction.
+=#
+function _accumulate_operand!(dX, t::AbstractChar, G, factor)
+    kind = uppercase(t)
+    if kind == 'N'
+        dX .+= factor .* G
+    elseif kind == 'T'
+        dX .+= factor .* transpose(G)
+    elseif kind == 'C'
+        dX .+= factor .* adjoint(G)
+    else
+        H = kind == 'S' ? G .+ transpose(G) : G .+ adjoint(G)
+        dX .+= factor .* (_stored_upper(t) ? triu(H, 1) : tril(H, -1))
+        dg = view(dX, diagind(dX))
+        dg .+= factor .* (kind == 'S' ? diag(G) : real.(diag(G)))
+    end
     return nothing
 end
 
 #=
-mul!(C, A, B, α, β):  C = α·A·B + β·C₀
+`dA += factor·dC·op(B)'`, projected back through op(A).
 
-Pullback: dA += conj(α)·dC·B'
-          dB += conj(α)·A'·dC
-          dC := conj(β)·dC                (cotangent w.r.t. C₀)
-          dα  = conj(⟨dC, A·B⟩)
-          dβ  = conj(⟨dC, C₀⟩)
+Both halves of that are themselves a matmul with a transposition, so as long as
+'N'/'T'/'C' describe both operands the whole thing is one more trip through
+`generic_matmatmul!` with β = 1: the accumulation is the rule's own β argument,
+no temporary and no elementwise pass. Which chars come out of rearranging
+`(dC·op(B)')` into a single gemm:
+
+    tA = 'N'    factor·dC·op(B)'          op(B)' is 'C'/conj/'N' for tB N/T/C
+    tA = 'T'    factor·conj(op(B))·dCᵀ    conj(op(B)) is conj/'C'/'T'
+    tA = 'C'    factor·op(B)·dC'          op(B) is tB itself
+
+The two `conj` slots are the only ones no char covers, and they cost a
+materialized conjugate for complex eltypes only. Symmetric/Hermitian can't play:
+`adjoint(Symmetric(B))` is not a gemm operand and the cotangent needs projecting
+onto a triangle either way, so those fall back to forming `G` and accumulating.
 =#
-
-function EnzymeRules.augmented_primal(
-        config::RevConfig,
-        func::Const{typeof(mul!)},
-        ::Type{RT},
-        C::Annotation{<:AbstractGPUArray},
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
-        α::Annotation{<:Number},
-        β::Annotation{<:Number},
-    ) where {RT}
-    # C₀ is needed for dβ; copy it before the primal overwrites C.val.
-    cache_C = !(β isa Const) ? copy(C.val) : nothing
-
-    func.val(C.val, A.val, B.val, α.val, β.val)
-
-    primal = needs_primal(config) ? C.val : nothing
-    shadow = needs_shadow(config) ? C.dval : nothing
-
-    # A is needed for dB, B for dA; cache them only if overwritten before reverse.
-    cache_A = (overwritten(config)[3] && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
-    cache_B = (overwritten(config)[4] && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
-    cache_α = !(α isa Const) ? A.val * B.val : nothing
-
-    return AugmentedReturn(primal, shadow, (cache_C, cache_A, cache_B, cache_α))
+function _pullback_left!(dA, tA::AbstractChar, tB::AbstractChar, dC, B, factor)
+    if !(_plain(tA) && _plain(tB))
+        _accumulate_operand!(dA, tA, dC * _wrap_adjoint(B, tB), factor)
+    elseif uppercase(tA) == 'N'
+        kb = uppercase(tB)
+        if kb == 'N'
+            _gemm!(dA, 'N', 'C', dC, B, factor, true)
+        elseif kb == 'C'
+            _gemm!(dA, 'N', 'N', dC, B, factor, true)
+        else
+            _gemm!(dA, 'N', 'N', dC, _conj(B), factor, true)
+        end
+    elseif uppercase(tA) == 'T'
+        kb = uppercase(tB)
+        if kb == 'N'
+            _gemm!(dA, 'N', 'T', _conj(B), dC, factor, true)
+        elseif kb == 'T'
+            _gemm!(dA, 'C', 'T', B, dC, factor, true)
+        else
+            _gemm!(dA, 'T', 'T', B, dC, factor, true)
+        end
+    else
+        _gemm!(dA, tB, 'C', B, dC, factor, true)
+    end
+    return nothing
 end
 
-function EnzymeRules.reverse(
-        config::RevConfig,
-        func::Const{typeof(mul!)},
-        ::Type{RT},
-        tape,
-        C::Annotation{<:AbstractGPUArray},
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
-        α::Annotation{<:Number},
-        β::Annotation{<:Number},
-    ) where {RT}
-    cache_C, cache_A, cache_B, cache_α = tape
+# `dB += factor·op(A)'·dC`, projected back through op(B): the mirror of
+# `_pullback_left!`, with the same fallback for Symmetric/Hermitian.
+function _pullback_right!(dB, tA::AbstractChar, tB::AbstractChar, A, dC, factor)
+    if !(_plain(tA) && _plain(tB))
+        _accumulate_operand!(dB, tB, _wrap_adjoint(A, tA) * dC, factor)
+    elseif uppercase(tB) == 'N'
+        ka = uppercase(tA)
+        if ka == 'N'
+            _gemm!(dB, 'C', 'N', A, dC, factor, true)
+        elseif ka == 'C'
+            _gemm!(dB, 'N', 'N', A, dC, factor, true)
+        else
+            _gemm!(dB, 'N', 'N', _conj(A), dC, factor, true)
+        end
+    elseif uppercase(tB) == 'T'
+        ka = uppercase(tA)
+        if ka == 'N'
+            _gemm!(dB, 'T', 'N', dC, _conj(A), factor, true)
+        elseif ka == 'T'
+            _gemm!(dB, 'T', 'C', dC, A, factor, true)
+        else
+            _gemm!(dB, 'T', 'T', dC, A, factor, true)
+        end
+    else
+        _gemm!(dB, 'C', tA, dC, A, factor, true)
+    end
+    return nothing
+end
+
+#=
+    generic_matmatmul!(C, tA, tB, A, B, α, β)    C = α·op(A)·op(B) + β·C₀
+    generic_matvecmul!(y, tA, A, x, α, β)        y = α·op(A)·x + β·y₀
+
+Where every non-triangular GPU matmul ends up, whether it came from `*` or from
+3-/5-arg `mul!`, and whether the backend takes it on to CUBLAS or to the
+GPUArrays fallback kernels. One rule per function therefore covers every wrapper
+combination:
+
+    dA += conj(α)·dC·op(B)'          projected back through op(A)
+    dB += conj(α)·op(A)'·dC          projected back through op(B)
+    dC := conj(β)·dC                 cotangent w.r.t. C₀
+    dα  = conj(⟨dC, op(A)·op(B)⟩)
+    dβ  = conj(⟨dC, C₀⟩)
+
+The first two are matmuls with a transposition, so they go back through this
+same function with β = 1 and nothing is accumulated by hand -- see
+`_pullback_left!`.
+
+3-arg `mul!` lands here with α = true, β = false, so `dC` gets zeroed, as it
+must: that form overwrites `C` instead of accumulating into it.
+
+α and β are separate arguments on Julia ≥1.12 and packed into a `MulAddMul`
+before that, so the rules are version-gated wrappers over the two helpers below.
+=#
+
+@inline function _matmul_caches(
+        C::Annotation, tA::AbstractChar, tB::AbstractChar, A::Annotation, B::Annotation,
+        ovw_A::Bool, ovw_B::Bool, ::Val{α_active}, ::Val{β_active},
+    ) where {α_active, β_active}
+    #=
+    dβ needs C₀, dB needs A and dA needs B; copy each only when the reverse pass
+    reads it and something has overwritten it by then.
+    =#
+    cache_C = β_active ? copy(C.val) : nothing
+    cache_A = (ovw_A && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
+    cache_B = (ovw_B && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
+    cache_prod = α_active ? LinearAlgebra.wrap(A.val, tA) * LinearAlgebra.wrap(B.val, tB) : nothing
+    return (cache_C, cache_A, cache_B, cache_prod)
+end
+
+@inline function _matmul_reverse!(
+        config, C::Annotation, tA::AbstractChar, tB::AbstractChar, A::Annotation, B::Annotation,
+        αval::Number, βval::Number, tape, ::Val{α_active}, ::Val{β_active},
+    ) where {α_active, β_active}
+    N = width(config)
+    if C isa Const
+        # Without C's shadow there is nothing to pull back from.
+        dα = α_active ? _dscalar(Val(N), typeof(αval), _ -> zero(αval)) : nothing
+        dβ = β_active ? _dscalar(Val(N), typeof(βval), _ -> zero(βval)) : nothing
+        return (dα, dβ)
+    end
+
+    cache_C, cache_A, cache_B, cache_prod = tape
     Cval = cache_C !== nothing ? cache_C : C.val
     Aval = cache_A !== nothing ? cache_A : A.val
     Bval = cache_B !== nothing ? cache_B : B.val
-    N = width(config)
 
-    if !(C isa Const)
-        dα = !(α isa Const) ?
-            _dscalar(Val(N), typeof(α.val), i -> conj(dot(_bget(C.dval, Val(N), i), cache_α))) :
-            nothing
-        dβ = !(β isa Const) ?
-            _dscalar(Val(N), typeof(β.val), i -> conj(dot(_bget(C.dval, Val(N), i), Cval))) :
-            nothing
+    dα = α_active ?
+        _dscalar(Val(N), typeof(αval), i -> conj(dot(_bget(C.dval, Val(N), i), cache_prod))) :
+        nothing
+    dβ = β_active ?
+        _dscalar(Val(N), typeof(βval), i -> conj(dot(_bget(C.dval, Val(N), i), Cval))) :
+        nothing
 
-        αc = conj(α.val)
-        βc = conj(β.val)
-        ntuple(Val(N)) do i
-            Base.@_inline_meta
-            dC = _bget(C.dval, Val(N), i)
-            if !(A isa Const)
-                _accumulate_operand!(_bget(A.dval, Val(N), i), dC * adjoint(Bval), αc)
-            end
-            if !(B isa Const)
-                _accumulate_operand!(_bget(B.dval, Val(N), i), adjoint(Aval) * dC, αc)
-            end
-            dC .*= βc
-            nothing
+    αc = conj(αval)
+    βc = conj(βval)
+    ntuple(Val(N)) do i
+        Base.@_inline_meta
+        dC = _bget(C.dval, Val(N), i)
+        if !(A isa Const)
+            _pullback_left!(_bget(A.dval, Val(N), i), tA, tB, dC, Bval, αc)
         end
-    else
-        dα = !(α isa Const) ? _dscalar(Val(N), typeof(α.val), _ -> zero(α.val)) : nothing
-        dβ = !(β isa Const) ? _dscalar(Val(N), typeof(β.val), _ -> zero(β.val)) : nothing
-    end
-
-    return (nothing, nothing, nothing, dα, dβ)
-end
-
-#=
-A * B:  allocating matmul (matrix or matrix-vector)
-
-Unlike the in-place `mul!` rule above, `*` allocates its result, so the rule
-owns the output shadow: `augmented_primal` returns a zeroed shadow and
-`reverse` zeroes it again after reading. Without this, the freshly-allocated
-result's shadow is uninitialized and downstream `+=` accumulates onto garbage.
-
-`A * B` does lower to `mul!(similar(...), A, B, true, false)`, so it is tempting
-to drop this rule and let the `mul!` one above cover it. That is not safe: it
-holds for CuArrays (every pattern covered below was re-checked on a GPU with
-this rule removed, and all still passed) but NOT for AbstractGPUArray in
-general. On JLArrays, dropping it makes `A * UpperTriangular(X)` return a wrong
-cotangent, because the shadow of the array `*` allocates via `similar` is not
-zeroed -- whereas the same operands passed to an explicit 5-arg `mul!` are
-differentiated correctly. So the allocation, not the multiply, is what this
-rule is really for.
-
-Pullback: dA += dY·B'
-          dB += A'·dY
-=#
-
-function EnzymeRules.augmented_primal(
-        config::RevConfig,
-        func::Const{typeof(*)},
-        ::Type{RT},
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
-    ) where {RT}
-    Y = A.val * B.val
-    primal = needs_primal(config) ? Y : nothing
-
-    N = width(config)
-    dY = if RT <: Duplicated || RT <: DuplicatedNoNeed
-        zero(Y)
-    elseif RT <: BatchDuplicated || RT <: BatchDuplicatedNoNeed
-        ntuple(_ -> zero(Y), Val(N))
-    else
+        if !(B isa Const)
+            _pullback_right!(_bget(B.dval, Val(N), i), tA, tB, Aval, dC, αc)
+        end
+        dC .*= βc
         nothing
     end
 
-    cache_A = (overwritten(config)[2] && !(B isa Const)) ? copy(A.val) : A.val
-    cache_B = (overwritten(config)[3] && !(A isa Const)) ? copy(B.val) : B.val
+    return (dα, dβ)
+end
 
-    return AugmentedReturn(primal, dY, (dY, cache_A, cache_B))
+@static if VERSION < v"1.12.0-DEV"
+
+    #=
+    With α and β packed into one `MulAddMul`, an active α or β arrives as a
+    single active struct, so its cotangent has to come back as that struct type.
+    =#
+    @inline _dmuladdmul(::Val{1}, ::Type{MAM}, dα, dβ) where {MAM} = MAM(dα, dβ)
+    @inline function _dmuladdmul(::Val{N}, ::Type{MAM}, dα, dβ) where {N, MAM}
+        return ntuple(i -> MAM(dα[i], dβ[i]), Val(N))
+    end
+
+    function EnzymeRules.augmented_primal(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matmatmul!)},
+            ::Type{RT},
+            C::Annotation{<:AbstractGPUVecOrMat},
+            tA::Const{<:AbstractChar},
+            tB::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUVecOrMat},
+            B::Annotation{<:AbstractGPUVecOrMat},
+            add::Annotation{<:LinearAlgebra.MulAddMul},
+        ) where {RT}
+        active = Val(!(add isa Const))
+        tape = _matmul_caches(
+            C, tA.val, tB.val, A, B,
+            overwritten(config)[5], overwritten(config)[6], active, active,
+        )
+
+        func.val(C.val, tA.val, tB.val, A.val, B.val, add.val)
+
+        primal = needs_primal(config) ? C.val : nothing
+        shadow = needs_shadow(config) ? C.dval : nothing
+        return AugmentedReturn(primal, shadow, tape)
+    end
+
+    function EnzymeRules.reverse(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matmatmul!)},
+            ::Type{RT},
+            tape,
+            C::Annotation{<:AbstractGPUVecOrMat},
+            tA::Const{<:AbstractChar},
+            tB::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUVecOrMat},
+            B::Annotation{<:AbstractGPUVecOrMat},
+            add::Annotation{<:LinearAlgebra.MulAddMul},
+        ) where {RT}
+        active = Val(!(add isa Const))
+        dα, dβ = _matmul_reverse!(
+            config, C, tA.val, tB.val, A, B,
+            add.val.alpha, add.val.beta, tape, active, active,
+        )
+        dadd = (add isa Const) ? nothing :
+            _dmuladdmul(Val(width(config)), typeof(add.val), dα, dβ)
+        return (nothing, nothing, nothing, nothing, nothing, dadd)
+    end
+
+    function EnzymeRules.augmented_primal(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matvecmul!)},
+            ::Type{RT},
+            y::Annotation{<:AbstractGPUVector},
+            tA::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUMatrix},
+            x::Annotation{<:AbstractGPUVector},
+            add::Annotation{<:LinearAlgebra.MulAddMul},
+        ) where {RT}
+        active = Val(!(add isa Const))
+        tape = _matmul_caches(
+            y, tA.val, 'N', A, x,
+            overwritten(config)[4], overwritten(config)[5], active, active,
+        )
+
+        func.val(y.val, tA.val, A.val, x.val, add.val)
+
+        primal = needs_primal(config) ? y.val : nothing
+        shadow = needs_shadow(config) ? y.dval : nothing
+        return AugmentedReturn(primal, shadow, tape)
+    end
+
+    function EnzymeRules.reverse(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matvecmul!)},
+            ::Type{RT},
+            tape,
+            y::Annotation{<:AbstractGPUVector},
+            tA::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUMatrix},
+            x::Annotation{<:AbstractGPUVector},
+            add::Annotation{<:LinearAlgebra.MulAddMul},
+        ) where {RT}
+        active = Val(!(add isa Const))
+        dα, dβ = _matmul_reverse!(
+            config, y, tA.val, 'N', A, x,
+            add.val.alpha, add.val.beta, tape, active, active,
+        )
+        dadd = (add isa Const) ? nothing :
+            _dmuladdmul(Val(width(config)), typeof(add.val), dα, dβ)
+        return (nothing, nothing, nothing, nothing, dadd)
+    end
+
+else
+
+    function EnzymeRules.augmented_primal(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matmatmul!)},
+            ::Type{RT},
+            C::Annotation{<:AbstractGPUVecOrMat},
+            tA::Const{<:AbstractChar},
+            tB::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUVecOrMat},
+            B::Annotation{<:AbstractGPUVecOrMat},
+            α::Annotation{<:Number},
+            β::Annotation{<:Number},
+        ) where {RT}
+        tape = _matmul_caches(
+            C, tA.val, tB.val, A, B,
+            overwritten(config)[5], overwritten(config)[6],
+            Val(!(α isa Const)), Val(!(β isa Const)),
+        )
+
+        func.val(C.val, tA.val, tB.val, A.val, B.val, α.val, β.val)
+
+        primal = needs_primal(config) ? C.val : nothing
+        shadow = needs_shadow(config) ? C.dval : nothing
+        return AugmentedReturn(primal, shadow, tape)
+    end
+
+    function EnzymeRules.reverse(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matmatmul!)},
+            ::Type{RT},
+            tape,
+            C::Annotation{<:AbstractGPUVecOrMat},
+            tA::Const{<:AbstractChar},
+            tB::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUVecOrMat},
+            B::Annotation{<:AbstractGPUVecOrMat},
+            α::Annotation{<:Number},
+            β::Annotation{<:Number},
+        ) where {RT}
+        dα, dβ = _matmul_reverse!(
+            config, C, tA.val, tB.val, A, B, α.val, β.val, tape,
+            Val(!(α isa Const)), Val(!(β isa Const)),
+        )
+        return (nothing, nothing, nothing, nothing, nothing, dα, dβ)
+    end
+
+    function EnzymeRules.augmented_primal(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matvecmul!)},
+            ::Type{RT},
+            y::Annotation{<:AbstractGPUVector},
+            tA::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUMatrix},
+            x::Annotation{<:AbstractGPUVector},
+            α::Annotation{<:Number},
+            β::Annotation{<:Number},
+        ) where {RT}
+        tape = _matmul_caches(
+            y, tA.val, 'N', A, x,
+            overwritten(config)[4], overwritten(config)[5],
+            Val(!(α isa Const)), Val(!(β isa Const)),
+        )
+
+        func.val(y.val, tA.val, A.val, x.val, α.val, β.val)
+
+        primal = needs_primal(config) ? y.val : nothing
+        shadow = needs_shadow(config) ? y.dval : nothing
+        return AugmentedReturn(primal, shadow, tape)
+    end
+
+    function EnzymeRules.reverse(
+            config::RevConfig,
+            func::Const{typeof(LinearAlgebra.generic_matvecmul!)},
+            ::Type{RT},
+            tape,
+            y::Annotation{<:AbstractGPUVector},
+            tA::Const{<:AbstractChar},
+            A::Annotation{<:AbstractGPUMatrix},
+            x::Annotation{<:AbstractGPUVector},
+            α::Annotation{<:Number},
+            β::Annotation{<:Number},
+        ) where {RT}
+        dα, dβ = _matmul_reverse!(
+            config, y, tA.val, 'N', A, x, α.val, β.val, tape,
+            Val(!(α isa Const)), Val(!(β isa Const)),
+        )
+        return (nothing, nothing, nothing, nothing, dα, dβ)
+    end
+
+end
+
+#=
+    generic_trimatmul!(C, uploc, isunitc, tfun, A, B)    C = tfun(T(A))·B
+    generic_mattrimul!(C, uploc, isunitc, tfun, A, B)    C = A·tfun(T(B))
+
+Triangular operands never reach `generic_matmatmul!`; LinearAlgebra sends them
+here instead, again bare plus a description of how to read them: `uploc`
+('U'/'L') names the stored triangle, `isunitc` is 'U' when the diagonal is
+structurally 1, and `tfun` is identity/transpose/adjoint. The operand is
+`tfun(T_uploc(A))` -- `transpose(UpperTriangular(X))` arrives as uploc 'U' with
+`tfun` `transpose`. There is no α/β here, `C` is always overwritten, so this is
+where `C`'s cotangent gets consumed. With `M` the operand as the primal reads it:
+
+    dA += tfun(tril/triu(dC·B'))
+    dB += M'·dC
+    dC := 0
+
+`M'·dC` goes through `mul!` into a zeroed buffer, not `*`. The GPUArrays kernels
+for these two end with `C[i,j] += …` rather than `=`, so with the uninitialized
+array `*` allocates they mix junk into the result; zeroing first makes that
+accumulation harmless, and backends that do overwrite (CUBLAS trmm) don't care.
+=#
+
+#=
+`adjoint(tfun(T_uploc(A)))`, again with a single lazy wrapper (see
+`_wrap_adjoint`). Only `identity` leaves an adjoint behind, and with it the
+flipped triangle; `transpose` and `adjoint` cancel against the outer one, the
+former down to a conjugation of the data.
+=#
+@inline function _triangular_adjoint(A, uploc::AbstractChar, isunitc::AbstractChar, tfun::F) where {F}
+    P = tfun === identity ? adjoint(A) : (tfun === transpose ? _conj(A) : A)
+    upper = tfun === identity ? uploc != 'U' : uploc == 'U'
+    return if upper
+        isunitc == 'U' ? UnitUpperTriangular(P) : UpperTriangular(P)
+    else
+        isunitc == 'U' ? UnitLowerTriangular(P) : LowerTriangular(P)
+    end
+end
+
+#=
+Project `G` back onto A's stored triangle, skipping a structurally-fixed unit
+diagonal. `tfun` swaps the triangles, so it can be undone after the projection
+rather than before -- and it has to be, because `triu`/`tril` of a lazy transpose
+drops into a scalar-indexing loop while broadcasting over one is fine.
+=#
+@inline function _accumulate_triangular!(
+        dA, uploc::AbstractChar, isunitc::AbstractChar, tfun::F, G,
+    ) where {F}
+    k = isunitc == 'U' ? 1 : 0
+    upper = tfun === identity ? uploc == 'U' : uploc != 'U'
+    dA .+= tfun(upper ? triu(G, k) : tril(G, -k))
+    return nothing
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(LinearAlgebra.generic_trimatmul!)},
+        ::Type{RT},
+        C::Annotation{<:AbstractGPUVecOrMat},
+        uploc::Const{<:AbstractChar},
+        isunitc::Const{<:AbstractChar},
+        tfun::Const,
+        A::Annotation{<:AbstractGPUMatrix},
+        B::Annotation{<:AbstractGPUVecOrMat},
+    ) where {RT}
+    # `lmul!(T, B)` arrives as C === B, so the primal overwrites the B that dA needs.
+    aliased = C.val === B.val
+    cache_A = (overwritten(config)[6] && !(B isa Const) && !(C isa Const)) ? copy(A.val) : nothing
+    cache_B = ((aliased || overwritten(config)[7]) && !(A isa Const) && !(C isa Const)) ?
+        copy(B.val) : nothing
+
+    func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
+
+    primal = needs_primal(config) ? C.val : nothing
+    shadow = needs_shadow(config) ? C.dval : nothing
+    return AugmentedReturn(primal, shadow, (cache_A, cache_B, aliased))
 end
 
 function EnzymeRules.reverse(
         config::RevConfig,
-        func::Const{typeof(*)},
+        func::Const{typeof(LinearAlgebra.generic_trimatmul!)},
         ::Type{RT},
         tape,
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
+        C::Annotation{<:AbstractGPUVecOrMat},
+        uploc::Const{<:AbstractChar},
+        isunitc::Const{<:AbstractChar},
+        tfun::Const,
+        A::Annotation{<:AbstractGPUMatrix},
+        B::Annotation{<:AbstractGPUVecOrMat},
     ) where {RT}
-    dY, cache_A, cache_B = tape
-    if dY !== nothing
+    if !(C isa Const)
+        cache_A, cache_B, aliased = tape
+        Aval = cache_A !== nothing ? cache_A : A.val
+        Bval = cache_B !== nothing ? cache_B : B.val
+        M′ = (B isa Const) ? nothing :
+            _triangular_adjoint(Aval, uploc.val, isunitc.val, tfun.val)
         N = width(config)
         ntuple(Val(N)) do i
             Base.@_inline_meta
-            dYi = _bget(dY, Val(N), i)
+            dC = _bget(C.dval, Val(N), i)
+            # dA first: when the shadows alias, dB below overwrites dC.
             if !(A isa Const)
-                _accumulate_operand!(_bget(A.dval, Val(N), i), dYi * adjoint(cache_B), true)
+                _accumulate_triangular!(
+                    _bget(A.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
+                    dC * adjoint(Bval),
+                )
             end
             if !(B isa Const)
-                _accumulate_operand!(_bget(B.dval, Val(N), i), adjoint(cache_A) * dYi, true)
+                dB = _bget(B.dval, Val(N), i)
+                G = LinearAlgebra.mul!(zero(dC), M′, dC)
+                # Replace when C === B: dB is dC, and C's cotangent is spent here.
+                aliased ? (dB .= G) : (dB .+= G)
             end
-            fill!(dYi, zero(eltype(dYi)))
+            aliased || fill!(dC, zero(eltype(dC)))
             nothing
         end
     end
-    return (nothing, nothing)
+    return (nothing, nothing, nothing, nothing, nothing, nothing)
+end
+
+function EnzymeRules.augmented_primal(
+        config::RevConfig,
+        func::Const{typeof(LinearAlgebra.generic_mattrimul!)},
+        ::Type{RT},
+        C::Annotation{<:AbstractGPUMatrix},
+        uploc::Const{<:AbstractChar},
+        isunitc::Const{<:AbstractChar},
+        tfun::Const,
+        A::Annotation{<:AbstractGPUMatrix},
+        B::Annotation{<:AbstractGPUMatrix},
+    ) where {RT}
+    # `rmul!(A, T)` lands here as C === A.
+    aliased = C.val === A.val
+    cache_A = ((aliased || overwritten(config)[6]) && !(B isa Const) && !(C isa Const)) ?
+        copy(A.val) : nothing
+    cache_B = (overwritten(config)[7] && !(A isa Const) && !(C isa Const)) ? copy(B.val) : nothing
+
+    func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
+
+    primal = needs_primal(config) ? C.val : nothing
+    shadow = needs_shadow(config) ? C.dval : nothing
+    return AugmentedReturn(primal, shadow, (cache_A, cache_B, aliased))
+end
+
+function EnzymeRules.reverse(
+        config::RevConfig,
+        func::Const{typeof(LinearAlgebra.generic_mattrimul!)},
+        ::Type{RT},
+        tape,
+        C::Annotation{<:AbstractGPUMatrix},
+        uploc::Const{<:AbstractChar},
+        isunitc::Const{<:AbstractChar},
+        tfun::Const,
+        A::Annotation{<:AbstractGPUMatrix},
+        B::Annotation{<:AbstractGPUMatrix},
+    ) where {RT}
+    if !(C isa Const)
+        cache_A, cache_B, aliased = tape
+        Aval = cache_A !== nothing ? cache_A : A.val
+        Bval = cache_B !== nothing ? cache_B : B.val
+        M′ = (A isa Const) ? nothing :
+            _triangular_adjoint(Bval, uploc.val, isunitc.val, tfun.val)
+        N = width(config)
+        ntuple(Val(N)) do i
+            Base.@_inline_meta
+            dC = _bget(C.dval, Val(N), i)
+            # dB first: when the shadows alias, dA below overwrites dC.
+            if !(B isa Const)
+                _accumulate_triangular!(
+                    _bget(B.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
+                    adjoint(Aval) * dC,
+                )
+            end
+            if !(A isa Const)
+                dA = _bget(A.dval, Val(N), i)
+                G = LinearAlgebra.mul!(zero(dC), dC, M′)
+                # Replace when C === A: dA is dC, and C's cotangent is spent here.
+                aliased ? (dA .= G) : (dA .+= G)
+            end
+            aliased || fill!(dC, zero(eltype(dC)))
+            nothing
+        end
+    end
+    return (nothing, nothing, nothing, nothing, nothing, nothing)
 end
 
 #=
-dot(a, b) = Σ conj(aᵢ)·bᵢ :  scalar inner product
-
-Pullback: da += conj(dr)·b   (`a` enters conjugated)
-          db += dr·a
-
-The conjugation on `da` is a no-op for real eltypes but required for complex
-ones; both directions are checked against Enzyme's own (rule-free) CPU path in
-test/ext/jlarrays.jl.
+dot(a, b) = Σ conj(aᵢ)·bᵢ, so `da += conj(dr)·b` and `db += dr·a`. The
+asymmetry only shows up for complex eltypes; test/ext/jlarrays.jl pins both
+directions against Enzyme's own rule-free CPU path.
 =#
 
 function EnzymeRules.augmented_primal(
@@ -326,8 +703,7 @@ function EnzymeRules.reverse(
             Base.@_inline_meta
             dr = _bget(dret.val, Val(N), i)
             if !(a isa Const)
-                # `a` enters `dot` conjugated, so its cotangent picks up conj(dr).
-                # No-op for real eltypes.
+                # `a` entered conjugated, so its cotangent picks up conj(dr).
                 _bget(a.dval, Val(N), i) .+= conj(dr) .* bv
             end
             if !(b isa Const)
@@ -339,11 +715,7 @@ function EnzymeRules.reverse(
     return (nothing, nothing)
 end
 
-#=
-sum(x):  scalar reduction
-
-Pullback: dx += dr̄        (scalar broadcast over every element)
-=#
+# sum(x): the return cotangent broadcasts onto every element, `dx += dr`.
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -2,8 +2,7 @@ module EnzymeGPUArraysCoreExt
 
 using GPUArraysCore
 using Enzyme
-using LinearAlgebra: LinearAlgebra, dot, Symmetric, Hermitian, UpperTriangular,
-    LowerTriangular, UnitUpperTriangular, UnitLowerTriangular, triu, tril, diag, diagind
+using LinearAlgebra: LinearAlgebra, dot
 using Enzyme.EnzymeCore: EnzymeCore
 using Enzyme.EnzymeCore.EnzymeRules:
     EnzymeRules,
@@ -84,37 +83,8 @@ a reverse rule that misses the argument's exact type is a hard error.
     return ntuple(i -> Enzyme._project(T, f(i))::T, Val(N))
 end
 
-#=
-Before anything reaches the GPU, `mul!` and `*` strip the wrapper off each
-operand and pass a char for how to read the bare array: 'N' plain, 'T'
-transposed, 'C' adjoint, 'S' Symmetric, 'H' Hermitian, the case naming the
-stored triangle ('S' upper, 's' lower). Julia ≥1.11 sends a `WrapperChar`, which
-holds the case in its own field, so go through `Char` to get the triangle back.
-=#
-@inline _stored_upper(t::AbstractChar) = isuppercase(Char(t))
-
 # `conj`, materialized; a no-op for real eltypes.
 @inline _conj(X) = eltype(X) <: Real ? X : conj.(X)
-
-#=
-`adjoint(wrap(X, t))`, leaving at most one lazy wrapper on the array. The
-backends peel off a single layer, so a nested `adjoint(transpose(X))` (or
-`adjoint(Symmetric(X))` when complex) matches no method and scalar-indexes.
-=#
-@inline function _wrap_adjoint(X, t::AbstractChar)
-    kind = uppercase(t)
-    return if kind == 'N'
-        adjoint(X)
-    elseif kind == 'T'
-        _conj(X)
-    elseif kind == 'C'
-        X
-    elseif kind == 'S'
-        Symmetric(_conj(X), _stored_upper(t) ? :U : :L)
-    else
-        Hermitian(X, _stored_upper(t) ? :U : :L)
-    end
-end
 
 @static if VERSION < v"1.12.0-DEV"
     @inline _gemm!(C, tA::AbstractChar, tB::AbstractChar, A, B, α::Number, β::Number) =
@@ -125,12 +95,10 @@ else
 end
 
 #=
-The ops a char can name -- identity, transpose, conj, adjoint -- form a group
-under composition, so write one as the pair of flags (transposed, conjugated)
-and the pullbacks stop needing a lookup table: `adjoint` flips both flags,
-`transpose` flips the first, and applying either to a product also swaps its two
-operands. `wrap`'s chars cover three of the four combinations; the fourth, a
-bare conj, has to be materialized (`_opdata`), and only for complex eltypes.
+Before anything reaches the GPU, `mul!` and `*` strip the wrapper off each
+operand and pass a char for how to read the bare array: 'N' plain, 'T'
+transposed, 'C' adjoint (and 'S'/'H' for Symmetric/Hermitian, which these rules
+do not handle -- see `_assert_rectangular`).
 =#
 @inline _plain(t::AbstractChar) = (k = uppercase(t); k == 'N' || k == 'T' || k == 'C')
 @inline _opflags(t::AbstractChar) =
@@ -141,38 +109,24 @@ bare conj, has to be materialized (`_opdata`), and only for complex eltypes.
 @inline _opdata(X, f::Tuple{Bool, Bool}) = (!f[1] && f[2]) ? _conj(X) : X
 
 #=
-Accumulate `G` into the shadow of an operand the primal read as `wrap(X, t)`,
-`G` being the (already scaled) cotangent of that wrapped operand. 'T'/'C' only
-transpose it. 'S'/'H' need a projection: one triangle is stored and each of its
-entries feeds two positions of the wrapped matrix, so (i,j) collects
-G[i,j] + G[j,i] and the diagonal collects G[i,i]. Hermitian keeps only the real
-part there, its diagonal being real by construction.
-
-`G` has to arrive scaled by conj(α) rather than scaled here, because the
-Hermitian projection is not linear in that factor: it conjugates one of the two
-terms it sums, and takes the real part of the diagonal.
+Symmetric/Hermitian operands reach the same entry points, as an 'S'/'H' char.
+Their cotangent is not another matmul -- only one triangle is stored, and each
+of its entries feeds two positions of the wrapped matrix, so it has to be
+projected -- and neither is a triangular operand's, which LinearAlgebra routes
+to `generic_trimatmul!`/`generic_mattrimul!` instead. Both are left to a
+follow-up; refusing them here beats handing back the cotangent of the full
+matrix as if it were the cotangent of the stored one.
 =#
-function _accumulate_operand!(dX, t::AbstractChar, G)
-    kind = uppercase(t)
-    if kind == 'N'
-        dX .+= G
-    elseif kind == 'T'
-        dX .+= transpose(G)
-    elseif kind == 'C'
-        dX .+= adjoint(G)
-    else
-        H = kind == 'S' ? G .+ transpose(G) : G .+ adjoint(G)
-        dX .+= _stored_upper(t) ? triu(H, 1) : tril(H, -1)
-        dg = view(dX, diagind(dX))
-        dg .+= kind == 'S' ? diag(G) : real.(diag(G))
+@inline function _assert_rectangular(tA::AbstractChar, tB::AbstractChar)
+    if !(_plain(tA) && _plain(tB))
+        throw(
+            ArgumentError(
+                "Enzyme: reverse mode over a Symmetric/Hermitian GPU array operand is " *
+                    "not supported yet (got wrapper chars '$(Char(tA))' and '$(Char(tB))')"
+            )
+        )
     end
     return nothing
-end
-
-# Scale a cotangent we just allocated, in place, skipping the no-op α = 1 case.
-@inline function _scale!(G, factor)
-    isone(factor) || (G .*= factor)
-    return G
 end
 
 #=
@@ -180,12 +134,9 @@ end
 op `tX`. Both cotangents of a matmul have that shape -- `dC·op(B)'` for the left
 operand, `op(A)'·dC` for the right -- so both go back through
 `generic_matmatmul!` with β = 1, which is the accumulation: no temporary, no
-elementwise pass. Undoing `tX` rewrites the product rather than transposing its
-result, which is where the operand swap comes from.
-
-Symmetric/Hermitian can't play: `adjoint(Symmetric(B))` is not a gemm operand,
-and the cotangent has to be projected onto a triangle regardless, so those form
-the product and hand it to `_accumulate_operand!`.
+elementwise pass, and the scaling rides along as α. Undoing `tX` rewrites the
+product rather than transposing its result, which is where the operand swap
+comes from.
 =#
 function _pullback!(dX, tX::AbstractChar, L, fL, R, fR, factor)
     kind = uppercase(tX)
@@ -205,10 +156,10 @@ end
     generic_matmatmul!(C, tA, tB, A, B, α, β)    C = α·op(A)·op(B) + β·C₀
     generic_matvecmul!(y, tA, A, x, α, β)        y = α·op(A)·x + β·y₀
 
-Where every non-triangular GPU matmul ends up, whether it came from `*` or from
+Where every rectangular GPU matmul ends up, whether it came from `*` or from
 3-/5-arg `mul!`, and whether the backend takes it on to CUBLAS or to the
-GPUArrays fallback kernels. One rule per function therefore covers every wrapper
-combination:
+GPUArrays fallback kernels. One rule per function therefore covers plain,
+transposed and adjointed operands in any combination:
 
     dA += conj(α)·dC·op(B)'          projected back through op(A)
     dB += conj(α)·op(A)'·dC          projected back through op(B)
@@ -230,6 +181,7 @@ before that, so the rules are version-gated wrappers over the two helpers below.
         config, C::Annotation, tA::AbstractChar, tB::AbstractChar, A::Annotation, B::Annotation,
         ovw_A::Bool, ovw_B::Bool, ::Val{α_active}, ::Val{β_active},
     ) where {α_active, β_active}
+    _assert_rectangular(tA, tB)
     #=
     dβ needs C₀, dα the product, dB needs A and dA needs B. A `Const` C means the
     reverse pass returns early and reads none of them, and `cache_prod` costs a
@@ -274,19 +226,14 @@ end
     fB = _opflags(tB)
     a_const = _isconst(config, A)
     b_const = _isconst(config, B)
-    plain = _plain(tA) && _plain(tB)
     ntuple(Val(N)) do i
         Base.@_inline_meta
         dC = _bget(C.dval, Val(N), i)
         if !a_const
-            dA = _bget(A.dval, Val(N), i)
-            plain ? _pullback!(dA, tA, dC, (false, false), Bval, _adjop(fB), αc) :
-                _accumulate_operand!(dA, tA, _scale!(dC * _wrap_adjoint(Bval, tB), αc))
+            _pullback!(_bget(A.dval, Val(N), i), tA, dC, (false, false), Bval, _adjop(fB), αc)
         end
         if !b_const
-            dB = _bget(B.dval, Val(N), i)
-            plain ? _pullback!(dB, tB, Aval, _adjop(fA), dC, (false, false), αc) :
-                _accumulate_operand!(dB, tB, _scale!(_wrap_adjoint(Aval, tA) * dC, αc))
+            _pullback!(_bget(B.dval, Val(N), i), tB, Aval, _adjop(fA), dC, (false, false), αc)
         end
         # β = 1 is the accumulate-into-C case, where this would be a no-op kernel.
         isone(βc) || (dC .*= βc)
@@ -482,187 +429,6 @@ else
 end
 
 #=
-    generic_trimatmul!(C, uploc, isunitc, tfun, A, B)    C = tfun(T(A))·B
-    generic_mattrimul!(C, uploc, isunitc, tfun, A, B)    C = A·tfun(T(B))
-
-Triangular operands never reach `generic_matmatmul!`; LinearAlgebra sends them
-here instead, again bare plus a description of how to read them: `uploc`
-('U'/'L') names the stored triangle, `isunitc` is 'U' when the diagonal is
-structurally 1, and `tfun` is identity/transpose/adjoint. The operand is
-`tfun(T_uploc(A))` -- `transpose(UpperTriangular(X))` arrives as uploc 'U' with
-`tfun` `transpose`. There is no α/β here, `C` is always overwritten, so this is
-where `C`'s cotangent gets consumed. With `M` the operand as the primal reads it:
-
-    dA += tfun(tril/triu(dC·B'))
-    dB += M'·dC
-    dC := 0
-
-`M'·dC` goes through `mul!` into a zeroed buffer, not `*`. The GPUArrays kernels
-for these two end with `C[i,j] += …` rather than `=`, so with the uninitialized
-array `*` allocates they mix junk into the result; zeroing first makes that
-accumulation harmless, and backends that do overwrite (CUBLAS trmm) don't care.
-=#
-
-#=
-`adjoint(tfun(T_uploc(A)))`, again with a single lazy wrapper (see
-`_wrap_adjoint`). Only `identity` leaves an adjoint behind, and with it the
-flipped triangle; `transpose` and `adjoint` cancel against the outer one, the
-former down to a conjugation of the data.
-=#
-@inline function _triangular_adjoint(A, uploc::AbstractChar, isunitc::AbstractChar, tfun::F) where {F}
-    P = tfun === identity ? adjoint(A) : (tfun === transpose ? _conj(A) : A)
-    upper = tfun === identity ? uploc != 'U' : uploc == 'U'
-    return if upper
-        isunitc == 'U' ? UnitUpperTriangular(P) : UpperTriangular(P)
-    else
-        isunitc == 'U' ? UnitLowerTriangular(P) : LowerTriangular(P)
-    end
-end
-
-#=
-Project `G` back onto A's stored triangle, skipping a structurally-fixed unit
-diagonal. `tfun` swaps the triangles, so it can be undone after the projection
-rather than before -- and it has to be, because `triu`/`tril` of a lazy transpose
-drops into a scalar-indexing loop while broadcasting over one is fine.
-=#
-@inline function _accumulate_triangular!(
-        dA, uploc::AbstractChar, isunitc::AbstractChar, tfun::F, G,
-    ) where {F}
-    k = isunitc == 'U' ? 1 : 0
-    upper = tfun === identity ? uploc == 'U' : uploc != 'U'
-    dA .+= tfun(upper ? triu(G, k) : tril(G, -k))
-    return nothing
-end
-
-function EnzymeRules.augmented_primal(
-        config::RevConfig,
-        func::Const{typeof(LinearAlgebra.generic_trimatmul!)},
-        ::Type{RT},
-        C::Annotation{<:AbstractGPUVecOrMat},
-        uploc::Const{<:AbstractChar},
-        isunitc::Const{<:AbstractChar},
-        tfun::Const,
-        A::Annotation{<:AbstractGPUMatrix},
-        B::Annotation{<:AbstractGPUVecOrMat},
-    ) where {RT}
-    # `lmul!(T, B)` arrives as C === B, so the primal overwrites the B that dA needs.
-    aliased = C.val === B.val
-    cache_A = (overwritten(config)[6] && !_isconst(config, B) && !_isconst(config, C)) ? copy(A.val) : nothing
-    cache_B = ((aliased || overwritten(config)[7]) && !_isconst(config, A) && !_isconst(config, C)) ?
-        copy(B.val) : nothing
-
-    func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
-
-    return _augreturn(config, C, (cache_A, cache_B, aliased))
-end
-
-function EnzymeRules.reverse(
-        config::RevConfig,
-        func::Const{typeof(LinearAlgebra.generic_trimatmul!)},
-        ::Type{RT},
-        tape,
-        C::Annotation{<:AbstractGPUVecOrMat},
-        uploc::Const{<:AbstractChar},
-        isunitc::Const{<:AbstractChar},
-        tfun::Const,
-        A::Annotation{<:AbstractGPUMatrix},
-        B::Annotation{<:AbstractGPUVecOrMat},
-    ) where {RT}
-    if !_isconst(config, C)
-        cache_A, cache_B, aliased = tape
-        Aval = cache_A !== nothing ? cache_A : A.val
-        Bval = cache_B !== nothing ? cache_B : B.val
-        M′ = _isconst(config, B) ? nothing :
-            _triangular_adjoint(Aval, uploc.val, isunitc.val, tfun.val)
-        N = width(config)
-        ntuple(Val(N)) do i
-            Base.@_inline_meta
-            dC = _bget(C.dval, Val(N), i)
-            # dA first: when the shadows alias, dB below overwrites dC.
-            if !_isconst(config, A)
-                _accumulate_triangular!(
-                    _bget(A.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
-                    dC * adjoint(Bval),
-                )
-            end
-            if !_isconst(config, B)
-                dB = _bget(B.dval, Val(N), i)
-                G = LinearAlgebra.mul!(zero(dC), M′, dC)
-                # Replace when C === B: dB is dC, and C's cotangent is spent here.
-                aliased ? (dB .= G) : (dB .+= G)
-            end
-            aliased || fill!(dC, zero(eltype(dC)))
-            nothing
-        end
-    end
-    return (nothing, nothing, nothing, nothing, nothing, nothing)
-end
-
-function EnzymeRules.augmented_primal(
-        config::RevConfig,
-        func::Const{typeof(LinearAlgebra.generic_mattrimul!)},
-        ::Type{RT},
-        C::Annotation{<:AbstractGPUMatrix},
-        uploc::Const{<:AbstractChar},
-        isunitc::Const{<:AbstractChar},
-        tfun::Const,
-        A::Annotation{<:AbstractGPUMatrix},
-        B::Annotation{<:AbstractGPUMatrix},
-    ) where {RT}
-    # `rmul!(A, T)` lands here as C === A.
-    aliased = C.val === A.val
-    cache_A = ((aliased || overwritten(config)[6]) && !_isconst(config, B) && !_isconst(config, C)) ?
-        copy(A.val) : nothing
-    cache_B = (overwritten(config)[7] && !_isconst(config, A) && !_isconst(config, C)) ? copy(B.val) : nothing
-
-    func.val(C.val, uploc.val, isunitc.val, tfun.val, A.val, B.val)
-
-    return _augreturn(config, C, (cache_A, cache_B, aliased))
-end
-
-function EnzymeRules.reverse(
-        config::RevConfig,
-        func::Const{typeof(LinearAlgebra.generic_mattrimul!)},
-        ::Type{RT},
-        tape,
-        C::Annotation{<:AbstractGPUMatrix},
-        uploc::Const{<:AbstractChar},
-        isunitc::Const{<:AbstractChar},
-        tfun::Const,
-        A::Annotation{<:AbstractGPUMatrix},
-        B::Annotation{<:AbstractGPUMatrix},
-    ) where {RT}
-    if !_isconst(config, C)
-        cache_A, cache_B, aliased = tape
-        Aval = cache_A !== nothing ? cache_A : A.val
-        Bval = cache_B !== nothing ? cache_B : B.val
-        M′ = _isconst(config, A) ? nothing :
-            _triangular_adjoint(Bval, uploc.val, isunitc.val, tfun.val)
-        N = width(config)
-        ntuple(Val(N)) do i
-            Base.@_inline_meta
-            dC = _bget(C.dval, Val(N), i)
-            # dB first: when the shadows alias, dA below overwrites dC.
-            if !_isconst(config, B)
-                _accumulate_triangular!(
-                    _bget(B.dval, Val(N), i), uploc.val, isunitc.val, tfun.val,
-                    adjoint(Aval) * dC,
-                )
-            end
-            if !_isconst(config, A)
-                dA = _bget(A.dval, Val(N), i)
-                G = LinearAlgebra.mul!(zero(dC), dC, M′)
-                # Replace when C === A: dA is dC, and C's cotangent is spent here.
-                aliased ? (dA .= G) : (dA .+= G)
-            end
-            aliased || fill!(dC, zero(eltype(dC)))
-            nothing
-        end
-    end
-    return (nothing, nothing, nothing, nothing, nothing, nothing)
-end
-
-#=
 dot(a, b) = Σ conj(aᵢ)·bᵢ, so `da += conj(dr)·b` and `db += dr·a`. The
 asymmetry only shows up for complex eltypes; test/ext/jlarrays.jl pins both
 directions against Enzyme's own rule-free CPU path.
@@ -708,36 +474,6 @@ function EnzymeRules.reverse(
         end
     end
     return (nothing, nothing)
-end
-
-# sum(x): the return cotangent broadcasts onto every element, `dx += dr`.
-
-function EnzymeRules.augmented_primal(
-        config::RevConfig,
-        func::Const{typeof(sum)},
-        ::Type,
-        x::Annotation{<:AbstractGPUArray},
-    )
-    primal = needs_primal(config) ? sum(x.val) : nothing
-    return AugmentedReturn(primal, nothing, nothing)
-end
-
-function EnzymeRules.reverse(
-        config::RevConfig,
-        func::Const{typeof(sum)},
-        dret,
-        tape,
-        x::Annotation{<:AbstractGPUArray},
-    )
-    if !(dret isa Const) && !_isconst(config, x)
-        N = width(config)
-        ntuple(Val(N)) do i
-            Base.@_inline_meta
-            _bget(x.dval, Val(N), i) .+= _dret(dret, Val(N), i)
-            nothing
-        end
-    end
-    return (nothing,)
 end
 
 end # module

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -7,7 +7,6 @@ using LinearAlgebra: LinearAlgebra, mul!, dot, Transpose, Adjoint, adjoint,
 using Enzyme.EnzymeCore: EnzymeCore
 using Enzyme.EnzymeCore.EnzymeRules:
     EnzymeRules,
-    FwdConfig,
     RevConfig,
     Annotation,
     AugmentedReturn,
@@ -132,61 +131,12 @@ end
 #=
 mul!(C, A, B, α, β):  C = α·A·B + β·C₀
 
-JVP:      dC = α·(dA·B + A·dB) + β·dC₀   (+ dα·A·B + dβ·C₀)
 Pullback: dA += conj(α)·dC·B'
           dB += conj(α)·A'·dC
           dC := conj(β)·dC                (cotangent w.r.t. C₀)
           dα  = conj(⟨dC, A·B⟩)
           dβ  = conj(⟨dC, C₀⟩)
 =#
-
-function EnzymeRules.forward(
-        config::FwdConfig,
-        func::Const{typeof(mul!)},
-        RT::Type{<:Annotation},
-        C::Annotation{<:AbstractGPUArray},
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
-        α::Annotation{<:Number},
-        β::Annotation{<:Number},
-    )
-    N = width(config)
-    if !(C isa Const)
-        # Update each output tangent from the old tangent values
-        # before the in-place primal overwrites C.val.
-        ntuple(Val(N)) do b
-            Base.@_inline_meta
-            dC = _bget(C.dval, Val(N), b)
-            tmp = β.val .* dC
-            if !(A isa Const)
-                tmp = tmp .+ α.val .* (_bget(A.dval, Val(N), b) * B.val)
-            end
-            if !(B isa Const)
-                tmp = tmp .+ α.val .* (A.val * _bget(B.dval, Val(N), b))
-            end
-            if !(α isa Const)
-                tmp = tmp .+ _bget(α.dval, Val(N), b) .* (A.val * B.val)
-            end
-            if !(β isa Const)
-                tmp = tmp .+ _bget(β.dval, Val(N), b) .* C.val
-            end
-            copyto!(dC, tmp)
-            nothing
-        end
-    end
-
-    func.val(C.val, A.val, B.val, α.val, β.val)
-
-    if needs_primal(config) && needs_shadow(config)
-        return N == 1 ? Duplicated(C.val, C.dval) : BatchDuplicated(C.val, C.dval)
-    elseif needs_shadow(config)
-        return C.dval
-    elseif needs_primal(config)
-        return C.val
-    else
-        return nothing
-    end
-end
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,
@@ -279,42 +229,9 @@ zeroed -- whereas the same operands passed to an explicit 5-arg `mul!` are
 differentiated correctly. So the allocation, not the multiply, is what this
 rule is really for.
 
-JVP:      dY = dA·B + A·dB
 Pullback: dA += dY·B'
           dB += A'·dY
 =#
-
-# dY_i = dA_i·B + A·dB_i  (factored out so inference sees a concrete array type)
-@inline function _matmul_jvp(A::Annotation, B::Annotation, ::Val{N}, i::Int) where {N}
-    if A isa Const
-        return A.val * _bget(B.dval, Val(N), i)
-    elseif B isa Const
-        return _bget(A.dval, Val(N), i) * B.val
-    else
-        return _bget(A.dval, Val(N), i) * B.val .+ A.val * _bget(B.dval, Val(N), i)
-    end
-end
-
-function EnzymeRules.forward(
-        config::FwdConfig,
-        func::Const{typeof(*)},
-        RT::Type{<:Annotation},
-        A::Annotation{<:MaybeWrappedGPU},
-        B::Annotation{<:MaybeWrappedGPU},
-    )
-    if RT <: Const
-        return needs_primal(config) ? A.val * B.val : nothing
-    end
-
-    N = width(config)
-    if N == 1
-        dY = _matmul_jvp(A, B, Val(1), 1)
-        return RT <: DuplicatedNoNeed ? dY : Duplicated(A.val * B.val, dY)
-    else
-        dY = ntuple(i -> _matmul_jvp(A, B, Val(N), i), Val(N))
-        return RT <: BatchDuplicatedNoNeed ? dY : BatchDuplicated(A.val * B.val, dY)
-    end
-end
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,
@@ -371,7 +288,6 @@ end
 #=
 dot(a, b) = Σ conj(aᵢ)·bᵢ :  scalar inner product
 
-JVP:      dr  = ⟨da, b⟩ + ⟨a, db⟩
 Pullback: da += conj(dr)·b   (`a` enters conjugated)
           db += dr·a
 
@@ -379,34 +295,6 @@ The conjugation on `da` is a no-op for real eltypes but required for complex
 ones; both directions are checked against Enzyme's own (rule-free) CPU path in
 test/ext/jlarrays.jl.
 =#
-
-function EnzymeRules.forward(
-        config::FwdConfig,
-        func::Const{typeof(dot)},
-        RT::Type{<:Annotation},
-        a::Annotation{<:AbstractGPUArray},
-        b::Annotation{<:AbstractGPUArray},
-    )
-    if needs_shadow(config)
-        N = width(config)
-        z = zero(promote_type(eltype(a.val), eltype(b.val)))
-        if N == 1
-            dr = (a isa Const ? z : dot(a.dval, b.val)) + (b isa Const ? z : dot(a.val, b.dval))
-            return needs_primal(config) ? Duplicated(dot(a.val, b.val), dr) : dr
-        else
-            dr = ntuple(
-                i -> (a isa Const ? z : dot(_bget(a.dval, Val(N), i), b.val)) +
-                    (b isa Const ? z : dot(a.val, _bget(b.dval, Val(N), i))),
-                Val(N),
-            )
-            return needs_primal(config) ? BatchDuplicated(dot(a.val, b.val), dr) : dr
-        end
-    elseif needs_primal(config)
-        return dot(a.val, b.val)
-    else
-        return nothing
-    end
-end
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,
@@ -454,31 +342,8 @@ end
 #=
 sum(x):  scalar reduction
 
-JVP:      dr  = sum(dx)
 Pullback: dx += dr̄        (scalar broadcast over every element)
 =#
-
-function EnzymeRules.forward(
-        config::FwdConfig,
-        func::Const{typeof(sum)},
-        RT::Type{<:Annotation},
-        x::Annotation{<:AbstractGPUArray},
-    )
-    if needs_shadow(config)
-        N = width(config)
-        if N == 1
-            dr = x isa Const ? zero(eltype(x.val)) : sum(x.dval)
-            return needs_primal(config) ? Duplicated(sum(x.val), dr) : dr
-        else
-            dr = ntuple(i -> x isa Const ? zero(eltype(x.val)) : sum(_bget(x.dval, Val(N), i)), Val(N))
-            return needs_primal(config) ? BatchDuplicated(sum(x.val), dr) : dr
-        end
-    elseif needs_primal(config)
-        return sum(x.val)
-    else
-        return nothing
-    end
-end
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -8,7 +8,7 @@ using Enzyme.EnzymeCore.EnzymeRules:
     EnzymeRules,
     RevConfig,
     Annotation,
-    AugmentedReturn,
+    augmented_rule_return_type,
     needs_primal,
     needs_shadow,
     overwritten,
@@ -49,41 +49,54 @@ end
 @inline _bget(x, ::Val{1}, ::Int) = x
 @inline _bget(x, ::Val{N}, i::Int) where {N} = x[i]
 
-#=
-The cotangent of an `Active` return. Batching splits this differently from a
-shadow: it is one `Active` at width 1 but an N-tuple *of* `Active`s above it,
-not an `Active` holding a tuple, so the unwrap has to happen per element.
-=#
+# Unwraps the return cotangent. At width > 1 `dret` is a tuple of `Active`s, not
+# one `Active` holding a tuple.
 @inline _dret(dret, w::Val, i::Int) = _bget(dret, w, i).val
 
-#=
-An operand contributes no cotangent when it is `Const`, and also when runtime
-activity hands us a `Duplicated` whose shadow is the primal itself -- writing to
-that would corrupt the value the augmented pass just computed.
-=#
+# True when an operand takes no cotangent: `Const`, or a runtime-activity shadow
+# that aliases the primal. Writing to the latter would clobber the primal.
 @inline _isconst(_, ::Const) = true
 @inline _isconst(config, x::Annotation) =
     EnzymeRules.runtime_activity(config) && x.dval === x.val
 
-# Every rule here returns its output argument and stashes a tape.
-@inline _augreturn(config, out::Annotation, tape) = AugmentedReturn(
-    needs_primal(config) ? out.val : nothing,
-    needs_shadow(config) ? out.dval : nothing,
-    tape,
-)
-
 #=
-Cotangent of an `Active` scalar argument: `f(i)`'s raw (possibly complex)
-contribution projected onto `T`, bare at width 1 and an N-tuple when batched.
-Dispatch on `Val{N}` rather than branching on `N == 1`, which infers as `Any` --
-a reverse rule that misses the argument's exact type is a hard error.
+Augmented return for the rules here: output argument plus a tape. Enzyme checks
+the primal/shadow types, so get them from `augmented_rule_return_type`. Use the
+2-arg form; the 3-arg one is `@generated` on the tape type, and a tape holding an
+`A·B` product doesn't always infer.
 =#
-@inline _dscalar(::Val{1}, ::Type{T}, f::F) where {T, F} = Enzyme._project(T, f(1))::T
-@inline function _dscalar(::Val{N}, ::Type{T}, f::F) where {N, T, F}
-    return ntuple(i -> Enzyme._project(T, f(i))::T, Val(N))
+@inline function _augreturn(config, ::Type{RT}, out::Annotation, tape) where {RT}
+    return augmented_rule_return_type(config, RT)(
+        needs_primal(config) ? out.val : nothing,
+        needs_shadow(config) ? out.dval : nothing,
+        tape,
+    )
 end
 
-# `conj`, materialized; a no-op for real eltypes.
+# `conj(⟨dCᵢ, M⟩)` as a `T`: batch element `i`'s share of dα or dβ. A struct
+# instead of a closure so `ntuple` gets something concrete.
+struct _DotCotangent{T, W, D, M}
+    dvals::D
+    mat::M
+end
+@inline _DotCotangent{T}(::Val{W}, dvals::D, mat::M) where {T, W, D, M} =
+    _DotCotangent{T, W, D, M}(dvals, mat)
+@inline (f::_DotCotangent{T, W})(i::Int) where {T, W} =
+    Enzyme._project(T, conj(dot(_bget(f.dvals, Val(W), i), f.mat)))::T
+
+# Cotangent of an `Active` scalar: bare at width 1, an N-tuple when batched.
+# Dispatch on `Val{N}` rather than an `N == 1` branch, which infers as `Any`.
+# Returning the wrong type here is a hard error.
+@inline _dscalar(w::Val{1}, ::Type{T}, dvals, M) where {T} =
+    _DotCotangent{T}(w, dvals, M)(1)
+@inline _dscalar(w::Val{N}, ::Type{T}, dvals, M) where {N, T} =
+    ntuple(_DotCotangent{T}(w, dvals, M), Val(N))
+
+# Same shape, zero value.
+@inline _dzero(::Val{1}, ::Type{T}) where {T} = zero(T)
+@inline _dzero(::Val{N}, ::Type{T}) where {N, T} = ntuple(Returns(zero(T)), Val(N))
+
+# Materialized `conj`. No-op for real eltypes.
 @inline _conj(X) = eltype(X) <: Real ? X : conj.(X)
 
 @static if VERSION < v"1.12.0-DEV"
@@ -94,12 +107,8 @@ else
         LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, α, β)
 end
 
-#=
-Before anything reaches the GPU, `mul!` and `*` strip the wrapper off each
-operand and pass a char for how to read the bare array: 'N' plain, 'T'
-transposed, 'C' adjoint (and 'S'/'H' for Symmetric/Hermitian, which these rules
-do not handle -- see `_assert_rectangular`).
-=#
+# `mul!` and `*` unwrap each operand and pass a char saying how to read the bare
+# array: 'N' plain, 'T' transposed, 'C' adjoint, 'S'/'H' Symmetric/Hermitian.
 @inline _plain(t::AbstractChar) = (k = uppercase(t); k == 'N' || k == 'T' || k == 'C')
 @inline _opflags(t::AbstractChar) =
     (k = uppercase(t); k == 'N' ? (false, false) : k == 'T' ? (true, false) : (true, true))
@@ -109,13 +118,11 @@ do not handle -- see `_assert_rectangular`).
 @inline _opdata(X, f::Tuple{Bool, Bool}) = (!f[1] && f[2]) ? _conj(X) : X
 
 #=
-Symmetric/Hermitian operands reach the same entry points, as an 'S'/'H' char.
-Their cotangent is not another matmul -- only one triangle is stored, and each
-of its entries feeds two positions of the wrapped matrix, so it has to be
-projected -- and neither is a triangular operand's, which LinearAlgebra routes
-to `generic_trimatmul!`/`generic_mattrimul!` instead. Both are left to a
-follow-up; refusing them here beats handing back the cotangent of the full
-matrix as if it were the cotangent of the stored one.
+Symmetric/Hermitian operands show up as 'S'/'H'. Only one triangle is stored and
+each entry feeds two positions, so their cotangent needs a projection instead of
+a matmul. Reject them rather than return the full matrix's cotangent. Triangular
+operands go to `generic_trimatmul!`/`generic_mattrimul!` and never get here. Both
+are follow-up work.
 =#
 @inline function _assert_rectangular(tA::AbstractChar, tB::AbstractChar)
     if !(_plain(tA) && _plain(tB))
@@ -130,13 +137,12 @@ matrix as if it were the cotangent of the stored one.
 end
 
 #=
-`dX += factor · op(L, fL) · op(R, fR)`, projected back through the operand's own
-op `tX`. Both cotangents of a matmul have that shape -- `dC·op(B)'` for the left
-operand, `op(A)'·dC` for the right -- so both go back through
-`generic_matmatmul!` with β = 1, which is the accumulation: no temporary, no
-elementwise pass, and the scaling rides along as α. Undoing `tX` rewrites the
-product rather than transposing its result, which is where the operand swap
-comes from.
+`dX += factor · op(L, fL) · op(R, fR)`, projected back through `tX`, the op on the
+operand being written to. Both matmul cotangents have this shape (`dC·op(B)'` for
+the left operand, `op(A)'·dC` for the right), so both go through
+`generic_matmatmul!` with β = 1, which accumulates in place with no temporary and
+takes `factor` as α. Undoing `tX` rewrites the product instead of transposing the
+result, so the operands swap.
 =#
 function _pullback!(dX, tX::AbstractChar, L, fL, R, fR, factor)
     kind = uppercase(tX)
@@ -156,9 +162,8 @@ end
     generic_matmatmul!(C, tA, tB, A, B, α, β)    C = α·op(A)·op(B) + β·C₀
     generic_matvecmul!(y, tA, A, x, α, β)        y = α·op(A)·x + β·y₀
 
-Where every rectangular GPU matmul ends up, whether it came from `*` or from
-3-/5-arg `mul!`, and whether the backend takes it on to CUBLAS or to the
-GPUArrays fallback kernels. One rule per function therefore covers plain,
+Every rectangular GPU matmul goes through these, from `*` or 3-/5-arg `mul!`, on
+CUBLAS or on the GPUArrays fallback kernels. One rule each covers plain,
 transposed and adjointed operands in any combination:
 
     dA += conj(α)·dC·op(B)'          projected back through op(A)
@@ -167,14 +172,14 @@ transposed and adjointed operands in any combination:
     dα  = conj(⟨dC, op(A)·op(B)⟩)
     dβ  = conj(⟨dC, C₀⟩)
 
-The first two are matmuls with a transposition, so they go back through this
-same function with β = 1 and nothing is accumulated by hand -- see `_pullback!`.
+The first two are matmuls, so they go back through this same function with β = 1
+instead of accumulating by hand. See `_pullback!`.
 
-3-arg `mul!` lands here with α = true, β = false, so `dC` gets zeroed, as it
-must: that form overwrites `C` instead of accumulating into it.
+3-arg `mul!` arrives as α = true, β = false, which zeroes `dC`. That's right:
+3-arg `mul!` overwrites `C`.
 
-α and β are separate arguments on Julia ≥1.12 and packed into a `MulAddMul`
-before that, so the rules are version-gated wrappers over the two helpers below.
+α and β are separate arguments on Julia ≥1.12 and one `MulAddMul` before that, so
+the rules below are version-gated wrappers over two shared helpers.
 =#
 
 @inline function _matmul_caches(
@@ -182,11 +187,9 @@ before that, so the rules are version-gated wrappers over the two helpers below.
         ovw_A::Bool, ovw_B::Bool, ::Val{α_active}, ::Val{β_active},
     ) where {α_active, β_active}
     _assert_rectangular(tA, tB)
-    #=
-    dβ needs C₀, dα the product, dB needs A and dA needs B. A `Const` C means the
-    reverse pass returns early and reads none of them, and `cache_prod` costs a
-    second matmul, so gate everything on the cotangent actually being wanted.
-    =#
+    # dβ needs C₀, dα the product, dA needs B, dB needs A. A `Const` C makes the
+    # reverse pass return early and read none of them, and `cache_prod` costs an
+    # extra matmul, so only cache what will actually be read.
     c_const = _isconst(config, C)
     cache_C = (β_active && !c_const) ? copy(C.val) : nothing
     cache_A = (ovw_A && !_isconst(config, B) && !c_const) ? copy(A.val) : nothing
@@ -202,9 +205,9 @@ end
     ) where {α_active, β_active}
     N = width(config)
     if _isconst(config, C)
-        # Without C's shadow there is nothing to pull back from.
-        dα = α_active ? _dscalar(Val(N), typeof(αval), Returns(zero(αval))) : nothing
-        dβ = β_active ? _dscalar(Val(N), typeof(βval), Returns(zero(βval))) : nothing
+        # No shadow on C means nothing to pull back.
+        dα = α_active ? _dzero(Val(N), typeof(αval)) : nothing
+        dβ = β_active ? _dzero(Val(N), typeof(βval)) : nothing
         return (dα, dβ)
     end
 
@@ -213,12 +216,8 @@ end
     Aval = cache_A !== nothing ? cache_A : A.val
     Bval = cache_B !== nothing ? cache_B : B.val
 
-    dα = α_active ?
-        _dscalar(Val(N), typeof(αval), i -> conj(dot(_bget(C.dval, Val(N), i), cache_prod))) :
-        nothing
-    dβ = β_active ?
-        _dscalar(Val(N), typeof(βval), i -> conj(dot(_bget(C.dval, Val(N), i), Cval))) :
-        nothing
+    dα = α_active ? _dscalar(Val(N), typeof(αval), C.dval, cache_prod) : nothing
+    dβ = β_active ? _dscalar(Val(N), typeof(βval), C.dval, Cval) : nothing
 
     αc = conj(αval)
     βc = conj(βval)
@@ -235,7 +234,7 @@ end
         if !b_const
             _pullback!(_bget(B.dval, Val(N), i), tB, Aval, _adjop(fA), dC, (false, false), αc)
         end
-        # β = 1 is the accumulate-into-C case, where this would be a no-op kernel.
+        # Skip the scale at β = 1; it would be a no-op kernel.
         isone(βc) || (dC .*= βc)
         nothing
     end
@@ -245,13 +244,21 @@ end
 
 @static if VERSION < v"1.12.0-DEV"
 
-    #=
-    With α and β packed into one `MulAddMul`, an active α or β arrives as a
-    single active struct, so its cotangent has to come back as that struct type.
-    =#
+    # Here α and β are one `MulAddMul`, so an active α or β is a single active
+    # struct and its cotangent comes back as that struct.
+
+    # `i -> MAM(dα[i], dβ[i])` without the closure.
+    struct _PackMulAddMul{MAM, A, B}
+        dα::A
+        dβ::B
+    end
+    @inline _PackMulAddMul{MAM}(dα::A, dβ::B) where {MAM, A, B} =
+        _PackMulAddMul{MAM, A, B}(dα, dβ)
+    @inline (f::_PackMulAddMul{MAM})(i::Int) where {MAM} = MAM(f.dα[i], f.dβ[i])
+
     @inline _dmuladdmul(::Val{1}, ::Type{MAM}, dα, dβ) where {MAM} = MAM(dα, dβ)
     @inline function _dmuladdmul(::Val{N}, ::Type{MAM}, dα, dβ) where {N, MAM}
-        return ntuple(i -> MAM(dα[i], dβ[i]), Val(N))
+        return ntuple(_PackMulAddMul{MAM}(dα, dβ), Val(N))
     end
 
     function EnzymeRules.augmented_primal(
@@ -273,7 +280,7 @@ end
 
         func.val(C.val, tA.val, tB.val, A.val, B.val, add.val)
 
-        return _augreturn(config, C, tape)
+        return _augreturn(config, RT, C, tape)
     end
 
     function EnzymeRules.reverse(
@@ -316,7 +323,7 @@ end
 
         func.val(y.val, tA.val, A.val, x.val, add.val)
 
-        return _augreturn(config, y, tape)
+        return _augreturn(config, RT, y, tape)
     end
 
     function EnzymeRules.reverse(
@@ -362,7 +369,7 @@ else
 
         func.val(C.val, tA.val, tB.val, A.val, B.val, α.val, β.val)
 
-        return _augreturn(config, C, tape)
+        return _augreturn(config, RT, C, tape)
     end
 
     function EnzymeRules.reverse(
@@ -404,7 +411,7 @@ else
 
         func.val(y.val, tA.val, A.val, x.val, α.val, β.val)
 
-        return _augreturn(config, y, tape)
+        return _augreturn(config, RT, y, tape)
     end
 
     function EnzymeRules.reverse(
@@ -428,23 +435,23 @@ else
 
 end
 
-#=
-dot(a, b) = Σ conj(aᵢ)·bᵢ, so `da += conj(dr)·b` and `db += dr·a`. The
-asymmetry only shows up for complex eltypes; test/ext/jlarrays.jl pins both
-directions against Enzyme's own rule-free CPU path.
-=#
+# dot(a, b) = Σ conj(aᵢ)·bᵢ, so `da += conj(dr)·b` and `db += dr·a`. The asymmetry
+# only shows up for complex eltypes.
 
 function EnzymeRules.augmented_primal(
         config::RevConfig,
         func::Const{typeof(dot)},
-        ::Type,
+        ::Type{RT},
         a::Annotation{<:AbstractGPUArray},
         b::Annotation{<:AbstractGPUArray},
-    )
-    primal = needs_primal(config) ? dot(a.val, b.val) : nothing
+    ) where {RT}
     cache_a = (overwritten(config)[2] && !_isconst(config, b)) ? copy(a.val) : nothing
     cache_b = (overwritten(config)[3] && !_isconst(config, a)) ? copy(b.val) : nothing
-    return AugmentedReturn(primal, nothing, (cache_a, cache_b))
+    tape = (cache_a, cache_b)
+    # A scalar return is `Active`, so there's no shadow to return.
+    return augmented_rule_return_type(config, RT)(
+        needs_primal(config) ? dot(a.val, b.val) : nothing, nothing, tape,
+    )
 end
 
 function EnzymeRules.reverse(
@@ -463,8 +470,16 @@ function EnzymeRules.reverse(
         ntuple(Val(N)) do i
             Base.@_inline_meta
             dr = _dret(dret, Val(N), i)
+            #= axpy! is slower. measured on 5090
+            n	        broadcastmed (µs)	axpy! med (µs)	ratio
+            1 000	    15.90	            23.34	        1.47
+            100 000	    18.76	            22.78	        1.21
+            1 000 000	19.30	            23.38	        1.21
+            10 000 000	163.05	            162.54	        1.00
+            100 000 000	1534	            1537	        1.00
+            =#
             if !_isconst(config, a)
-                # `a` entered conjugated, so its cotangent picks up conj(dr).
+                # `a` is conjugated in the primal, so dr comes back conjugated.
                 _bget(a.dval, Val(N), i) .+= conj(dr) .* bv
             end
             if !_isconst(config, b)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,8 +1,7 @@
 using CUDA
 using Enzyme
-using LinearAlgebra: dot
-using Test
 using LinearAlgebra: mul!, dot, UpperTriangular, LowerTriangular, Symmetric, Hermitian
+using Test
 
 @testset "CUDA memory copies" begin
     #= Exercise the reverse copy rules across CUDA's memory types. A host<->device

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -2,6 +2,7 @@ using CUDA
 using Enzyme
 using LinearAlgebra: dot
 using Test
+using LinearAlgebra: mul!, dot
 
 @testset "CUDA memory copies" begin
     #= Exercise the reverse copy rules across CUDA's memory types. A host<->device
@@ -242,4 +243,86 @@ end
     Enzyme.autodiff(Reverse, square!, BatchDuplicated(A, (dA, dA2)))
     @test all(dA .≈ (2:2:64))
     @test all(dA2 .≈ 3*(2:2:64))
+end
+
+# Rules from EnzymeGPUArraysCoreExt for dense matmul / dot / sum on GPU arrays.
+@testset "GPUArrays linalg rules" begin
+    cu(x) = CuArray(x)
+
+    @testset "matmul reverse" begin
+        A0 = randn(Float32, 3, 4)
+        B0 = randn(Float32, 4, 2)
+        dA = cu(zero(A0))
+        dB = cu(zero(B0))
+        Enzyme.autodiff(Reverse, (A, B) -> sum(A * B), Active, Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
+        @test Array(dA) ≈ ones(Float32, 3, 2) * B0'
+        @test Array(dB) ≈ A0' * ones(Float32, 3, 2)
+    end
+
+    @testset "composed transpose matmul" begin
+        X0 = randn(Float32, 6, 3)
+        β0 = randn(Float32, 3)
+        dX = cu(zero(X0))
+        dβ = cu(zero(β0))
+        Enzyme.autodiff(Reverse, (X, β) -> sum(transpose(X) * (X * β)), Active, Duplicated(cu(X0), dX), Duplicated(cu(β0), dβ))
+        ϵ = 1.0f-3
+        fdβ = map(eachindex(β0)) do i
+            βp = copy(β0); βp[i] += ϵ
+            βm = copy(β0); βm[i] -= ϵ
+            (sum(transpose(X0) * (X0 * βp)) - sum(transpose(X0) * (X0 * βm))) / (2ϵ)
+        end
+        @test Array(dβ) ≈ fdβ rtol = 1.0f-2
+    end
+
+    @testset "mul! reverse (preallocated)" begin
+        A0 = randn(Float32, 3, 4)
+        B0 = randn(Float32, 4, 2)
+        dA = cu(zero(A0))
+        dB = cu(zero(B0))
+        function loss(C, A, B)
+            mul!(C, A, B)
+            return sum(C)
+        end
+        C = cu(zeros(Float32, 3, 2))
+        dC = cu(zeros(Float32, 3, 2))
+        Enzyme.autodiff(Reverse, loss, Active, Duplicated(C, dC), Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
+        @test Array(dA) ≈ ones(Float32, 3, 2) * B0'
+        @test Array(dB) ≈ A0' * ones(Float32, 3, 2)
+    end
+
+    @testset "dot reverse" begin
+        a0 = randn(Float32, 8)
+        b0 = randn(Float32, 8)
+        da = cu(zero(a0))
+        db = cu(zero(b0))
+        Enzyme.autodiff(Reverse, (a, b) -> dot(a, b), Active, Duplicated(cu(a0), da), Duplicated(cu(b0), db))
+        @test Array(da) ≈ b0
+        @test Array(db) ≈ a0
+    end
+
+    @testset "sum reverse" begin
+        x0 = randn(Float32, 10)
+        dx = cu(zero(x0))
+        Enzyme.autodiff(Reverse, sum, Active, Duplicated(cu(x0), dx))
+        @test all(Array(dx) .≈ 1)
+    end
+
+    @testset "sum(A .* B) broadcast reduction" begin
+        A0 = randn(Float32, 4, 5)
+        B0 = randn(Float32, 4, 5)
+        dA = cu(zero(A0))
+        dB = cu(zero(B0))
+        Enzyme.autodiff(Reverse, (A, B) -> sum(A .* B), Active, Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
+        @test Array(dA) ≈ B0
+        @test Array(dB) ≈ A0
+    end
+
+    @testset "matmul forward" begin
+        A0 = randn(Float32, 3, 4)
+        B0 = randn(Float32, 4, 2)
+        dA = randn(Float32, 3, 4)
+        dB = randn(Float32, 4, 2)
+        out = Enzyme.autodiff(Forward, (A, B) -> A * B, Duplicated, Duplicated(cu(A0), cu(dA)), Duplicated(cu(B0), cu(dB)))
+        @test Array(out[1]) ≈ dA * B0 + A0 * dB
+    end
 end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,6 +1,6 @@
 using CUDA
 using Enzyme
-using LinearAlgebra: mul!, dot, UpperTriangular, LowerTriangular, Symmetric, Hermitian
+using LinearAlgebra: mul!, dot, Symmetric
 using Test
 
 @testset "CUDA memory copies" begin
@@ -244,7 +244,9 @@ end
     @test all(dA2 .≈ 3*(2:2:64))
 end
 
-# Rules from EnzymeGPUArraysCoreExt for dense matmul / dot / sum on GPU arrays.
+#=
+Rules from EnzymeGPUArraysCoreExt for dense matmul / dot on GPU arrays. 
+=#
 @testset "GPUArrays linalg rules" begin
     cu(x) = CuArray(x)
 
@@ -278,13 +280,13 @@ end
         B0 = randn(Float32, 4, 2)
         dA = cu(zero(A0))
         dB = cu(zero(B0))
-        function loss(C, A, B)
+        function matmul!(C, A, B)
             mul!(C, A, B)
-            return sum(C)
+            return nothing
         end
         C = cu(zeros(Float32, 3, 2))
-        dC = cu(zeros(Float32, 3, 2))
-        Enzyme.autodiff(Reverse, loss, Active, Duplicated(C, dC), Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
+        dC = cu(ones(Float32, 3, 2))
+        Enzyme.autodiff(Reverse, matmul!, Const, Duplicated(C, dC), Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
         @test Array(dA) ≈ ones(Float32, 3, 2) * B0'
         @test Array(dB) ≈ A0' * ones(Float32, 3, 2)
     end
@@ -299,48 +301,20 @@ end
         @test Array(db) ≈ a0
     end
 
-    @testset "sum reverse" begin
-        x0 = randn(Float32, 10)
-        dx = cu(zero(x0))
-        Enzyme.autodiff(Reverse, sum, Active, Duplicated(cu(x0), dx))
-        @test all(Array(dx) .≈ 1)
-    end
-
-    @testset "sum(A .* B) broadcast reduction" begin
-        A0 = randn(Float32, 4, 5)
-        B0 = randn(Float32, 4, 5)
-        dA = cu(zero(A0))
-        dB = cu(zero(B0))
-        Enzyme.autodiff(Reverse, (A, B) -> sum(A .* B), Active, Duplicated(cu(A0), dA), Duplicated(cu(B0), dB))
-        @test Array(dA) ≈ B0
-        @test Array(dB) ≈ A0
-    end
-
-    # Structured operands: primal uses the specialized BLAS kernel; reverse
-    # projects the cotangent onto the wrapper's stored entries. Ground truth is
-    # central finite differences over the underlying data.
-    @testset "structured operand: $name" for (name, wrap) in (
-            ("UpperTriangular", UpperTriangular),
-            ("LowerTriangular", LowerTriangular),
-            ("Symmetric(:U)", X -> Symmetric(X, :U)),
-            ("Symmetric(:L)", X -> Symmetric(X, :L)),
-            ("Hermitian(:U)", X -> Hermitian(X, :U)),
-        )
+    # Symmetric/Hermitian reach `generic_matmatmul!` as an 'S'/'H' char; the rule
+    # refuses them rather than handing back the cotangent of the full matrix.
+    @testset "Symmetric operand is rejected" begin
         n = 4
         X0 = randn(Float32, n, n)
-        B0 = randn(Float32, n, 3)
         dX = cu(zero(X0))
-        Enzyme.autodiff(
-            Reverse, (A, B) -> sum(A * B), Active,
-            Duplicated(wrap(cu(X0)), wrap(dX)), Const(cu(B0)),
-        )
-        ϵ = 1.0f-3
-        fd = zero(X0)
-        for idx in eachindex(X0)
-            Xp = copy(X0); Xp[idx] += ϵ
-            Xm = copy(X0); Xm[idx] -= ϵ
-            fd[idx] = (sum(wrap(Xp) * B0) - sum(wrap(Xm) * B0)) / (2ϵ)
+        function matmul!(C, A, B)
+            mul!(C, A, B)
+            return nothing
         end
-        @test Array(dX) ≈ fd rtol = 1.0f-2
+        @test_throws ArgumentError Enzyme.autodiff(
+            Reverse, matmul!, Const,
+            Duplicated(cu(zeros(Float32, n, 3)), cu(ones(Float32, n, 3))),
+            Duplicated(Symmetric(cu(X0), :U), Symmetric(dX, :U)), Const(cu(randn(Float32, n, 3))),
+        )
     end
 end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -316,15 +316,6 @@ end
         @test Array(dB) ≈ A0
     end
 
-    @testset "matmul forward" begin
-        A0 = randn(Float32, 3, 4)
-        B0 = randn(Float32, 4, 2)
-        dA = randn(Float32, 3, 4)
-        dB = randn(Float32, 4, 2)
-        out = Enzyme.autodiff(Forward, (A, B) -> A * B, Duplicated, Duplicated(cu(A0), cu(dA)), Duplicated(cu(B0), cu(dB)))
-        @test Array(out[1]) ≈ dA * B0 + A0 * dB
-    end
-
     # Structured operands: primal uses the specialized BLAS kernel; reverse
     # projects the cotangent onto the wrapper's stored entries. Ground truth is
     # central finite differences over the underlying data.

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -2,7 +2,7 @@ using CUDA
 using Enzyme
 using LinearAlgebra: dot
 using Test
-using LinearAlgebra: mul!, dot
+using LinearAlgebra: mul!, dot, UpperTriangular, LowerTriangular, Symmetric, Hermitian
 
 @testset "CUDA memory copies" begin
     #= Exercise the reverse copy rules across CUDA's memory types. A host<->device
@@ -324,5 +324,33 @@ end
         dB = randn(Float32, 4, 2)
         out = Enzyme.autodiff(Forward, (A, B) -> A * B, Duplicated, Duplicated(cu(A0), cu(dA)), Duplicated(cu(B0), cu(dB)))
         @test Array(out[1]) ≈ dA * B0 + A0 * dB
+    end
+
+    # Structured operands: primal uses the specialized BLAS kernel; reverse
+    # projects the cotangent onto the wrapper's stored entries. Ground truth is
+    # central finite differences over the underlying data.
+    @testset "structured operand: $name" for (name, wrap) in (
+            ("UpperTriangular", UpperTriangular),
+            ("LowerTriangular", LowerTriangular),
+            ("Symmetric(:U)", X -> Symmetric(X, :U)),
+            ("Symmetric(:L)", X -> Symmetric(X, :L)),
+            ("Hermitian(:U)", X -> Hermitian(X, :U)),
+        )
+        n = 4
+        X0 = randn(Float32, n, n)
+        B0 = randn(Float32, n, 3)
+        dX = cu(zero(X0))
+        Enzyme.autodiff(
+            Reverse, (A, B) -> sum(A * B), Active,
+            Duplicated(wrap(cu(X0)), wrap(dX)), Const(cu(B0)),
+        )
+        ϵ = 1.0f-3
+        fd = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            fd[idx] = (sum(wrap(Xp) * B0) - sum(wrap(Xm) * B0)) / (2ϵ)
+        end
+        @test Array(dX) ≈ fd rtol = 1.0f-2
     end
 end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -245,11 +245,15 @@ end
 end
 
 #=
-Rules from EnzymeGPUArraysCoreExt for dense matmul / dot on GPU arrays. 
+The matmul/dot rules on a real backend, where they route through CUBLAS instead of
+the GPUArrays fallback kernels. This file also covers the allocating `A * B` and
+reductions over the result, neither of which works on JLArray (see
+test/ext/jlarrays.jl for why, and for the rest of the coverage).
 =#
 @testset "GPUArrays linalg rules" begin
     cu(x) = CuArray(x)
 
+    # sum(A·B) seeds dC with ones, so dA = ones·B' and dB = A'·ones.
     @testset "matmul reverse" begin
         A0 = randn(Float32, 3, 4)
         B0 = randn(Float32, 4, 2)
@@ -260,6 +264,8 @@ Rules from EnzymeGPUArraysCoreExt for dense matmul / dot on GPU arrays.
         @test Array(dB) ≈ A0' * ones(Float32, 3, 2)
     end
 
+    # `X` plain and transposed in one loss, so both cotangents accumulate into the
+    # same shadow. Checked against central differences.
     @testset "composed transpose matmul" begin
         X0 = randn(Float32, 6, 3)
         β0 = randn(Float32, 3)
@@ -275,6 +281,7 @@ Rules from EnzymeGPUArraysCoreExt for dense matmul / dot on GPU arrays.
         @test Array(dβ) ≈ fdβ rtol = 1.0f-2
     end
 
+    # 3-arg `mul!` on an explicit buffer, the path the JLArray tests use throughout.
     @testset "mul! reverse (preallocated)" begin
         A0 = randn(Float32, 3, 4)
         B0 = randn(Float32, 4, 2)
@@ -301,8 +308,8 @@ Rules from EnzymeGPUArraysCoreExt for dense matmul / dot on GPU arrays.
         @test Array(db) ≈ a0
     end
 
-    # Symmetric/Hermitian reach `generic_matmatmul!` as an 'S'/'H' char; the rule
-    # refuses them rather than handing back the cotangent of the full matrix.
+    # Symmetric/Hermitian operands aren't supported yet; the rule rejects them
+    # instead of returning the full matrix's cotangent.
     @testset "Symmetric operand is rejected" begin
         n = 4
         X0 = randn(Float32, n, n)

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -1,5 +1,5 @@
 using Enzyme, Test, JLArrays
-using LinearAlgebra: mul!, dot
+using LinearAlgebra: mul!, dot, UpperTriangular, LowerTriangular, Symmetric, Hermitian
 
 function jlres(x)
     2 * collect(x)
@@ -84,5 +84,55 @@ end
             Duplicated(jl(A0), jl(dA)), Duplicated(jl(B0), jl(dB)),
         )
         @test collect(out[1]) ≈ dA * B0 + A0 * dB
+    end
+
+    # Structured operands (triangular / symmetric / hermitian). The primal goes
+    # through the specialized BLAS kernel; the reverse must project the cotangent
+    # onto the wrapper's stored entries. Ground truth is central finite
+    # differences over the underlying data (non-stored entries must stay 0).
+    @testset "structured operand: $name" for (name, wrap) in (
+            ("UpperTriangular", UpperTriangular),
+            ("LowerTriangular", LowerTriangular),
+            ("Symmetric(:U)", X -> Symmetric(X, :U)),
+            ("Symmetric(:L)", X -> Symmetric(X, :L)),
+            ("Hermitian(:U)", X -> Hermitian(X, :U)),
+        )
+        n = 4
+        X0 = randn(n, n)
+        B0 = randn(n, 3)
+
+        dX = jl(zero(X0))
+        Enzyme.autodiff(
+            Reverse, (A, B) -> sum(A * B), Active,
+            Duplicated(wrap(jl(X0)), wrap(dX)), Const(jl(B0)),
+        )
+
+        ϵ = 1.0e-6
+        fd = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            fd[idx] = (sum(wrap(Xp) * B0) - sum(wrap(Xm) * B0)) / (2ϵ)
+        end
+        @test collect(dX) ≈ fd rtol = 1.0e-5
+    end
+
+    @testset "structured operand on the right (B = UpperTriangular)" begin
+        m, n = 3, 4
+        A0 = randn(m, n)
+        X0 = randn(n, n)
+        dX = jl(zero(X0))
+        Enzyme.autodiff(
+            Reverse, (A, B) -> sum(A * B), Active,
+            Const(jl(A0)), Duplicated(UpperTriangular(jl(X0)), UpperTriangular(dX)),
+        )
+        ϵ = 1.0e-6
+        fd = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            fd[idx] = (sum(A0 * UpperTriangular(Xp)) - sum(A0 * UpperTriangular(Xm))) / (2ϵ)
+        end
+        @test collect(dX) ≈ fd rtol = 1.0e-5
     end
 end

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -1,4 +1,5 @@
 using Enzyme, Test, JLArrays
+using LinearAlgebra: mul!, dot
 
 function jlres(x)
     2 * collect(x)
@@ -8,4 +9,80 @@ end
     # TODO fix activity of jlarray
     # Enzyme.jacobian(Forward, jlres, JLArray([3.0, 5.0]))
     # Enzyme.jacobian(Reverse, jlres, JLArray([3.0, 5.0]))
+end
+
+# AbstractGPUArray linear-algebra rules (matmul / dot / sum). JLArray is a
+# CPU-backed `AbstractGPUArray`, so it exercises exactly the dispatch the
+# CUDA/AMDGPU/Metal backends hit, without needing a device.
+@testset "GPUArrays linalg rules" begin
+    jl(x) = JLArray(x)
+
+    @testset "matmul reverse ($m×$k × $k×$n)" for (m, k, n) in ((3, 4, 2), (5, 5, 1))
+        A0 = randn(m, k)
+        B0 = randn(k, n)
+
+        # loss = sum(A*B); analytic grads dA = ones*B', dB = A'*ones
+        f(A, B) = sum(A * B)
+        dA = jl(zero(A0))
+        dB = jl(zero(B0))
+        Enzyme.autodiff(Reverse, f, Active, Duplicated(jl(A0), dA), Duplicated(jl(B0), dB))
+
+        ones_mn = ones(m, n)
+        @test collect(dA) ≈ ones_mn * B0'
+        @test collect(dB) ≈ A0' * ones_mn
+    end
+
+    @testset "matmul reverse with transpose" begin
+        # mirrors pmcmc_matmul(transpose(X), X*β): a composed/wrapped matmul
+        X0 = randn(6, 3)
+        β0 = randn(3)
+        g(X, β) = sum(transpose(X) * (X * β))
+        dX = jl(zero(X0))
+        dβ = jl(zero(β0))
+        Enzyme.autodiff(Reverse, g, Active, Duplicated(jl(X0), dX), Duplicated(jl(β0), dβ))
+
+        # finite-difference check against the CPU primal
+        gcpu(X, β) = sum(transpose(X) * (X * β))
+        ϵ = 1.0e-6
+        fdβ = map(eachindex(β0)) do i
+            βp = copy(β0); βp[i] += ϵ
+            βm = copy(β0); βm[i] -= ϵ
+            (gcpu(X0, βp) - gcpu(X0, βm)) / (2ϵ)
+        end
+        @test collect(dβ) ≈ fdβ rtol = 1.0e-4
+    end
+
+    @testset "dot reverse" begin
+        a0 = randn(8)
+        b0 = randn(8)
+        h(a, b) = dot(a, b)
+        da = jl(zero(a0))
+        db = jl(zero(b0))
+        Enzyme.autodiff(Reverse, h, Active, Duplicated(jl(a0), da), Duplicated(jl(b0), db))
+        @test collect(da) ≈ b0
+        @test collect(db) ≈ a0
+    end
+
+    @testset "sum reverse" begin
+        x0 = randn(10)
+        da = jl(zero(x0))
+        Enzyme.autodiff(Reverse, sum, Active, Duplicated(jl(x0), da))
+        @test all(collect(da) .≈ 1)
+        # Note: `sum(A .* B)` (reduction over a broadcast) also relies on this
+        # rule, but JLArrays cannot differentiate the broadcast kernel itself,
+        # so that pattern is covered in the CUDA test instead.
+    end
+
+    @testset "matmul forward" begin
+        A0 = randn(3, 4)
+        B0 = randn(4, 2)
+        dA = randn(3, 4)
+        dB = randn(4, 2)
+        # d(A*B) = dA*B + A*dB
+        out = Enzyme.autodiff(
+            Forward, (A, B) -> A * B, Duplicated,
+            Duplicated(jl(A0), jl(dA)), Duplicated(jl(B0), jl(dB)),
+        )
+        @test collect(out[1]) ≈ dA * B0 + A0 * dB
+    end
 end

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -52,6 +52,52 @@ end
         @test collect(dβ) ≈ fdβ rtol = 1.0e-4
     end
 
+    # The 5-arg `mul!` paths the tests above do not reach: β ≠ 0 (accumulate into
+    # C, whose pullback scales dC by conj(β)) and Active α/β, whose cotangents the
+    # rule has to return with exactly the scalar's own type.
+    @testset "mul! beta != 0 and Active alpha/beta" begin
+        A0 = randn(3, 4)
+        B0 = randn(4, 2)
+        C0 = randn(3, 2)
+
+        # loss = sum(2·A·B + 0.5·C₀)  ⇒  dA = 2·ones·B',  dC₀ = 0.5
+        function loss(C, A, B)
+            mul!(C, A, B, 2.0, 0.5)
+            return sum(C)
+        end
+        dA = jl(zero(A0))
+        dC = jl(zero(C0))
+        Enzyme.autodiff(
+            Reverse, loss, Active,
+            Duplicated(jl(copy(C0)), dC), Duplicated(jl(A0), dA), Const(jl(B0)),
+        )
+        @test collect(dA) ≈ 2.0 .* (ones(3, 2) * B0')
+        @test all(collect(dC) .≈ 0.5)
+
+        # dα = sum(A·B) and dβ = sum(C₀) come back as Active scalar returns
+        function lossα(C, A, B, α)
+            mul!(C, A, B, α, 0.5)
+            return sum(C)
+        end
+        outα = Enzyme.autodiff(
+            Reverse, lossα, Active,
+            Duplicated(jl(copy(C0)), jl(zero(C0))), Duplicated(jl(A0), jl(zero(A0))),
+            Const(jl(B0)), Active(2.0),
+        )
+        @test outα[1][4] ≈ sum(A0 * B0)
+
+        function lossβ(C, A, B, β)
+            mul!(C, A, B, 2.0, β)
+            return sum(C)
+        end
+        outβ = Enzyme.autodiff(
+            Reverse, lossβ, Active,
+            Duplicated(jl(copy(C0)), jl(zero(C0))), Duplicated(jl(A0), jl(zero(A0))),
+            Const(jl(B0)), Active(0.5),
+        )
+        @test outβ[1][4] ≈ sum(C0)
+    end
+
     @testset "dot reverse" begin
         a0 = randn(8)
         b0 = randn(8)
@@ -61,6 +107,33 @@ end
         Enzyme.autodiff(Reverse, h, Active, Duplicated(jl(a0), da), Duplicated(jl(b0), db))
         @test collect(da) ≈ b0
         @test collect(db) ≈ a0
+    end
+
+    # `dot(a,b) = Σ conj(aᵢ)·bᵢ`, so the cotangent of `a` picks up conj(dr) while
+    # `b`'s does not. A real cotangent cannot tell the two apart, so the loss below
+    # drives a complex one (dr = 2-3im). Ground truth is Enzyme's own handling of
+    # plain `Array`, which has no rule in this extension.
+    @testset "dot reverse, complex conjugation" begin
+        a0 = ComplexF64[1 + 2im, -3 + 1im, 0.5 - 1.5im]
+        b0 = ComplexF64[2 - 1im, 0.25 + 3im, -1 + 0.5im]
+        closs(a, b) = real((2 + 3im) * dot(a, b))
+
+        ref_da, ref_db = zero(a0), zero(b0)
+        Enzyme.autodiff(
+            Reverse, closs, Active,
+            Duplicated(copy(a0), ref_da), Duplicated(copy(b0), ref_db),
+        )
+
+        da, db = jl(zero(a0)), jl(zero(b0))
+        Enzyme.autodiff(
+            Reverse, closs, Active,
+            Duplicated(jl(copy(a0)), da), Duplicated(jl(copy(b0)), db),
+        )
+        @test collect(da) ≈ ref_da
+        @test collect(db) ≈ ref_db
+        # and explicitly: conj on `a`'s cotangent only
+        @test collect(da) ≈ conj(2 - 3im) .* b0
+        @test collect(db) ≈ (2 - 3im) .* a0
     end
 
     @testset "sum reverse" begin

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -1,6 +1,5 @@
 using Enzyme, Test, JLArrays
-using LinearAlgebra: mul!, lmul!, rmul!, dot, transpose, adjoint,
-    UpperTriangular, LowerTriangular, Symmetric, Hermitian
+using LinearAlgebra: mul!, dot, transpose, adjoint, Symmetric
 
 function jlres(x)
     2 * collect(x)
@@ -13,22 +12,32 @@ end
 end
 
 #=
-AbstractGPUArray linear-algebra rules (matmul / dot / sum). JLArray is a
-CPU-backed `AbstractGPUArray`, so it reaches these rules through the same
-LinearAlgebra entry points a real backend does, without needing a device.
+AbstractGPUArray linear-algebra rules (matmul / dot). JLArray is a CPU-backed
+`AbstractGPUArray`, so it reaches these rules through the same LinearAlgebra
+entry points a real backend does, without needing a device.
 
-The rules live on `generic_matmatmul!` / `generic_matvecmul!` /
-`generic_trimatmul!` / `generic_mattrimul!`, so the tests drive `mul!` with an
-explicit output buffer. The allocating `A * B` reaches the same rules, but on
-JLArray the shadow of the array it allocates is never zeroed and the reverse pass
-reads junk out of it -- see the `@test_broken` at the end.
+The rules live on `generic_matmatmul!` / `generic_matvecmul!`, so the tests drive
+`mul!` with an explicit output buffer and differentiate a function that returns
+nothing, seeding the output's shadow with ones. That is the cotangent `sum(C)`
+would hand back, and it keeps every testset here on the rules under test: a
+reduction over a JLArray goes through the backend's `mapreducedim!` kernel, and
+Enzyme cannot yet differentiate that one (LLVM verifier error out of
+`EnzymeCreateAugmentedPrimal`). `dot` is not an option either -- GPUArrays infers
+it as `Any`, so nesting it inside a larger function asks the rule for a shadow of
+a scalar.
+
+Not covered for the same reason: the allocating `A * B`. It reaches the same
+rules, but the shadow of the array `similar` hands back is never zeroed for an
+AbstractGPUArray, so the reverse pass reads junk out of it instead of the
+incoming cotangent -- an allocation problem rather than a matmul one, it hits any
+rule whose output was freshly allocated, and it does not reproduce on CUDA.
 =#
 @testset "GPUArrays linalg rules" begin
     jl(x) = JLArray(x)
 
-    function matmul_sum(C, A, B)
+    function matmul!(C, A, B)
         mul!(C, A, B)
-        return sum(C)
+        return nothing
     end
 
     #=
@@ -55,12 +64,13 @@ reads junk out of it -- see the `@test_broken` at the end.
         A0 = randn(m, k)
         B0 = randn(k, n)
 
-        # loss = sum(A·B); analytic grads dA = ones*B', dB = A'*ones
+        # dC = ones is the cotangent of sum(A·B); analytic grads dA = ones·B',
+        # dB = A'·ones
         dA = jl(zero(A0))
         dB = jl(zero(B0))
         Enzyme.autodiff(
-            Reverse, matmul_sum, Active,
-            Duplicated(jl(zeros(m, n)), jl(zeros(m, n))),
+            Reverse, matmul!, Const,
+            Duplicated(jl(zeros(m, n)), jl(ones(m, n))),
             Duplicated(jl(A0), dA), Duplicated(jl(B0), dB),
         )
 
@@ -82,8 +92,8 @@ reads junk out of it -- see the `@test_broken` at the end.
         dA1 = jl(fill(1.0, m, k))
         dA2 = jl(fill(-2.0, m, k))
         Enzyme.autodiff(
-            Reverse, matmul_sum, Active,
-            BatchDuplicated(jl(zeros(m, n)), (jl(zeros(m, n)), jl(zeros(m, n)))),
+            Reverse, matmul!, Const,
+            BatchDuplicated(jl(zeros(m, n)), (jl(ones(m, n)), jl(ones(m, n)))),
             BatchDuplicated(jl(A0), (dA1, dA2)), Const(jl(B0)),
         )
         expected = ones(m, n) * B0'
@@ -91,21 +101,17 @@ reads junk out of it -- see the `@test_broken` at the end.
         @test collect(dA2) ≈ -2.0 .+ expected
     end
 
-    # A `Const` output has no shadow, so nothing flows back through the matmul and
-    # the rule's early return is what runs -- dA here comes only from `sum(A)`.
+    # A `Const` output has no shadow, so the rule's early return is what runs and
+    # nothing at all flows back into the operands.
     @testset "Const output buffer" begin
         m, k, n = 3, 4, 2
-        A0 = randn(m, k)
-        function const_out(C, A, B)
-            mul!(C, A, B)
-            return sum(A)
-        end
-        dA = jl(zero(A0))
+        dA = jl(fill(7.0, m, k))
         Enzyme.autodiff(
-            Reverse, const_out, Active,
-            Const(jl(zeros(m, n))), Duplicated(jl(A0), dA), Const(jl(randn(k, n))),
+            Reverse, matmul!, Const,
+            Const(jl(zeros(m, n))), Duplicated(jl(randn(m, k)), dA),
+            Const(jl(randn(k, n))),
         )
-        @test all(collect(dA) .≈ 1)
+        @test all(collect(dA) .≈ 7.0)
     end
 
     #=
@@ -115,16 +121,16 @@ reads junk out of it -- see the `@test_broken` at the end.
     @testset "matvec reverse with transpose" begin
         X0 = randn(6, 3)
         β0 = randn(3)
-        function g(y, z, X, β)
+        function g!(y, z, X, β)
             mul!(z, X, β)
             mul!(y, transpose(X), z)
-            return sum(y)
+            return nothing
         end
         dX = jl(zero(X0))
         dβ = jl(zero(β0))
         Enzyme.autodiff(
-            Reverse, g, Active,
-            Duplicated(jl(zeros(3)), jl(zeros(3))), Duplicated(jl(zeros(6)), jl(zeros(6))),
+            Reverse, g!, Const,
+            Duplicated(jl(zeros(3)), jl(ones(3))), Duplicated(jl(zeros(6)), jl(zeros(6))),
             Duplicated(jl(X0), dX), Duplicated(jl(β0), dβ),
         )
 
@@ -139,7 +145,8 @@ reads junk out of it -- see the `@test_broken` at the end.
     chars it has to pick differ per combination -- 'C' is a genuine adjoint once
     the eltype is complex, and a transposed complex operand needs a materialized
     conjugate that no char can express. Enzyme's cotangent for a real-valued loss
-    of complex inputs is ∂L/∂Re + i·∂L/∂Im, which central differences reproduce.
+    of complex inputs is ∂L/∂Re + i·∂L/∂Im, so a real `dC` of ones is the seed for
+    `real(sum(C))`, which central differences reproduce.
     =#
     @testset "matmul reverse, $name" for (name, T, wa, wb) in (
             ("transpose(A)·B", Float64, transpose, identity),
@@ -153,14 +160,14 @@ reads junk out of it -- see the `@test_broken` at the end.
         B0 = randn(T, wb === identity ? (k, n) : (n, k))
         cpu(A) = real(sum(wa(A) * wb(B0)))
 
-        function wrapped_sum(C, A, B)
+        function wrapped_mul!(C, A, B)
             mul!(C, wa(A), wb(B))
-            return real(sum(C))
+            return nothing
         end
         dA = jl(zero(A0))
         Enzyme.autodiff(
-            Reverse, wrapped_sum, Active,
-            Duplicated(jl(zeros(T, m, n)), jl(zeros(T, m, n))),
+            Reverse, wrapped_mul!, Const,
+            Duplicated(jl(zeros(T, m, n)), jl(ones(T, m, n))),
             Duplicated(jl(copy(A0)), dA), Const(jl(B0)),
         )
 
@@ -178,38 +185,38 @@ reads junk out of it -- see the `@test_broken` at the end.
         C0 = randn(3, 2)
 
         # loss = sum(2·A·B + 0.5·C₀)  ⇒  dA = 2·ones·B',  dC₀ = 0.5
-        function loss(C, A, B)
+        function loss!(C, A, B)
             mul!(C, A, B, 2.0, 0.5)
-            return sum(C)
+            return nothing
         end
         dA = jl(zero(A0))
-        dC = jl(zero(C0))
+        dC = jl(ones(3, 2))
         Enzyme.autodiff(
-            Reverse, loss, Active,
+            Reverse, loss!, Const,
             Duplicated(jl(copy(C0)), dC), Duplicated(jl(A0), dA), Const(jl(B0)),
         )
         @test collect(dA) ≈ 2.0 .* (ones(3, 2) * B0')
         @test all(collect(dC) .≈ 0.5)
 
-        # dα = sum(A·B) and dβ = sum(C₀) come back as Active scalar returns
-        function lossα(C, A, B, α)
+        # dα = sum(A·B) and dβ = sum(C₀) come back as Active argument cotangents
+        function lossα!(C, A, B, α)
             mul!(C, A, B, α, 0.5)
-            return sum(C)
+            return nothing
         end
         outα = Enzyme.autodiff(
-            Reverse, lossα, Active,
-            Duplicated(jl(copy(C0)), jl(zero(C0))), Duplicated(jl(A0), jl(zero(A0))),
+            Reverse, lossα!, Const,
+            Duplicated(jl(copy(C0)), jl(ones(3, 2))), Duplicated(jl(A0), jl(zero(A0))),
             Const(jl(B0)), Active(2.0),
         )
         @test outα[1][4] ≈ sum(A0 * B0)
 
-        function lossβ(C, A, B, β)
+        function lossβ!(C, A, B, β)
             mul!(C, A, B, 2.0, β)
-            return sum(C)
+            return nothing
         end
         outβ = Enzyme.autodiff(
-            Reverse, lossβ, Active,
-            Duplicated(jl(copy(C0)), jl(zero(C0))), Duplicated(jl(A0), jl(zero(A0))),
+            Reverse, lossβ!, Const,
+            Duplicated(jl(copy(C0)), jl(ones(3, 2))), Duplicated(jl(A0), jl(zero(A0))),
             Const(jl(B0)), Active(0.5),
         )
         @test outβ[1][4] ≈ sum(C0)
@@ -271,163 +278,21 @@ reads junk out of it -- see the `@test_broken` at the end.
         @test collect(db) ≈ (2 - 3im) .* a0
     end
 
-    @testset "sum reverse" begin
-        x0 = randn(10)
-        da = jl(zero(x0))
-        Enzyme.autodiff(Reverse, sum, Active, Duplicated(jl(x0), da))
-        @test all(collect(da) .≈ 1)
-        #=
-        `sum(A .* B)` leans on this rule too, but JLArrays can't differentiate the
-        broadcast kernel, so that one lives in the CUDA tests.
-        =#
-    end
-
     #=
-    Structured operands arrive unwrapped: Symmetric/Hermitian as an 'S'/'H' char
-    to `generic_matmatmul!`, triangular ones as uploc/isunitc/tfun to
-    `generic_trimatmul!`/`generic_mattrimul!`. Only stored entries are free
-    parameters, so finite differences over the raw data are the check -- the
-    non-stored ones have to come back 0.
+    Symmetric/Hermitian operands reach `generic_matmatmul!` as an 'S'/'H' char and
+    need their cotangent projected onto the stored triangle, which is not a matmul.
+    Triangular ones go to `generic_trimatmul!`/`generic_mattrimul!`, which have no
+    rule at all. Both are follow-up work; until then the rule refuses the ones it
+    does see rather than returning the cotangent of the full matrix.
     =#
-    @testset "structured operand: $name" for (name, wrap) in (
-            ("UpperTriangular", UpperTriangular),
-            ("LowerTriangular", LowerTriangular),
-            ("Symmetric(:U)", X -> Symmetric(X, :U)),
-            ("Symmetric(:L)", X -> Symmetric(X, :L)),
-            ("Hermitian(:U)", X -> Hermitian(X, :U)),
-            ("transpose(UpperTriangular)", X -> transpose(UpperTriangular(X))),
-        )
+    @testset "Symmetric operand is rejected" begin
         n = 4
         X0 = randn(n, n)
-        B0 = randn(n, 3)
-
         dX = jl(zero(X0))
-        Enzyme.autodiff(
-            Reverse, matmul_sum, Active,
-            Duplicated(jl(zeros(n, 3)), jl(zeros(n, 3))),
-            Duplicated(wrap(jl(X0)), wrap(dX)), Const(jl(B0)),
+        @test_throws ArgumentError Enzyme.autodiff(
+            Reverse, matmul!, Const,
+            Duplicated(jl(zeros(n, 3)), jl(ones(n, 3))),
+            Duplicated(Symmetric(jl(X0), :U), Symmetric(dX, :U)), Const(jl(randn(n, 3))),
         )
-
-        @test collect(dX) ≈ fdgrad(X -> sum(wrap(X) * B0), X0) rtol = 1.0e-5
-    end
-
-    #=
-    The one combination where the projection stops being linear in α: a Hermitian
-    operand sums a term and its conjugate and reads the diagonal as real, so α has
-    to be folded into the cotangent before the projection, not after. It also needs
-    a complex eltype to reach at all -- `wrapper_char` sends a real Hermitian as
-    'S'.
-    =#
-    @testset "Hermitian operand, complex alpha" begin
-        n, p = 3, 2
-        A0 = randn(ComplexF64, n, n)
-        B0 = randn(ComplexF64, n, p)
-        α = 1.7 - 0.9im
-        cpu(A) = real(sum(Hermitian(A, :U) * B0 * α))
-
-        function herm_sum(C, A, B)
-            mul!(C, Hermitian(A, :U), B, α, false)
-            return real(sum(C))
-        end
-        dA = jl(zero(A0))
-        Enzyme.autodiff(
-            Reverse, herm_sum, Active,
-            Duplicated(jl(zeros(ComplexF64, n, p)), jl(zeros(ComplexF64, n, p))),
-            Duplicated(jl(copy(A0)), dA), Const(jl(B0)),
-        )
-
-        @test collect(dA) ≈ fdgrad(cpu, A0) rtol = 1.0e-4
-    end
-
-    #=
-    A structured operand times a vector goes through `generic_matvecmul!` instead,
-    where the projection lands on an outer-product cotangent. `:L` also checks that
-    the rule reads the triangle out of the char's case ('s', not 'S').
-    =#
-    @testset "structured matvec: Symmetric(:L)" begin
-        n = 4
-        X0 = randn(n, n)
-        v0 = randn(n)
-        dX = jl(zero(X0))
-        function matvec_sum(y, A, x)
-            mul!(y, A, x)
-            return sum(y)
-        end
-        Enzyme.autodiff(
-            Reverse, matvec_sum, Active,
-            Duplicated(jl(zeros(n)), jl(zeros(n))),
-            Duplicated(Symmetric(jl(X0), :L), Symmetric(dX, :L)), Const(jl(v0)),
-        )
-        @test collect(dX) ≈ fdgrad(X -> sum(Symmetric(X, :L) * v0), X0) rtol = 1.0e-5
-    end
-
-    @testset "structured operand on the right: $name" for (name, wrap) in (
-            ("UpperTriangular", UpperTriangular),
-            ("transpose(UpperTriangular)", X -> transpose(UpperTriangular(X))),
-            ("Symmetric(:L)", X -> Symmetric(X, :L)),
-        )
-        m, n = 3, 4
-        A0 = randn(m, n)
-        X0 = randn(n, n)
-        dX = jl(zero(X0))
-        Enzyme.autodiff(
-            Reverse, matmul_sum, Active,
-            Duplicated(jl(zeros(m, n)), jl(zeros(m, n))),
-            Const(jl(A0)), Duplicated(wrap(jl(X0)), wrap(dX)),
-        )
-        @test collect(dX) ≈ fdgrad(X -> sum(A0 * wrap(X)), X0) rtol = 1.0e-5
-    end
-
-    #=
-    `lmul!`/`rmul!` reach the triangular rules with the output aliasing the operand
-    it overwrites, so the operand's cotangent has to replace the shared shadow
-    rather than accumulate into it. Only cotangents are checked here, which is just
-    as well -- the GPUArrays triangular kernels accumulate into their output, so
-    the in-place primal is itself off by the operand on JLArray.
-
-    Both cases wrap in `UpperTriangular` because Julia 1.11's `lmul!`/`rmul!` ask
-    `istriu` first, which for a `LowerTriangular` has to read the data and so
-    scalar-indexes a GPU array. The rule is oblivious to which triangle it is; the
-    testsets above cover both.
-    =#
-    @testset "triangular in place: $name" for (name, f, cpu) in (
-            (
-                "lmul!", (B, X) -> (lmul!(UpperTriangular(X), B); sum(B)),
-                (B, X) -> sum(UpperTriangular(X) * B),
-            ),
-            (
-                "rmul!", (A, X) -> (rmul!(A, UpperTriangular(X)); sum(A)),
-                (A, X) -> sum(A * UpperTriangular(X)),
-            ),
-        )
-        n = 4
-        M0 = randn(n, n)
-        X0 = randn(n, n)
-        dM = jl(zero(M0))
-        dX = jl(zero(X0))
-        Enzyme.autodiff(
-            Reverse, f, Active, Duplicated(jl(copy(M0)), dM), Duplicated(jl(X0), dX),
-        )
-
-        @test collect(dM) ≈ fdgrad(M -> cpu(M, X0), M0) rtol = 1.0e-5
-        @test collect(dX) ≈ fdgrad(X -> cpu(M0, X), X0) rtol = 1.0e-5
-    end
-
-    #=
-    `A * B` is `mul!(similar(...), A, B)`, so it reaches the same rules -- but
-    Enzyme never zeroes the shadow of what `similar` hands back for an
-    AbstractGPUArray, and the reverse pass reads that memory instead of the
-    incoming cotangent. An allocation problem, not a matmul one: it hits any rule
-    whose output was freshly allocated. Doesn't reproduce on CUDA.
-    =#
-    @testset "allocating A * B (unzeroed shadow)" begin
-        A0 = randn(3, 4)
-        B0 = randn(4, 2)
-        dA = jl(zero(A0))
-        Enzyme.autodiff(
-            Reverse, (A, B) -> sum(A * B), Active,
-            Duplicated(jl(A0), dA), Const(jl(B0)),
-        )
-        @test_broken collect(dA) ≈ ones(3, 2) * B0'
     end
 end

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -1,5 +1,6 @@
 using Enzyme, Test, JLArrays
-using LinearAlgebra: mul!, dot, UpperTriangular, LowerTriangular, Symmetric, Hermitian
+using LinearAlgebra: mul!, lmul!, rmul!, dot, transpose, adjoint,
+    UpperTriangular, LowerTriangular, Symmetric, Hermitian
 
 function jlres(x)
     2 * collect(x)
@@ -11,35 +12,62 @@ end
     # Enzyme.jacobian(Reverse, jlres, JLArray([3.0, 5.0]))
 end
 
-# AbstractGPUArray linear-algebra rules (matmul / dot / sum). JLArray is a
-# CPU-backed `AbstractGPUArray`, so it exercises exactly the dispatch the
-# CUDA/AMDGPU/Metal backends hit, without needing a device.
+#=
+AbstractGPUArray linear-algebra rules (matmul / dot / sum). JLArray is a
+CPU-backed `AbstractGPUArray`, so it reaches these rules through the same
+LinearAlgebra entry points a real backend does, without needing a device.
+
+The rules live on `generic_matmatmul!` / `generic_matvecmul!` /
+`generic_trimatmul!` / `generic_mattrimul!`, so the tests drive `mul!` with an
+explicit output buffer. The allocating `A * B` reaches the same rules, but on
+JLArray the shadow of the array it allocates is never zeroed and the reverse pass
+reads junk out of it -- see the `@test_broken` at the end.
+=#
 @testset "GPUArrays linalg rules" begin
     jl(x) = JLArray(x)
+
+    function matmul_sum(C, A, B)
+        mul!(C, A, B)
+        return sum(C)
+    end
 
     @testset "matmul reverse ($m×$k × $k×$n)" for (m, k, n) in ((3, 4, 2), (5, 5, 1))
         A0 = randn(m, k)
         B0 = randn(k, n)
 
-        # loss = sum(A*B); analytic grads dA = ones*B', dB = A'*ones
-        f(A, B) = sum(A * B)
+        # loss = sum(A·B); analytic grads dA = ones*B', dB = A'*ones
         dA = jl(zero(A0))
         dB = jl(zero(B0))
-        Enzyme.autodiff(Reverse, f, Active, Duplicated(jl(A0), dA), Duplicated(jl(B0), dB))
+        Enzyme.autodiff(
+            Reverse, matmul_sum, Active,
+            Duplicated(jl(zeros(m, n)), jl(zeros(m, n))),
+            Duplicated(jl(A0), dA), Duplicated(jl(B0), dB),
+        )
 
         ones_mn = ones(m, n)
         @test collect(dA) ≈ ones_mn * B0'
         @test collect(dB) ≈ A0' * ones_mn
     end
 
-    @testset "matmul reverse with transpose" begin
-        # mirrors pmcmc_matmul(transpose(X), X*β): a composed/wrapped matmul
+    #=
+    The same operand plain and transposed, and both products matrix-vector: two
+    passes through `generic_matvecmul!`, with tA = 'N' and then 'T'.
+    =#
+    @testset "matvec reverse with transpose" begin
         X0 = randn(6, 3)
         β0 = randn(3)
-        g(X, β) = sum(transpose(X) * (X * β))
+        function g(y, z, X, β)
+            mul!(z, X, β)
+            mul!(y, transpose(X), z)
+            return sum(y)
+        end
         dX = jl(zero(X0))
         dβ = jl(zero(β0))
-        Enzyme.autodiff(Reverse, g, Active, Duplicated(jl(X0), dX), Duplicated(jl(β0), dβ))
+        Enzyme.autodiff(
+            Reverse, g, Active,
+            Duplicated(jl(zeros(3)), jl(zeros(3))), Duplicated(jl(zeros(6)), jl(zeros(6))),
+            Duplicated(jl(X0), dX), Duplicated(jl(β0), dβ),
+        )
 
         # finite-difference check against the CPU primal
         gcpu(X, β) = sum(transpose(X) * (X * β))
@@ -50,11 +78,66 @@ end
             (gcpu(X0, βp) - gcpu(X0, βm)) / (2ϵ)
         end
         @test collect(dβ) ≈ fdβ rtol = 1.0e-4
+        fdX = map(eachindex(X0)) do i
+            Xp = copy(X0); Xp[i] += ϵ
+            Xm = copy(X0); Xm[i] -= ϵ
+            (gcpu(Xp, β0) - gcpu(Xm, β0)) / (2ϵ)
+        end
+        @test collect(dX) ≈ reshape(fdX, size(X0)) rtol = 1.0e-4
     end
 
-    # The 5-arg `mul!` paths the tests above do not reach: β ≠ 0 (accumulate into
-    # C, whose pullback scales dC by conj(β)) and Active α/β, whose cotangents the
-    # rule has to return with exactly the scalar's own type.
+    #=
+    Wrapped operands, where the pullback's char algebra stops being trivial: it
+    rewrites each cotangent as one more `generic_matmatmul!` with β = 1, and the
+    chars it has to pick differ per combination -- 'C' is a genuine adjoint once
+    the eltype is complex, and a transposed complex operand needs a materialized
+    conjugate that no char can express. Enzyme's cotangent for a real-valued loss
+    of complex inputs is ∂L/∂Re + i·∂L/∂Im, which central differences reproduce.
+    =#
+    @testset "matmul reverse, $name" for (name, T, wa, wb) in (
+            ("transpose(A)·B", Float64, transpose, identity),
+            ("A·transpose(B)", Float64, identity, transpose),
+            ("adjoint(A)·B, complex", ComplexF64, adjoint, identity),
+            ("transpose(A)·B, complex", ComplexF64, transpose, identity),
+            ("A·adjoint(B), complex", ComplexF64, identity, adjoint),
+        )
+        m, k, n = 3, 4, 2
+        A0 = randn(T, wa === identity ? (m, k) : (k, m))
+        B0 = randn(T, wb === identity ? (k, n) : (n, k))
+        cpu(A) = real(sum(wa(A) * wb(B0)))
+
+        function wrapped_sum(C, A, B)
+            mul!(C, wa(A), wb(B))
+            return real(sum(C))
+        end
+        dA = jl(zero(A0))
+        Enzyme.autodiff(
+            Reverse, wrapped_sum, Active,
+            Duplicated(jl(zeros(T, m, n)), jl(zeros(T, m, n))),
+            Duplicated(jl(copy(A0)), dA), Const(jl(B0)),
+        )
+
+        ϵ = 1.0e-6
+        fd = zero(A0)
+        for idx in eachindex(A0)
+            Ap = copy(A0); Ap[idx] += ϵ
+            Am = copy(A0); Am[idx] -= ϵ
+            g = (cpu(Ap) - cpu(Am)) / (2ϵ)
+            if T <: Complex
+                Aip = copy(A0); Aip[idx] += im * ϵ
+                Aim = copy(A0); Aim[idx] -= im * ϵ
+                g += im * (cpu(Aip) - cpu(Aim)) / (2ϵ)
+            end
+            fd[idx] = g
+        end
+        @test collect(dA) ≈ fd rtol = 1.0e-4
+    end
+
+    #=
+    5-arg `mul!`, which the tests above miss: β ≠ 0 scales dC by conj(β), and an
+    Active α/β has to come back typed exactly as the scalar was (and before Julia
+    1.12 the two of them arrive as one `MulAddMul`).
+    =#
     @testset "mul! beta != 0 and Active alpha/beta" begin
         A0 = randn(3, 4)
         B0 = randn(4, 2)
@@ -109,10 +192,11 @@ end
         @test collect(db) ≈ a0
     end
 
-    # `dot(a,b) = Σ conj(aᵢ)·bᵢ`, so the cotangent of `a` picks up conj(dr) while
-    # `b`'s does not. A real cotangent cannot tell the two apart, so the loss below
-    # drives a complex one (dr = 2-3im). Ground truth is Enzyme's own handling of
-    # plain `Array`, which has no rule in this extension.
+    #=
+    `a`'s cotangent picks up conj(dr) and `b`'s does not, which a real cotangent
+    cannot tell apart -- hence the complex loss (dr = 2-3im). Ground truth is
+    Enzyme on plain `Array`, which no rule here touches.
+    =#
     @testset "dot reverse, complex conjugation" begin
         a0 = ComplexF64[1 + 2im, -3 + 1im, 0.5 - 1.5im]
         b0 = ComplexF64[2 - 1im, 0.25 + 3im, -1 + 0.5im]
@@ -141,21 +225,26 @@ end
         da = jl(zero(x0))
         Enzyme.autodiff(Reverse, sum, Active, Duplicated(jl(x0), da))
         @test all(collect(da) .≈ 1)
-        # Note: `sum(A .* B)` (reduction over a broadcast) also relies on this
-        # rule, but JLArrays cannot differentiate the broadcast kernel itself,
-        # so that pattern is covered in the CUDA test instead.
+        #=
+        `sum(A .* B)` leans on this rule too, but JLArrays can't differentiate the
+        broadcast kernel, so that one lives in the CUDA tests.
+        =#
     end
 
-    # Structured operands (triangular / symmetric / hermitian). The primal goes
-    # through the specialized BLAS kernel; the reverse must project the cotangent
-    # onto the wrapper's stored entries. Ground truth is central finite
-    # differences over the underlying data (non-stored entries must stay 0).
+    #=
+    Structured operands arrive unwrapped: Symmetric/Hermitian as an 'S'/'H' char
+    to `generic_matmatmul!`, triangular ones as uploc/isunitc/tfun to
+    `generic_trimatmul!`/`generic_mattrimul!`. Only stored entries are free
+    parameters, so finite differences over the raw data are the check -- the
+    non-stored ones have to come back 0.
+    =#
     @testset "structured operand: $name" for (name, wrap) in (
             ("UpperTriangular", UpperTriangular),
             ("LowerTriangular", LowerTriangular),
             ("Symmetric(:U)", X -> Symmetric(X, :U)),
             ("Symmetric(:L)", X -> Symmetric(X, :L)),
             ("Hermitian(:U)", X -> Hermitian(X, :U)),
+            ("transpose(UpperTriangular)", X -> transpose(UpperTriangular(X))),
         )
         n = 4
         X0 = randn(n, n)
@@ -163,7 +252,8 @@ end
 
         dX = jl(zero(X0))
         Enzyme.autodiff(
-            Reverse, (A, B) -> sum(A * B), Active,
+            Reverse, matmul_sum, Active,
+            Duplicated(jl(zeros(n, 3)), jl(zeros(n, 3))),
             Duplicated(wrap(jl(X0)), wrap(dX)), Const(jl(B0)),
         )
 
@@ -177,22 +267,122 @@ end
         @test collect(dX) ≈ fd rtol = 1.0e-5
     end
 
-    @testset "structured operand on the right (B = UpperTriangular)" begin
-        m, n = 3, 4
-        A0 = randn(m, n)
+    #=
+    A structured operand times a vector goes through `generic_matvecmul!` instead,
+    where the projection lands on an outer-product cotangent. `:L` also checks that
+    the rule reads the triangle out of the char's case ('s', not 'S').
+    =#
+    @testset "structured matvec: Symmetric(:L)" begin
+        n = 4
         X0 = randn(n, n)
+        v0 = randn(n)
         dX = jl(zero(X0))
+        function matvec_sum(y, A, x)
+            mul!(y, A, x)
+            return sum(y)
+        end
         Enzyme.autodiff(
-            Reverse, (A, B) -> sum(A * B), Active,
-            Const(jl(A0)), Duplicated(UpperTriangular(jl(X0)), UpperTriangular(dX)),
+            Reverse, matvec_sum, Active,
+            Duplicated(jl(zeros(n)), jl(zeros(n))),
+            Duplicated(Symmetric(jl(X0), :L), Symmetric(dX, :L)), Const(jl(v0)),
         )
         ϵ = 1.0e-6
         fd = zero(X0)
         for idx in eachindex(X0)
             Xp = copy(X0); Xp[idx] += ϵ
             Xm = copy(X0); Xm[idx] -= ϵ
-            fd[idx] = (sum(A0 * UpperTriangular(Xp)) - sum(A0 * UpperTriangular(Xm))) / (2ϵ)
+            fd[idx] = (sum(Symmetric(Xp, :L) * v0) - sum(Symmetric(Xm, :L) * v0)) / (2ϵ)
         end
         @test collect(dX) ≈ fd rtol = 1.0e-5
+    end
+
+    @testset "structured operand on the right: $name" for (name, wrap) in (
+            ("UpperTriangular", UpperTriangular),
+            ("transpose(UpperTriangular)", X -> transpose(UpperTriangular(X))),
+            ("Symmetric(:L)", X -> Symmetric(X, :L)),
+        )
+        m, n = 3, 4
+        A0 = randn(m, n)
+        X0 = randn(n, n)
+        dX = jl(zero(X0))
+        Enzyme.autodiff(
+            Reverse, matmul_sum, Active,
+            Duplicated(jl(zeros(m, n)), jl(zeros(m, n))),
+            Const(jl(A0)), Duplicated(wrap(jl(X0)), wrap(dX)),
+        )
+        ϵ = 1.0e-6
+        fd = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            fd[idx] = (sum(A0 * wrap(Xp)) - sum(A0 * wrap(Xm))) / (2ϵ)
+        end
+        @test collect(dX) ≈ fd rtol = 1.0e-5
+    end
+
+    #=
+    `lmul!`/`rmul!` reach the triangular rules with the output aliasing the operand
+    it overwrites, so the operand's cotangent has to replace the shared shadow
+    rather than accumulate into it. Only cotangents are checked here, which is just
+    as well -- the GPUArrays triangular kernels accumulate into their output, so
+    the in-place primal is itself off by the operand on JLArray.
+
+    Both cases wrap in `UpperTriangular` because Julia 1.11's `lmul!`/`rmul!` ask
+    `istriu` first, which for a `LowerTriangular` has to read the data and so
+    scalar-indexes a GPU array. The rule is oblivious to which triangle it is; the
+    testsets above cover both.
+    =#
+    @testset "triangular in place: $name" for (name, f, cpu) in (
+            (
+                "lmul!", (B, X) -> (lmul!(UpperTriangular(X), B); sum(B)),
+                (B, X) -> sum(UpperTriangular(X) * B),
+            ),
+            (
+                "rmul!", (A, X) -> (rmul!(A, UpperTriangular(X)); sum(A)),
+                (A, X) -> sum(A * UpperTriangular(X)),
+            ),
+        )
+        n = 4
+        M0 = randn(n, n)
+        X0 = randn(n, n)
+        dM = jl(zero(M0))
+        dX = jl(zero(X0))
+        Enzyme.autodiff(
+            Reverse, f, Active, Duplicated(jl(copy(M0)), dM), Duplicated(jl(X0), dX),
+        )
+
+        ϵ = 1.0e-6
+        fdM = zero(M0)
+        for idx in eachindex(M0)
+            Mp = copy(M0); Mp[idx] += ϵ
+            Mm = copy(M0); Mm[idx] -= ϵ
+            fdM[idx] = (cpu(Mp, X0) - cpu(Mm, X0)) / (2ϵ)
+        end
+        fdX = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            fdX[idx] = (cpu(M0, Xp) - cpu(M0, Xm)) / (2ϵ)
+        end
+        @test collect(dM) ≈ fdM rtol = 1.0e-5
+        @test collect(dX) ≈ fdX rtol = 1.0e-5
+    end
+
+    #=
+    `A * B` is `mul!(similar(...), A, B)`, so it reaches the same rules -- but
+    Enzyme never zeroes the shadow of what `similar` hands back for an
+    AbstractGPUArray, and the reverse pass reads that memory instead of the
+    incoming cotangent. An allocation problem, not a matmul one: it hits any rule
+    whose output was freshly allocated. Doesn't reproduce on CUDA.
+    =#
+    @testset "allocating A * B (unzeroed shadow)" begin
+        A0 = randn(3, 4)
+        B0 = randn(4, 2)
+        dA = jl(zero(A0))
+        Enzyme.autodiff(
+            Reverse, (A, B) -> sum(A * B), Active,
+            Duplicated(jl(A0), dA), Const(jl(B0)),
+        )
+        @test_broken collect(dA) ≈ ones(3, 2) * B0'
     end
 end

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -146,19 +146,6 @@ end
         # so that pattern is covered in the CUDA test instead.
     end
 
-    @testset "matmul forward" begin
-        A0 = randn(3, 4)
-        B0 = randn(4, 2)
-        dA = randn(3, 4)
-        dB = randn(4, 2)
-        # d(A*B) = dA*B + A*dB
-        out = Enzyme.autodiff(
-            Forward, (A, B) -> A * B, Duplicated,
-            Duplicated(jl(A0), jl(dA)), Duplicated(jl(B0), jl(dB)),
-        )
-        @test collect(out[1]) ≈ dA * B0 + A0 * dB
-    end
-
     # Structured operands (triangular / symmetric / hermitian). The primal goes
     # through the specialized BLAS kernel; the reverse must project the cotangent
     # onto the wrapper's stored entries. Ground truth is central finite

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -31,6 +31,26 @@ reads junk out of it -- see the `@test_broken` at the end.
         return sum(C)
     end
 
+    #=
+    Central differences over the entries of `X0`. For a complex input Enzyme's
+    cotangent of a real-valued loss is ∂L/∂Re + i·∂L/∂Im, so both directions are
+    needed.
+    =#
+    function fdgrad(f, X0, ϵ = 1.0e-6)
+        g = zero(X0)
+        for idx in eachindex(X0)
+            Xp = copy(X0); Xp[idx] += ϵ
+            Xm = copy(X0); Xm[idx] -= ϵ
+            g[idx] = (f(Xp) - f(Xm)) / (2ϵ)
+            if eltype(X0) <: Complex
+                Xip = copy(X0); Xip[idx] += im * ϵ
+                Xim = copy(X0); Xim[idx] -= im * ϵ
+                g[idx] += im * (f(Xip) - f(Xim)) / (2ϵ)
+            end
+        end
+        return g
+    end
+
     @testset "matmul reverse ($m×$k × $k×$n)" for (m, k, n) in ((3, 4, 2), (5, 5, 1))
         A0 = randn(m, k)
         B0 = randn(k, n)
@@ -47,6 +67,45 @@ reads junk out of it -- see the `@test_broken` at the end.
         ones_mn = ones(m, n)
         @test collect(dA) ≈ ones_mn * B0'
         @test collect(dB) ≈ A0' * ones_mn
+    end
+
+    #=
+    Batch width > 1, which `_bget`, `_dscalar` and every `ntuple(Val(N))` in the
+    rules exist to serve and nothing else here reaches. The shadows start at
+    different values so this also pins that each batch element accumulates into
+    its own array rather than all of them landing in the first.
+    =#
+    @testset "batched matmul reverse" begin
+        m, k, n = 3, 4, 2
+        A0 = randn(m, k)
+        B0 = randn(k, n)
+        dA1 = jl(fill(1.0, m, k))
+        dA2 = jl(fill(-2.0, m, k))
+        Enzyme.autodiff(
+            Reverse, matmul_sum, Active,
+            BatchDuplicated(jl(zeros(m, n)), (jl(zeros(m, n)), jl(zeros(m, n)))),
+            BatchDuplicated(jl(A0), (dA1, dA2)), Const(jl(B0)),
+        )
+        expected = ones(m, n) * B0'
+        @test collect(dA1) ≈ 1.0 .+ expected
+        @test collect(dA2) ≈ -2.0 .+ expected
+    end
+
+    # A `Const` output has no shadow, so nothing flows back through the matmul and
+    # the rule's early return is what runs -- dA here comes only from `sum(A)`.
+    @testset "Const output buffer" begin
+        m, k, n = 3, 4, 2
+        A0 = randn(m, k)
+        function const_out(C, A, B)
+            mul!(C, A, B)
+            return sum(A)
+        end
+        dA = jl(zero(A0))
+        Enzyme.autodiff(
+            Reverse, const_out, Active,
+            Const(jl(zeros(m, n))), Duplicated(jl(A0), dA), Const(jl(randn(k, n))),
+        )
+        @test all(collect(dA) .≈ 1)
     end
 
     #=
@@ -69,21 +128,9 @@ reads junk out of it -- see the `@test_broken` at the end.
             Duplicated(jl(X0), dX), Duplicated(jl(β0), dβ),
         )
 
-        # finite-difference check against the CPU primal
         gcpu(X, β) = sum(transpose(X) * (X * β))
-        ϵ = 1.0e-6
-        fdβ = map(eachindex(β0)) do i
-            βp = copy(β0); βp[i] += ϵ
-            βm = copy(β0); βm[i] -= ϵ
-            (gcpu(X0, βp) - gcpu(X0, βm)) / (2ϵ)
-        end
-        @test collect(dβ) ≈ fdβ rtol = 1.0e-4
-        fdX = map(eachindex(X0)) do i
-            Xp = copy(X0); Xp[i] += ϵ
-            Xm = copy(X0); Xm[i] -= ϵ
-            (gcpu(Xp, β0) - gcpu(Xm, β0)) / (2ϵ)
-        end
-        @test collect(dX) ≈ reshape(fdX, size(X0)) rtol = 1.0e-4
+        @test collect(dβ) ≈ fdgrad(β -> gcpu(X0, β), β0) rtol = 1.0e-4
+        @test collect(dX) ≈ fdgrad(X -> gcpu(X, β0), X0) rtol = 1.0e-4
     end
 
     #=
@@ -117,20 +164,7 @@ reads junk out of it -- see the `@test_broken` at the end.
             Duplicated(jl(copy(A0)), dA), Const(jl(B0)),
         )
 
-        ϵ = 1.0e-6
-        fd = zero(A0)
-        for idx in eachindex(A0)
-            Ap = copy(A0); Ap[idx] += ϵ
-            Am = copy(A0); Am[idx] -= ϵ
-            g = (cpu(Ap) - cpu(Am)) / (2ϵ)
-            if T <: Complex
-                Aip = copy(A0); Aip[idx] += im * ϵ
-                Aim = copy(A0); Aim[idx] -= im * ϵ
-                g += im * (cpu(Aip) - cpu(Aim)) / (2ϵ)
-            end
-            fd[idx] = g
-        end
-        @test collect(dA) ≈ fd rtol = 1.0e-4
+        @test collect(dA) ≈ fdgrad(cpu, A0) rtol = 1.0e-4
     end
 
     #=
@@ -190,6 +224,23 @@ reads junk out of it -- see the `@test_broken` at the end.
         Enzyme.autodiff(Reverse, h, Active, Duplicated(jl(a0), da), Duplicated(jl(b0), db))
         @test collect(da) ≈ b0
         @test collect(db) ≈ a0
+    end
+
+    # Batched, where the return cotangent arrives as a tuple of `Active`s rather
+    # than as one `Active`. The shadows start apart so this also pins that each
+    # batch element accumulates into its own array.
+    @testset "batched dot reverse" begin
+        a0 = randn(6)
+        b0 = randn(6)
+        h(a, b) = dot(a, b)
+        da1 = jl(fill(1.0, 6))
+        da2 = jl(fill(-2.0, 6))
+        Enzyme.autodiff(
+            Reverse, h, Active,
+            BatchDuplicated(jl(a0), (da1, da2)), Const(jl(b0)),
+        )
+        @test collect(da1) ≈ 1.0 .+ b0
+        @test collect(da2) ≈ -2.0 .+ b0
     end
 
     #=
@@ -257,14 +308,35 @@ reads junk out of it -- see the `@test_broken` at the end.
             Duplicated(wrap(jl(X0)), wrap(dX)), Const(jl(B0)),
         )
 
-        ϵ = 1.0e-6
-        fd = zero(X0)
-        for idx in eachindex(X0)
-            Xp = copy(X0); Xp[idx] += ϵ
-            Xm = copy(X0); Xm[idx] -= ϵ
-            fd[idx] = (sum(wrap(Xp) * B0) - sum(wrap(Xm) * B0)) / (2ϵ)
+        @test collect(dX) ≈ fdgrad(X -> sum(wrap(X) * B0), X0) rtol = 1.0e-5
+    end
+
+    #=
+    The one combination where the projection stops being linear in α: a Hermitian
+    operand sums a term and its conjugate and reads the diagonal as real, so α has
+    to be folded into the cotangent before the projection, not after. It also needs
+    a complex eltype to reach at all -- `wrapper_char` sends a real Hermitian as
+    'S'.
+    =#
+    @testset "Hermitian operand, complex alpha" begin
+        n, p = 3, 2
+        A0 = randn(ComplexF64, n, n)
+        B0 = randn(ComplexF64, n, p)
+        α = 1.7 - 0.9im
+        cpu(A) = real(sum(Hermitian(A, :U) * B0 * α))
+
+        function herm_sum(C, A, B)
+            mul!(C, Hermitian(A, :U), B, α, false)
+            return real(sum(C))
         end
-        @test collect(dX) ≈ fd rtol = 1.0e-5
+        dA = jl(zero(A0))
+        Enzyme.autodiff(
+            Reverse, herm_sum, Active,
+            Duplicated(jl(zeros(ComplexF64, n, p)), jl(zeros(ComplexF64, n, p))),
+            Duplicated(jl(copy(A0)), dA), Const(jl(B0)),
+        )
+
+        @test collect(dA) ≈ fdgrad(cpu, A0) rtol = 1.0e-4
     end
 
     #=
@@ -286,14 +358,7 @@ reads junk out of it -- see the `@test_broken` at the end.
             Duplicated(jl(zeros(n)), jl(zeros(n))),
             Duplicated(Symmetric(jl(X0), :L), Symmetric(dX, :L)), Const(jl(v0)),
         )
-        ϵ = 1.0e-6
-        fd = zero(X0)
-        for idx in eachindex(X0)
-            Xp = copy(X0); Xp[idx] += ϵ
-            Xm = copy(X0); Xm[idx] -= ϵ
-            fd[idx] = (sum(Symmetric(Xp, :L) * v0) - sum(Symmetric(Xm, :L) * v0)) / (2ϵ)
-        end
-        @test collect(dX) ≈ fd rtol = 1.0e-5
+        @test collect(dX) ≈ fdgrad(X -> sum(Symmetric(X, :L) * v0), X0) rtol = 1.0e-5
     end
 
     @testset "structured operand on the right: $name" for (name, wrap) in (
@@ -310,14 +375,7 @@ reads junk out of it -- see the `@test_broken` at the end.
             Duplicated(jl(zeros(m, n)), jl(zeros(m, n))),
             Const(jl(A0)), Duplicated(wrap(jl(X0)), wrap(dX)),
         )
-        ϵ = 1.0e-6
-        fd = zero(X0)
-        for idx in eachindex(X0)
-            Xp = copy(X0); Xp[idx] += ϵ
-            Xm = copy(X0); Xm[idx] -= ϵ
-            fd[idx] = (sum(A0 * wrap(Xp)) - sum(A0 * wrap(Xm))) / (2ϵ)
-        end
-        @test collect(dX) ≈ fd rtol = 1.0e-5
+        @test collect(dX) ≈ fdgrad(X -> sum(A0 * wrap(X)), X0) rtol = 1.0e-5
     end
 
     #=
@@ -351,21 +409,8 @@ reads junk out of it -- see the `@test_broken` at the end.
             Reverse, f, Active, Duplicated(jl(copy(M0)), dM), Duplicated(jl(X0), dX),
         )
 
-        ϵ = 1.0e-6
-        fdM = zero(M0)
-        for idx in eachindex(M0)
-            Mp = copy(M0); Mp[idx] += ϵ
-            Mm = copy(M0); Mm[idx] -= ϵ
-            fdM[idx] = (cpu(Mp, X0) - cpu(Mm, X0)) / (2ϵ)
-        end
-        fdX = zero(X0)
-        for idx in eachindex(X0)
-            Xp = copy(X0); Xp[idx] += ϵ
-            Xm = copy(X0); Xm[idx] -= ϵ
-            fdX[idx] = (cpu(M0, Xp) - cpu(M0, Xm)) / (2ϵ)
-        end
-        @test collect(dM) ≈ fdM rtol = 1.0e-5
-        @test collect(dX) ≈ fdX rtol = 1.0e-5
+        @test collect(dM) ≈ fdgrad(M -> cpu(M, X0), M0) rtol = 1.0e-5
+        @test collect(dX) ≈ fdgrad(X -> cpu(M0, X), X0) rtol = 1.0e-5
     end
 
     #=

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -12,25 +12,21 @@ end
 end
 
 #=
-AbstractGPUArray linear-algebra rules (matmul / dot). JLArray is a CPU-backed
-`AbstractGPUArray`, so it reaches these rules through the same LinearAlgebra
-entry points a real backend does, without needing a device.
+The AbstractGPUArray matmul/dot rules. JLArray is a CPU-backed AbstractGPUArray,
+so it hits the same LinearAlgebra entry points a real backend does, no device
+needed.
 
-The rules live on `generic_matmatmul!` / `generic_matvecmul!`, so the tests drive
-`mul!` with an explicit output buffer and differentiate a function that returns
-nothing, seeding the output's shadow with ones. That is the cotangent `sum(C)`
-would hand back, and it keeps every testset here on the rules under test: a
-reduction over a JLArray goes through the backend's `mapreducedim!` kernel, and
-Enzyme cannot yet differentiate that one (LLVM verifier error out of
-`EnzymeCreateAugmentedPrimal`). `dot` is not an option either -- GPUArrays infers
-it as `Any`, so nesting it inside a larger function asks the rule for a shadow of
-a scalar.
+The rules sit on `generic_matmatmul!` / `generic_matvecmul!`, so these tests call
+`mul!` into an explicit buffer and seed the output shadow with ones, which is what
+`sum(C)` would hand back. A reduction can't be used instead: `mapreducedim!` over
+a JLArray doesn't differentiate yet (LLVM verifier error out of
+`EnzymeCreateAugmentedPrimal`), and `dot` on GPUArrays infers as `Any`, so nesting
+it asks the rule for a scalar's shadow.
 
-Not covered for the same reason: the allocating `A * B`. It reaches the same
-rules, but the shadow of the array `similar` hands back is never zeroed for an
-AbstractGPUArray, so the reverse pass reads junk out of it instead of the
-incoming cotangent -- an allocation problem rather than a matmul one, it hits any
-rule whose output was freshly allocated, and it does not reproduce on CUDA.
+The allocating `A * B` isn't tested here either. The shadow of the array `similar`
+returns is never zeroed for an AbstractGPUArray, so the reverse pass reads junk
+instead of the incoming cotangent. That affects any rule with a freshly allocated
+output and doesn't happen on CUDA.
 =#
 @testset "GPUArrays linalg rules" begin
     jl(x) = JLArray(x)
@@ -40,11 +36,9 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         return nothing
     end
 
-    #=
-    Central differences over the entries of `X0`. For a complex input Enzyme's
-    cotangent of a real-valued loss is ∂L/∂Re + i·∂L/∂Im, so both directions are
-    needed.
-    =#
+    # Central differences over the entries of `X0`. For complex inputs Enzyme's
+    # cotangent of a real loss is ∂L/∂Re + i·∂L/∂Im, so the imaginary direction
+    # gets its own difference.
     function fdgrad(f, X0, ϵ = 1.0e-6)
         g = zero(X0)
         for idx in eachindex(X0)
@@ -79,12 +73,9 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(dB) ≈ A0' * ones_mn
     end
 
-    #=
-    Batch width > 1, which `_bget`, `_dscalar` and every `ntuple(Val(N))` in the
-    rules exist to serve and nothing else here reaches. The shadows start at
-    different values so this also pins that each batch element accumulates into
-    its own array rather than all of them landing in the first.
-    =#
+    # Width 2, the only case that reaches `_bget` and the `ntuple(Val(N))` loops.
+    # The shadows start at different values, so this also checks each batch
+    # element accumulates into its own array.
     @testset "batched matmul reverse" begin
         m, k, n = 3, 4, 2
         A0 = randn(m, k)
@@ -101,8 +92,27 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(dA2) ≈ -2.0 .+ expected
     end
 
-    # A `Const` output has no shadow, so the rule's early return is what runs and
-    # nothing at all flows back into the operands.
+    # Active α at width 2, where the cotangent comes back as a tuple of scalars:
+    # dα[i] = ⟨dCᵢ, A·B⟩.
+    @testset "batched matmul reverse, Active alpha" begin
+        m, k, n = 3, 4, 2
+        A0 = randn(m, k)
+        B0 = randn(k, n)
+        function lossα!(C, A, B, α)
+            mul!(C, A, B, α, 0.5)
+            return nothing
+        end
+        out = Enzyme.autodiff(
+            Reverse, lossα!, Const,
+            BatchDuplicated(jl(randn(m, n)), (jl(ones(m, n)), jl(fill(2.0, m, n)))),
+            Const(jl(A0)), Const(jl(B0)), Active(2.0),
+        )
+        s = sum(A0 * B0)
+        @test all(out[1][4] .≈ (s, 2.0 * s))
+    end
+
+    # A `Const` output has no shadow, so the rule returns early and the operands
+    # get nothing.
     @testset "Const output buffer" begin
         m, k, n = 3, 4, 2
         dA = jl(fill(7.0, m, k))
@@ -114,10 +124,8 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test all(collect(dA) .≈ 7.0)
     end
 
-    #=
-    The same operand plain and transposed, and both products matrix-vector: two
-    passes through `generic_matvecmul!`, with tA = 'N' and then 'T'.
-    =#
+    # The same operand plain and transposed, both products matrix-vector: two
+    # passes through `generic_matvecmul!`, tA = 'N' then 'T'.
     @testset "matvec reverse with transpose" begin
         X0 = randn(6, 3)
         β0 = randn(3)
@@ -140,13 +148,11 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
     end
 
     #=
-    Wrapped operands, where the pullback's char algebra stops being trivial: it
-    rewrites each cotangent as one more `generic_matmatmul!` with β = 1, and the
-    chars it has to pick differ per combination -- 'C' is a genuine adjoint once
-    the eltype is complex, and a transposed complex operand needs a materialized
-    conjugate that no char can express. Enzyme's cotangent for a real-valued loss
-    of complex inputs is ∂L/∂Re + i·∂L/∂Im, so a real `dC` of ones is the seed for
-    `real(sum(C))`, which central differences reproduce.
+    Wrapped operands, where the char algebra in `_pullback!` actually matters: the
+    chars differ per combination, 'C' is a real adjoint once the eltype is complex,
+    and a transposed complex operand needs a materialized conjugate that no char
+    can express. A real `dC` of ones seeds `real(sum(C))`, which is what `fdgrad`
+    differentiates.
     =#
     @testset "matmul reverse, $name" for (name, T, wa, wb) in (
             ("transpose(A)·B", Float64, transpose, identity),
@@ -174,11 +180,9 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(dA) ≈ fdgrad(cpu, A0) rtol = 1.0e-4
     end
 
-    #=
-    5-arg `mul!`, which the tests above miss: β ≠ 0 scales dC by conj(β), and an
-    Active α/β has to come back typed exactly as the scalar was (and before Julia
-    1.12 the two of them arrive as one `MulAddMul`).
-    =#
+    # 5-arg `mul!`, which the tests above miss: β ≠ 0 scales dC by conj(β), and an
+    # Active α/β has to come back as the scalar's own type (one `MulAddMul` before
+    # Julia 1.12).
     @testset "mul! beta != 0 and Active alpha/beta" begin
         A0 = randn(3, 4)
         B0 = randn(4, 2)
@@ -233,9 +237,8 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(db) ≈ a0
     end
 
-    # Batched, where the return cotangent arrives as a tuple of `Active`s rather
-    # than as one `Active`. The shadows start apart so this also pins that each
-    # batch element accumulates into its own array.
+    # Batched, so the return cotangent is a tuple of `Active`s. The shadows start
+    # apart to check per-element accumulation.
     @testset "batched dot reverse" begin
         a0 = randn(6)
         b0 = randn(6)
@@ -250,11 +253,9 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(da2) ≈ -2.0 .+ b0
     end
 
-    #=
-    `a`'s cotangent picks up conj(dr) and `b`'s does not, which a real cotangent
-    cannot tell apart -- hence the complex loss (dr = 2-3im). Ground truth is
-    Enzyme on plain `Array`, which no rule here touches.
-    =#
+    # Only `a`'s cotangent picks up conj(dr), which a real cotangent can't tell
+    # apart, so the loss is complex (dr = 2-3im). Reference values come from Enzyme
+    # on plain `Array`s, which these rules don't touch.
     @testset "dot reverse, complex conjugation" begin
         a0 = ComplexF64[1 + 2im, -3 + 1im, 0.5 - 1.5im]
         b0 = ComplexF64[2 - 1im, 0.25 + 3im, -1 + 0.5im]
@@ -278,13 +279,9 @@ rule whose output was freshly allocated, and it does not reproduce on CUDA.
         @test collect(db) ≈ (2 - 3im) .* a0
     end
 
-    #=
-    Symmetric/Hermitian operands reach `generic_matmatmul!` as an 'S'/'H' char and
-    need their cotangent projected onto the stored triangle, which is not a matmul.
-    Triangular ones go to `generic_trimatmul!`/`generic_mattrimul!`, which have no
-    rule at all. Both are follow-up work; until then the rule refuses the ones it
-    does see rather than returning the cotangent of the full matrix.
-    =#
+    # Symmetric/Hermitian operands need their cotangent projected onto the stored
+    # triangle, which isn't a matmul, so the rule rejects them for now. Triangular
+    # operands go elsewhere in LinearAlgebra and have no rule at all.
     @testset "Symmetric operand is rejected" begin
         n = 4
         X0 = randn(n, n)


### PR DESCRIPTION
Resolves #3122.

Adds custom rules for matmul/dot/sum on GPU arrays.

This came up while building GPU MCMC in [ParallelMCMC.jl#32](https://github.com/rsenne/ParallelMCMC.jl/pull/32), where @wsmoses suggested overloading matmul for GPU arrays directly in Enzyme as an extension rather than keeping per-package wrappers.