### PR TITLE
Forward-mode deepcopy: handle Const argument with Duplicated return (fixes #3258)

### DIFF
--- a/src/internal_rules/core.jl
+++ b/src/internal_rules/core.jl
@@ -129,6 +129,52 @@ function EnzymeRules.forward(
     end)
 end
 
+# A `Const` argument carries no shadow, but a `Duplicated` result may still be
+# requested (e.g. via runtime-activity widening), so deepcopy the primal and
+# pair it with a freshly zeroed shadow.
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(Base.deepcopy)},
+    ::Type{<:DuplicatedNoNeed},
+    x::Const,
+)
+    return Enzyme.make_zero(func.val(x.val))
+end
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(Base.deepcopy)},
+    ::Type{<:BatchDuplicatedNoNeed},
+    x::Const,
+)
+    primal = func.val(x.val)
+    return ntuple(Val(EnzymeRules.width(config))) do _
+        Enzyme.make_zero(primal)
+    end
+end
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(Base.deepcopy)},
+    ::Type{<:Duplicated},
+    x::Const,
+)
+    primal = func.val(x.val)
+    return Duplicated(primal, Enzyme.make_zero(primal))
+end
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(Base.deepcopy)},
+    ::Type{<:BatchDuplicated},
+    x::Const,
+)
+    primal = func.val(x.val)
+    return BatchDuplicated(primal, ntuple(Val(EnzymeRules.width(config))) do _
+        Enzyme.make_zero(primal)
+    end)
+end
+
 function EnzymeRules.augmented_primal(
     config::EnzymeRules.RevConfig,
     func::Const{typeof(Base.deepcopy)},

--- a/test/rules/internal_rules/deepcopy.jl
+++ b/test/rules/internal_rules/deepcopy.jl
@@ -1,4 +1,5 @@
 using Enzyme
+using Enzyme.EnzymeRules
 using Test
 
 @testset "core fallback traversal" begin
@@ -98,5 +99,42 @@ using Test
         
         res = Enzyme.autodiff(Enzyme.set_runtime_activity(Enzyme.Forward), Enzyme.Const(f), Enzyme.Duplicated, Enzyme.Duplicated(w, dw))
         @test res[1].v ≈ [1.0, 0.0]
+    end
+
+    @testset "forward-mode deepcopy with Const argument" begin
+        f(x) = Base.deepcopy(x)
+        x = [1.0, 2.0]
+
+        # A Const argument has no shadow, but a Duplicated result may still be
+        # requested (runtime-activity widening). The shadow of an inactive input
+        # is zero. This exercises the issue MWE through the public API.
+        for mode in (Enzyme.Forward, Enzyme.set_runtime_activity(Enzyme.Forward))
+            res = Enzyme.autodiff(mode, Enzyme.Const(f), Enzyme.Duplicated, Enzyme.Const(x))
+            @test res[1] ≈ [0.0, 0.0]
+        end
+
+        # Drive the rule methods directly to cover the Batch and NoNeed variants
+        # the public API collapses to width-1 Duplicated when all args are Const.
+        cfg1 = EnzymeRules.FwdConfig{true, true, 1, false, false}()
+        cfg2 = EnzymeRules.FwdConfig{true, true, 2, false, false}()
+        fc = Enzyme.Const(Base.deepcopy)
+        xc = Enzyme.Const(x)
+
+        dup = EnzymeRules.forward(cfg1, fc, Enzyme.Duplicated, xc)
+        @test dup.val ≈ x
+        @test dup.dval ≈ [0.0, 0.0]
+        @test dup.val !== x
+
+        dupnn = EnzymeRules.forward(cfg1, fc, Enzyme.DuplicatedNoNeed, xc)
+        @test dupnn ≈ [0.0, 0.0]
+
+        bdup = EnzymeRules.forward(cfg2, fc, Enzyme.BatchDuplicated, xc)
+        @test bdup.val ≈ x
+        @test length(bdup.dval) == 2
+        @test all(d -> d ≈ [0.0, 0.0], bdup.dval)
+
+        bdupnn = EnzymeRules.forward(cfg2, fc, Enzyme.BatchDuplicatedNoNeed, xc)
+        @test length(bdupnn) == 2
+        @test all(d -> d ≈ [0.0, 0.0], bdupnn)
     end
 end


### PR DESCRIPTION
## Summary

Fixes #3258. Adds the missing forward-mode `EnzymeRules.forward` methods for `Base.deepcopy` when the **argument is `Const`** but a `Duplicated`/`BatchDuplicated` result is requested (the runtime-activity-widening path).

Previously `src/internal_rules/core.jl` defined forward `deepcopy` rules only for `Duplicated`/`BatchDuplicated` (and the `…NoNeed`) *arguments*. With a `Const` argument and a `Duplicated` return requested, no method matched:

```
MethodError: no method matching forward(
  ::EnzymeRules.FwdConfigWidth{1, true, true, true, false},
  ::Const{typeof(deepcopy)},
  ::Type{Duplicated{Vector{Float64}}},
  ::Const{Vector{Float64}})
```

## Fix

Add the four `Const`-argument variants — `Duplicated`, `DuplicatedNoNeed`, `BatchDuplicated`, `BatchDuplicatedNoNeed` — returning the deepcopied primal paired with a freshly zeroed shadow (`Enzyme.make_zero` of the copy). The derivative of deepcopying an inactive value is zero, so a zeroed shadow is the correct result. Batch width is taken from `EnzymeRules.width(config)`.

## Verification (run locally, Julia 1.11.9, this branch)

Issue MWE — previously a `MethodError`, now returns a zeroed shadow:

```julia
import Enzyme
const RA_F = Enzyme.set_runtime_activity(Enzyme.Forward)
f(x) = Base.deepcopy(x)
x = [1.0, 2.0]
Enzyme.autodiff(RA_F, Enzyme.Const(f), Enzyme.Const(x))
# (var"1" = [0.0, 0.0],)
```

Output observed:
```
Const arg (RA): (var"1" = [0.0, 0.0],)
Const arg (plain): (var"1" = [0.0, 0.0],)
Duplicated arg control: (var"1" = [1.0, 0.0],)            # implemented path still works
BatchDuplicated arg control: (var"1" = (var"1" = [1.0, 0.0], var"2" = [0.0, 1.0]),)
```

## Tests

Added a testset to `test/rules/internal_rules/deepcopy.jl` covering the `Const`-argument case through the public API (width-1 `Duplicated` under both `Forward` and runtime-activity `Forward`) and driving the rule methods directly to exercise the `BatchDuplicated` (width 2) and `…NoNeed` variants, which the public API collapses to width-1 `Duplicated` when all arguments are `Const`. Full file passes locally (17/17).

## Context

This is the next blocker (after #3135 → #3137, #3246 → #3251, #3253 → #3254) for an Enzyme forward-over-reverse HVP of a neural-ODE loss in SciML/SciMLSensitivity.jl#1427, where DiffEqBase's `solve_up` rule deepcopies an inactive `u0` (`Const`) while the surrounding forward-over-reverse requests a `Duplicated` result.

---

Please ignore until reviewed by @ChrisRackauckas. Implemented at @wsmoses's request in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)