### PR TITLE
Fix type-unstable newstruct shadow construction for constant and mutable cases

### DIFF
--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -27,6 +27,12 @@
                 end
               end
             end
+            if aref == ActiveState
+                return quote
+                    Base.@_inline_meta
+                    make_zero(primarg)
+                end
+            end
         end
         if aref == DupState
             return quote
@@ -128,10 +134,15 @@ function body_construct_augfwd(
         push!(res_syms, sres)
     end
 
+    # Mutable structs are DupState overall: their shadow must be a plain shadow
+    # object, not a MixedState-style RefValue, to match what downstream consumers
+    # derive from active_reg_nothrow of the result type.
+    wrapcond = tuple ? :any_mixed : :(any_mixed && !ismutabletype(NewType))
+
     if Width == 1
         push!(results,
             quote
-                if any_mixed
+                if $wrapcond
                     $(ref_syms[1])
                 else
                     $(res_syms[1])
@@ -139,7 +150,7 @@ function body_construct_augfwd(
             end)
     else
         push!(results, quote
-                if any_mixed
+                if $wrapcond
                     ReturnType(($(ref_syms...),))
                 else
                     ReturnType(($(res_syms...),))
@@ -172,8 +183,10 @@ function body_construct_rev(
             end
             shad = batchshadowargs[i][w]
             out = :(
-                if $(Symbol("active_ref_$i")) == MixedState ||
-                   $(Symbol("active_ref_$i")) == ActiveState
+                if (
+                        $(Symbol("active_ref_$i")) == MixedState ||
+                            $(Symbol("active_ref_$i")) == ActiveState
+                    ) && ActivityTup[$i]
                     if $shad isa Base.RefValue
                         $shad[] = recursive_add($shad[], $expr, identity, guaranteed_nonactive)
                     else
@@ -185,12 +198,23 @@ function body_construct_rev(
         end
     end
 
+    # Must mirror the shadow wrapping in body_construct_augfwd: mutable structs
+    # store the plain shadow object in the tape rather than a RefValue.
     tapes = Vector{Expr}(undef, Width)
-    @inbounds tapes[1] = :(tval_1 = tape[])
-    for w = 2:Width
-        sym = Symbol("tval_$w")
-        df = dfns[w]
-        @inbounds tapes[w] = :($sym = $df[])
+    if tuple
+        @inbounds tapes[1] = :(tval_1 = tape[])
+        for w in 2:Width
+            sym = Symbol("tval_$w")
+            df = dfns[w]
+            @inbounds tapes[w] = :($sym = $df[])
+        end
+    else
+        @inbounds tapes[1] = :(tval_1 = ismutabletype(NewStruct) ? tape : tape[])
+        for w in 2:Width
+            sym = Symbol("tval_$w")
+            df = dfns[w]
+            @inbounds tapes[w] = :($sym = ismutabletype(NewStruct) ? $df : $df[])
+        end
     end
 
     quote

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -167,3 +167,46 @@ end
    _, _, shad = fwd(Const(typeunstable_constant_shadow))
 end
 
+
+@noinline newstruct_runtime_any()::Any = Base.inferencebarrier(Ref(1.0))
+
+mutable struct NewstructConstField{T}
+    v::Float64
+    inner::T
+end
+
+function newstruct_const_active_field(x)
+    w = NewstructConstField(0.0, newstruct_runtime_any())
+    w.v = sum(abs2, x)
+    return w.v
+end
+
+@testset "Runtime newstruct with constant active-typed field" begin
+    g = Enzyme.gradient(
+        set_runtime_activity(Reverse), newstruct_const_active_field, [3.0, 1.0]
+    )[1]
+    @test g ≈ [6.0, 2.0]
+end
+
+@noinline mutwrap_runtime_any()::Any = Base.inferencebarrier(Ref(1.0))
+
+mutable struct MutWrapGeneric{T}
+    v::Float64
+    inner::T
+end
+
+@noinline mutwrap_use(w, x) = w.v * @inbounds x[1]
+
+function mutwrap_generic_call(x)
+    w = MutWrapGeneric(0.0, mutwrap_runtime_any())
+    w.v = x[2]
+    f = Base.inferencebarrier(mutwrap_use)
+    return (f(w, x))::Float64
+end
+
+@testset "Mutable runtime newstruct shadow passed to generic call" begin
+    g = Enzyme.gradient(
+        set_runtime_activity(Reverse), mutwrap_generic_call, [3.0, 5.0]
+    )[1]
+    @test g ≈ [5.0, 3.0]
+end


### PR DESCRIPTION
> [!NOTE]
> Draft opened by Chris's agent — please ignore until reviewed/approved by @ChrisRackauckas.

Two bugs in the type-unstable `jl_new_struct*` rules, exposed once #2437's `jl_get_builtin_fptr` fix allowed compilation to reach `runtime_newstruct_augfwd` on real workloads (differentiating a SciML `EnsembleProblem` solve, where SciMLBase's `AggregateLogger{T}` is constructed with a runtime-computed type parameter; see SciML/SciMLSensitivity.jl#1424 and @wsmoses's request there).

### 1. Constant arguments of `ActiveState` type crash `create_shadow_ret`

A constant argument (`ActivityTup[i] == false`) whose type is `ActiveState` (e.g. a `Float64` literal initializing a field) is passed shadow `nothing`, and `create_shadow_ret` had no case for it — it fell through to `batchshadowarg[]`:

```
MethodError: no method matching getindex(::Nothing)
  [2] create_shadow_ret    @ src/rules/typeunstablerules.jl:3 [inlined]
  [4] runtime_newstruct_augfwd(..., ::Type{SciMLBase.AggregateLogger{ConsoleLogger}}, ...)
```

MWE:

```julia
import Enzyme
@noinline get_any()::Any = Base.inferencebarrier(Ref(1.0))
mutable struct Wrap{T}; v::Float64; inner::T; end
f(x) = (w = Wrap(0.0, get_any()); w.v = sum(abs2, x); w.v)
Enzyme.gradient(Enzyme.set_runtime_activity(Enzyme.Reverse), f, [3.0, 1.0])
```

Fixed by giving constant + `ActiveState` arguments a `make_zero(primarg)` shadow. The reverse (`body_construct_rev`) had the matching hole — it unconditionally accumulated into the shadow for any Active/Mixed-state field, which throws `EnzymeNonScalarReturnException` for constant arguments whose shadow is `nothing`; accumulation is now gated on `ActivityTup[i]`.

### 2. Mutable structs got a `MixedState`-style `RefValue` shadow

`runtime_newstruct_augfwd` Ref-wrapped the shadow whenever *any field* was Active/Mixed state. That is correct for immutable structs (overall `MixedState`), but mutable structs are `DupState` overall — downstream consumers derive the shadow representation from `active_reg_nothrow` of the result type and expect a plain shadow object. When the constructed value is later passed to a runtime generic call (or `setfield!`), this produced e.g.

```
MethodError: no method matching EnzymeCore.Duplicated(::SciMLBase.AggregateLogger{ConsoleLogger}, ::Base.RefValue{SciMLBase.AggregateLogger{ConsoleLogger}})
```

in `create_activity_wrapper`. The Ref wrap now applies only to immutable (genuinely `MixedState`) types, with the tape read in `body_construct_rev` mirrored accordingly.

### Verification

- Both MWEs fail on current main and pass with this PR (gradients verified correct: `[6.0, 2.0]` and `[5.0, 3.0]`); both added as regression tests in `test/typeunstable.jl`.
- The second test was additionally verified to fail with only fix 1 applied (`type RefValue has no field v` in `rt_jl_setfield_aug`), i.e. it specifically covers fix 2.
- `test/typeunstable.jl` (including the #2817 runtime-activity tuple construction tests), `test/mixed.jl`, and `test/mixedapplyiter.jl` all pass locally on Julia 1.11.9.
- With this PR the SciML ensemble adjoint progresses past the Julia rules and now hits a separate native crash in Enzyme core C++ (`UpgradeAllocasToMallocs`/`RecursivelyReplaceAddressSpace`, with an `ET_GCRewrite` "Could not find use of stored value" warning on a 271-root sret) — details in SciML/SciMLSensitivity.jl#1424; that one is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
