### PR TITLE
Handle UnionAll Broadcasted in broadcast override inference

### DIFF
--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -1074,6 +1074,10 @@ end
 @inline function bc_or_array_or_number_ty(@nospecialize(Ty::Type), midnothing::Bool=true)::Bool
     if ( midnothing && Ty <: Base.Broadcast.Broadcasted{<:Base.Broadcast.DefaultArrayStyle, Nothing}) ||
        (!midnothing && Ty <: Base.Broadcast.Broadcasted{<:Base.Broadcast.DefaultArrayStyle})
+        # If `Ty` is not a fully-specified `DataType` (e.g. a `UnionAll` with free
+        # type parameters, or a `Union`), the args tuple type is unknown so we
+        # cannot apply the override.
+        Ty isa DataType || return false
         return all(Base.Fix2(bc_or_array_or_number_ty, midnothing), Ty.parameters[4].parameters)
     else
     return Ty <: AbstractArray || Ty <: Number || Ty <: Base.RefValue
@@ -1083,6 +1087,7 @@ end
 @inline function has_array(@nospecialize(Ty::Type), midnothing::Bool=true)::Bool
     if ( midnothing && Ty <: Base.Broadcast.Broadcasted{<:Base.Broadcast.DefaultArrayStyle, Nothing}) ||
        (!midnothing && Ty <: Base.Broadcast.Broadcasted{<:Base.Broadcast.DefaultArrayStyle})
+        Ty isa DataType || return false
         return any(Base.Fix2(has_array, midnothing), Ty.parameters[4].parameters)
     else
     return Ty <: AbstractArray


### PR DESCRIPTION
## Problem

Inference crashes with a `FieldError` when Enzyme's broadcast mapreduce/foldl override is consulted for a `Broadcasted` type that `widenconst` left only partially specified (a `UnionAll` with free `Axes`/`F`/`Args` parameters):

```
FieldError: type UnionAll has no field `parameters`, available fields: `var`, `body`
  [2] bc_or_array_or_number_ty(Ty::Type, midnothing::Bool)
      @ Enzyme.Compiler.Interpreter src/compiler/interpreter.jl:1077
```

`bc_or_array_or_number_ty` and `has_array` match `Ty <: Broadcast.Broadcasted{...}` and then directly read `Ty.parameters[4]` (the broadcast args tuple type). That access assumes `Ty` is a concrete `DataType`, but a `UnionAll` has no `parameters` field. This was hit in the wild by the SVD reverse rule in TensorKit, which produces such a partially-specified `Broadcasted` type.

## Fix

Guard both helpers so they bail out (return `false`) when `Ty` is not a fully-specified `DataType`. Returning `false` is the conservative, correct choice: when the args tuple type is unknown, Enzyme simply skips the broadcast override and falls back to the normal AD path instead of crashing.

## Testing

```julia
BC = Base.Broadcast.Broadcasted
DAS = Base.Broadcast.DefaultArrayStyle
T1 = BC{DAS{2}, A, F, Args} where {A, F, Args}   # UnionAll, previously crashed
bc_or_array_or_number_ty(T1, false)  # => false (was: FieldError)
has_array(T1, false)                 # => false (was: FieldError)
# concrete Broadcasted still returns true as before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)