### PR TITLE
Implement from_tape_type for Core.VecElement and NTuple{Size, Core.Ve…

### DIFF
--- a/src/typeutils/conversion.jl
+++ b/src/typeutils/conversion.jl
@@ -112,6 +112,9 @@ from_tape_type(::Type{T}) where {T<:AbstractFloat} = convert(LLVMType, T)
 from_tape_type(::Type{T}) where {T<:Integer} = convert(LLVMType, T)
 from_tape_type(::Type{NTuple{Size,T}}) where {Size,T} =
     LLVM.ArrayType(from_tape_type(T), Size)
+from_tape_type(::Type{Core.VecElement{T}}) where {T} = from_tape_type(T)
+from_tape_type(::Type{NTuple{Size,Core.VecElement{T}}}) where {Size,T} =
+    LLVM.VectorType(from_tape_type(T), Size)
 from_tape_type(::Type{Core.LLVMPtr{T,Addr}}) where {T,Addr} =
     LLVM.PointerType(from_tape_type(UInt8), Addr)
 # from_tape_type(::Type{Core.LLVMPtr{T, Addr}}, ctx) where {T, Addr} = LLVM.PointerType(from_tape_type(T, ctx), Addr)

--- a/test/typetree.jl
+++ b/test/typetree.jl
@@ -152,3 +152,11 @@ end
         @test Enzyme.get_offsets(UnionMember) == [(Enzyme.API.DT_Float, 0), (Enzyme.API.DT_Pointer, 4), (Enzyme.API.DT_Integer, 8)]
     end
 end
+
+@testset "from_tape_type" begin
+    LLVM.Context() do ctx
+        @test Enzyme.Compiler.from_tape_type(NTuple{8, VecElement{Float32}}) == LLVM.VectorType(LLVM.FloatType(), 8)
+        @test Enzyme.Compiler.from_tape_type(NTuple{8, Float32}) == LLVM.ArrayType(LLVM.FloatType(), 8)
+    end
+end
+


### PR DESCRIPTION
…cElement} to support SIMD registers in tape materialization