### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,8 +10,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     if: build.message !~ /\[skip tests\]/
     timeout_in_minutes: 60
     commands: |
@@ -36,8 +35,7 @@ steps:
 #       - JuliaCI/julia#v1:
 #           version: "{{matrix.version}}"
 #     agents:
-#       queue: "juliagpu"
-#       rocm: "*"
+#       queue: "rocm"
 #     if: build.message !~ /\[skip tests\]/
 #     timeout_in_minutes: 60
 #     commands: |


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)