### PR TITLE
Fix ijl_lazy_load_and_lookup to emit named enzyme_math declarations (#3090)

### DIFF
--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -616,6 +616,40 @@ end
 
 const DebugLTO = Ref(false)
 
+# Recover the function type used to call the result of an `ijl_lazy_load_and_lookup`.
+# The looked-up pointer reaches the indirect call directly, through a cache slot
+# (`store`/`load`, possibly via a global), and/or through phi/cast nodes. Walk that
+# transitive closure to find the call. Returns the LLVM function type or `nothing`.
+function lazy_lookup_callee_type(inst::LLVM.Instruction)
+    seen = Set{LLVM.Value}()
+    worklist = LLVM.Value[inst]
+    while !isempty(worklist)
+        v = pop!(worklist)
+        v in seen && continue
+        push!(seen, v)
+        for u in LLVM.uses(v)
+            user = LLVM.user(u)
+            if isa(user, LLVM.CallInst)
+                if called_operand(user) == v
+                    return called_type(user)
+                end
+            elseif isa(user, LLVM.PHIInst) ||
+                    isa(user, LLVM.BitCastInst) ||
+                    isa(user, LLVM.AddrSpaceCastInst)
+                push!(worklist, user)
+            elseif isa(user, LLVM.StoreInst) &&
+                    LLVM.Value(LLVM.API.LLVMGetOperand(user, 0)) == v
+                ptr = LLVM.Value(LLVM.API.LLVMGetOperand(user, 1))
+                for u2 in LLVM.uses(ptr)
+                    ld = LLVM.user(u2)
+                    isa(ld, LLVM.LoadInst) && push!(worklist, ld)
+                end
+            end
+        end
+    end
+    return nothing
+end
+
 function try_import_llvmbc(mod::LLVM.Module, flib::String, fname::String, imported::Set{String})
     found = false
     inmod = nothing
@@ -926,8 +960,46 @@ function check_ir!(interp, @nospecialize(job::CompilerJob), errors::Vector{IRErr
                 return
             end
 
-            found, replaceWith = if isa(flib, String)
-                try_import_llvmbc(mod, flib, fname, imported)
+            # Resolve the library reference to an on-disk path so we can either import
+            # its bitcode or emit a named `ejlstr$...` declaration. On Julia 1.13+ `flib`
+            # is a library-reference object (e.g. a LazyLibrary) rather than a path string.
+            flib_path = if isa(flib, String)
+                flib
+            else
+                try
+                    Libdl.dlpath(flib)
+                catch
+                    try
+                        Libdl.dlpath(Libdl.dlopen(flib))
+                    catch
+                        nothing
+                    end
+                end
+            end
+
+            found, replaceWith = if isa(flib_path, String)
+                f2, rw = try_import_llvmbc(mod, flib_path, fname, imported)
+                if f2
+                    (true, rw)
+                else
+                    # The library ships no bitcode for `fname`. Mirror the PLT (`jlplt_*_got`)
+                    # path: emit a named declaration carrying `enzyme_math` so Enzyme recognizes
+                    # the foreign math function (e.g. `Faddeeva_erf`) for activity analysis,
+                    # instead of leaving an anonymous `inttoptr` indirect call.
+                    FT = lazy_lookup_callee_type(inst)
+                    if FT !== nothing
+                        fused_name = "ejlstr\$$fname\$$flib_path"
+                        newf, _ = get_function!(mod, fused_name, FT)
+                        while isa(newf, LLVM.ConstantExpr)
+                            newf = operands(newf)[1]
+                        end
+                        push!(function_attributes(newf), StringAttribute("enzyme_math", fname))
+                        push!(function_attributes(newf), StringAttribute(PRESERVEPRIMAL_ATTR_KIND, "*"))
+                        (true, newf)
+                    else
+                        (false, nothing)
+                    end
+                end
             else
                 (false, nothing)
             end


### PR DESCRIPTION
## Summary

Fixes #3090.

Differentiating foreign math functions resolved via `ijl_lazy_load_and_lookup` (e.g. `SpecialFunctions.erf(::ComplexF64)` → `Faddeeva_erf`) failed on Julia 1.13 with:

```
Mismatched estimated activity type for { double, double }
expected DUP_ARG or CONSTANT found OUT_DIFF
```

### Root cause

Enzyme recognizes a foreign math call through the `enzyme_math` function attribute attached to a **named** declaration. Pre-1.13 these calls were emitted as PLT GOT loads (`jlplt_*_got`), whose handler creates a named `ejlstr$<fname>$<libpath>` declaration carrying `enzyme_math` (resolved at JIT time via `jl_load_and_lookup`). Julia 1.13 moved these calls to `ijl_lazy_load_and_lookup`, but that handler's fallback only replaced the looked-up pointer with an **anonymous `inttoptr`** constant, so activity analysis could not classify the complex `{ double, double }` return. #3101 made the 1.13 arguments resolvable but did not restore the naming.

### Fix

Make the `ijl_lazy_load_and_lookup` handler mirror the PLT path: when bitcode import is unavailable (e.g. `libopenspecfun` ships no `.llvmbc`), emit a named `ejlstr$<fname>$<libpath>` declaration with `enzyme_math` and `enzyme_preserve_primal`. A new `lazy_lookup_callee_type` helper recovers the indirect call's function type by walking the use graph transitively, including the phi/cache-global structure 1.13 generates (`store %p, @cache; %r = phi [%cached, %fresh]; call %r(...)`).

### Verification (Julia 1.13)

- `erf(::ComplexF64)` reverse (`ReverseHolomorphic`) and forward modes both match the analytic derivative `2/√π·exp(−x²)`.
- `erf`, `erfc`, `erfi` work.
- `erfcx`, `dawson` now give a clean `EnzymeNoDerivativeError: No reverse pass found for ejlstr$Faddeeva_erfcx$...` (correct name, missing rule) instead of an internal crash — **identical to Julia 1.12's PLT path**, confirming this is not a regression but a pre-existing missing-rule gap.
- No regression on Julia 1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)