### PR TITLE
Fix Julia 1.13 segfault on undef/partially-initialized struct return (#3087)

### DIFF
--- a/src/llvm/transforms.jl
+++ b/src/llvm/transforms.jl
@@ -1901,6 +1901,11 @@ function remove_readonly_unused_calls!(fn::LLVM.Function, next::Set{String})
 end
 
 function propagate_returned!(mod::LLVM.Module)
+    sretkind = LLVM.kind(if LLVM.version().major >= 12
+        LLVM.TypeAttribute("sret", LLVM.Int32Type())
+    else
+        LLVM.EnumAttribute("sret")
+    end)
     globs = LLVM.GlobalVariable[]
     for g in globals(mod)
         if linkage(g) == LLVM.API.LLVMInternalLinkage ||
@@ -2133,6 +2138,24 @@ function propagate_returned!(mod::LLVM.Module)
                         illegalUse = true
                         break
                     end
+                    # If every caller passes undef/poison for this argument (val === nothing),
+                    # the interprocedural const-prop below would replace the argument with undef
+                    # inside the body. That is only sound for arguments used purely as values.
+                    # For an sret-like output pointer (`sret`/`enzyme_sret`/`enzyme_sret_v`) the
+                    # body *stores into* the argument, so replacing it with undef turns those
+                    # stores into stores-to-undef. Downstream InstCombine/SROA then treat that as
+                    # UB and collapse the whole function to `unreachable`/`poison`, miscompiling
+                    # the augmented forward pass (segfault, issue #3087). Skip the replacement for
+                    # such write-only output pointers when there is no concrete value to propagate.
+                    if !illegalUse && val === nothing && any(
+                        (
+                            kind(attr) == sretkind ||
+                            kind(attr) == kind(StringAttribute("enzyme_sret")) ||
+                            kind(attr) == kind(StringAttribute("enzyme_sret_v"))
+                        ) for attr in collect(parameter_attributes(fn, i))
+                    )
+                        illegalUse = true
+                    end
                     if !illegalUse
                         if val === nothing
                             val = LLVM.UndefValue(value_type(arg))
@@ -2332,7 +2355,7 @@ function delete_writes_into_removed_args(fn::LLVM.Function, toremove::Vector{Int
             cur, cval = pop!(todorep)
             if isa(cur, LLVM.StoreInst)
                 if operands(cur)[2] == cval
-                    LLVM.API.LLVMInstructionEraseFromParent(nphi)
+                    LLVM.API.LLVMInstructionEraseFromParent(cur)
                     continue
                 end
             end


### PR DESCRIPTION
Fixes #3087.

## Symptom

On Julia 1.13, reverse-mode `autodiff` over a function that calls an inner `@noinline` routine returning a small mixed tuple via `sret` (e.g. `Tuple{Float64,Int64}`) segfaults at runtime. This is the `Undef sret` testset in `test/core/abi.jl` (works on 1.12 and earlier).

## Root cause

The runtime trace bottoms out in an `augmented_julia_*` function whose entire body is `unreachable` — a miscompilation, traced as follows:

1. On 1.13 the core emits the augmented-forward pass of the inner function with the active scalar returned directly and the primal struct + its shadow delivered through `enzyme_sret` **output pointers** (on ≤1.12 it was a single combined `sret` struct that the caller reads). The caller never reads the primal cache and passes `undef` for the shadow sret.
2. `propagate_returned!`'s interprocedural constant propagation treats "every caller passes undef" as license to replace the argument with `undef` inside the body. For an sret-like **output** pointer the body *stores into* the argument, so this produced `store i64 2, ptr undef`.
3. Downstream InstCombine/SROA treat that store-to-`undef` as UB and collapse the whole augmented function to `ret poison`, then strip every argument → `define ... @aug()` with body `unreachable`.
4. At runtime the caller invokes the now-empty function, uses the undefined result, and falls through to garbage → SIGSEGV.

## Fix (`src/llvm/transforms.jl`)

1. Guard the const-prop in `propagate_returned!` so it never replaces an `sret` / `enzyme_sret` / `enzyme_sret_v` output pointer with `undef` when there is no concrete value to propagate (those arguments are stored into; undef-propagation creates store-to-undef UB).
2. Fix a latent typo in `delete_writes_into_removed_args`: erasing a store into a removed argument referenced the undefined `nphi` instead of `cur`.

No C++ core change required.

## Verification

- `Undef sret` regression test (`test/core/abi.jl`) now passes on 1.13; gradient matches 1.12 exactly and is finite-difference verified (`dx[1] = -1.60899866723324`).
- `core/abi` passes identically on **1.12 and 1.13** (144 pass / 1 broken).
- `callconv`, `rooted_args` (sret/ABI-heavy) and `basic` (295/295) pass on 1.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
