### PR TITLE
Fix julia_error calling backtrace on a ConstantExpr

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -1055,7 +1055,8 @@ function julia_error(
             for u in LLVM.uses(val)
                 u = LLVM.user(u)
                 if isa(u, LLVM.Instruction)
-                    bt = GPUCompiler.backtrace(val)
+                    bt = GPUCompiler.backtrace(u)
+                    break
                 end
             end
         elseif val isa LLVM.Function


### PR DESCRIPTION
> [!NOTE]
> Draft opened by Chris's agent — please ignore until reviewed/approved by @ChrisRackauckas.

When `julia_error` receives a `ConstantExpr` value, it loops over the uses to find an `Instruction` user, but then calls `GPUCompiler.backtrace` on the `ConstantExpr` itself rather than on the instruction it just found:

```julia
if isa(val, LLVM.ConstantExpr)
    for u in LLVM.uses(val)
        u = LLVM.user(u)
        if isa(u, LLVM.Instruction)
            bt = GPUCompiler.backtrace(val)   # <- should be `u`
        end
    end
```

`GPUCompiler.backtrace` only accepts an `LLVM.Instruction`, so this throws

```
MethodError: no method matching backtrace(::LLVM.ConstantExpr)
```

and masks whatever diagnostic the reporter was trying to surface (hit in practice via an `ET_NoDerivative` report whose value was a constexpr function pointer, while differentiating a SciML `EnsembleProblem` solve — see SciML/SciMLSensitivity.jl#1424). Also adds a `break` so the first instruction user's backtrace is used rather than the last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
