### PR TITLE
Add mul! (gemv/gemm) rule for GPU arrays (#2837)

### DIFF
--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -1,7 +1,10 @@
 module EnzymeGPUArraysCoreExt
 
 using GPUArraysCore
+using GPUArraysCore: AnyGPUArray
 using Enzyme
+using Enzyme: EnzymeRules
+using LinearAlgebra: mul!
 
 function Enzyme.zerosetfn(x::AbstractGPUArray, i::Int)
     res = zero(x)
@@ -33,6 +36,115 @@ end
         @allowscalar @inbounds res[i + start - 1] = 1
         return res
     end
+end
+
+# ---------------------------------------------------------------------------
+# mul! on GPU arrays (backend BLAS gemv/gemm)
+#
+# Enzyme's built-in BLAS differentiation only recognizes CPU BLAS symbols, so
+# on the CPU `mul!` is handled by the core. On GPUs the backend BLAS call (e.g.
+# `cublasSgemv`) is a foreign ccall Enzyme cannot differentiate through
+# (staged scalars via a device `Ref`, `retry_reclaim` atomics, gc-transition
+# bundles), which leaves the matrix gradient zero or trips an internal error.
+# So we provide the analytic derivative directly, dispatched on `AnyGPUArray`
+# (all backends, incl. wrapped transpose/adjoint/view; CPU `Array` is excluded
+# so the core CPU-BLAS path is untouched).
+# See https://github.com/EnzymeAD/Enzyme.jl/issues/2837.
+#
+# For `C = α*A*B + β*C`:
+#   forward:  Ċ = β*Ċ + α*(Ȧ*B + A*Ḃ)  (+ α̇*A*B + β̇*C for active scalars)
+#   reverse:  Ā += α*C̄*Bᵀ ;  B̄ += α*Aᵀ*C̄ ;  C̄ ← β*C̄
+#             ᾱ = Σ C̄ ⊙ (A*B) ;  β̄ = Σ C̄ ⊙ C_old
+# ---------------------------------------------------------------------------
+
+const GPUAnnotation = Annotation{<:AnyGPUArray}
+
+# Accumulate `α*X*Y` into `dst`. A plain GPU-array destination goes through the
+# in-place backend BLAS; a wrapped destination (e.g. `transpose(dW)`) is not a
+# valid BLAS output, so fall back to a broadcast into the wrapper.
+@inline _addmul!(dst::AbstractGPUArray, X, Y, α) = (mul!(dst, X, Y, α, true); nothing)
+@inline _addmul!(dst, X, Y, α) = (dst .+= α .* (X * Y); nothing)
+
+function EnzymeRules.forward(
+        config, ofn::Const{typeof(mul!)}, ::Type{RT},
+        C::GPUAnnotation, A::GPUAnnotation, B::GPUAnnotation,
+        α::Annotation{<:Number}, β::Annotation{<:Number}
+    ) where {RT}
+    W = EnzymeRules.width(config)
+    for i in 1:W
+        dC = W == 1 ? C.dval : C.dval[i]
+        dC .*= β.val
+        A isa Const || mul!(dC, W == 1 ? A.dval : A.dval[i], B.val, α.val, true)
+        B isa Const || mul!(dC, A.val, W == 1 ? B.dval : B.dval[i], α.val, true)
+        # `C.val` still holds the old value here (primal below), needed by the β̇ term
+        α isa Const || (dC .+= (W == 1 ? α.dval : α.dval[i]) .* (A.val * B.val))
+        β isa Const || (dC .+= (W == 1 ? β.dval : β.dval[i]) .* C.val)
+    end
+    ofn.val(C.val, A.val, B.val, α.val, β.val)
+
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        return W == 1 ? Duplicated(C.val, C.dval) : BatchDuplicated(C.val, C.dval)
+    elseif EnzymeRules.needs_shadow(config)
+        return C.dval
+    elseif EnzymeRules.needs_primal(config)
+        return C.val
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+        config, ofn::Const{typeof(mul!)}, ::Type{RT},
+        C::GPUAnnotation, A::GPUAnnotation, B::GPUAnnotation,
+        α::Annotation{<:Number}, β::Annotation{<:Number}
+    ) where {RT}
+    # snapshot inputs needed to form the reverse products. Ā = α*C̄*Bᵀ needs B's
+    # value, and B̄ = α*Aᵀ*C̄ needs A's value — i.e. each is needed when the *other*
+    # operand is active.
+    Aval = (B isa Const) ? nothing : copy(A.val)
+    Bval = (A isa Const) ? nothing : copy(B.val)
+    # α/β adjoints need A*B and the pre-update C respectively
+    ABval = (α isa Const) ? nothing : A.val * B.val
+    Cold = (β isa Const) ? nothing : copy(C.val)
+
+    ofn.val(C.val, A.val, B.val, α.val, β.val)
+
+    primal = EnzymeRules.needs_primal(config) ? C.val : nothing
+    shadow = EnzymeRules.needs_shadow(config) ? C.dval : nothing
+    return EnzymeRules.AugmentedReturn(primal, shadow, (Aval, Bval, α.val, β.val, ABval, Cold))
+end
+
+function EnzymeRules.reverse(
+        config, ofn::Const{typeof(mul!)}, ::Type{RT}, tape,
+        C::GPUAnnotation, A::GPUAnnotation, B::GPUAnnotation,
+        α::Annotation{<:Number}, β::Annotation{<:Number}
+    ) where {RT}
+    Aval, Bval, αval, βval, ABval, Cold = tape
+    W = EnzymeRules.width(config)
+    Cbar(i) = W == 1 ? C.dval : C.dval[i]
+
+    # scalar adjoints (use C̄ before it is scaled by β below)
+    dα = if α isa Const
+        nothing
+    elseif W == 1
+        sum(Cbar(1) .* ABval)
+    else
+        ntuple(i -> sum(Cbar(i) .* ABval), W)
+    end
+    dβ = if β isa Const
+        nothing
+    elseif W == 1
+        sum(Cbar(1) .* Cold)
+    else
+        ntuple(i -> sum(Cbar(i) .* Cold), W)
+    end
+
+    for i in 1:W
+        A isa Const || _addmul!(W == 1 ? A.dval : A.dval[i], Cbar(i), Bval', αval)
+        B isa Const || _addmul!(W == 1 ? B.dval : B.dval[i], Aval', Cbar(i), αval)
+        C isa Const || (Cbar(i) .*= βval)
+    end
+    return (nothing, nothing, nothing, dα, dβ)
 end
 
 end # module

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -243,3 +243,49 @@ end
     @test all(dA .≈ (2:2:64))
     @test all(dA2 .≈ 3*(2:2:64))
 end
+
+# https://github.com/EnzymeAD/Enzyme.jl/issues/2837
+# `mul!` on GPU arrays (backend BLAS gemv/gemm), handled by EnzymeGPUArraysCoreExt.
+struct Linear2837{W, B}
+    weight::W
+    bias::B
+end
+(m::Linear2837)(x) = m.weight * x .+ m.bias
+
+@testset "mul! on CuArrays (#2837)" begin
+    rev = Enzyme.set_runtime_activity(Reverse)
+    fwd = Enzyme.set_runtime_activity(Forward)
+
+    # reverse gemv:  y = W*x  →  dW = 1*x', dx = W'*1
+    W = cu(randn(Float32, 3, 4)); x = cu(randn(Float32, 4))
+    dW = Enzyme.make_zero(W); dx = Enzyme.make_zero(x)
+    Enzyme.autodiff(rev, Const(p -> sum(p[1] * p[2])), Active, Duplicated((W, x), (dW, dx)))
+    @test Array(dW) ≈ ones(Float32, 3) * Array(x)'
+    @test Array(dx) ≈ Array(W)' * ones(Float32, 3)
+
+    # reverse gemm:  C = A*B  →  dA = 1*B', dB = A'*1
+    A = cu(randn(Float32, 3, 4)); B = cu(randn(Float32, 4, 5))
+    dA = Enzyme.make_zero(A); dB = Enzyme.make_zero(B)
+    Enzyme.autodiff(rev, Const(p -> sum(p[1] * p[2])), Active, Duplicated((A, B), (dA, dB)))
+    @test Array(dA) ≈ ones(Float32, 3, 5) * Array(B)'
+    @test Array(dB) ≈ Array(A)' * ones(Float32, 3, 5)
+
+    # wrapped operand (AnyGPUArray): sum(Wᵀ*x)  →  dW[i,j] = x[i]
+    Wt = cu(randn(Float32, 4, 3)); xt = cu(randn(Float32, 4))
+    dWt = Enzyme.make_zero(Wt)
+    Enzyme.autodiff(rev, Const((W, x) -> sum(transpose(W) * x)), Active, Duplicated(Wt, dWt), Const(xt))
+    @test Array(dWt) ≈ Array(xt) * ones(Float32, 3)'
+
+    # the #2837 MWE: differentiate a struct "model", sum(W*x .+ b)
+    model = Linear2837(cu(Float32[1.0 2.0; 3.0 4.0]), cu(Float32[0.5, -0.5]))
+    dmodel = Duplicated(model, Enzyme.make_zero(model))
+    xm = cu(Float32[0.3, 0.7])
+    Enzyme.autodiff(rev, Const((m, x) -> sum(m(x))), Active, dmodel, Const(xm))
+    @test Array(dmodel.dval.weight) ≈ ones(Float32, 2) * Array(xm)'
+    @test all(Array(dmodel.dval.bias) .≈ 1)
+
+    # forward gemv:  ẏ = Ẇ*x
+    Wf = cu(randn(Float32, 3, 4)); xf = cu(randn(Float32, 4)); Ẇ = cu(randn(Float32, 3, 4))
+    ẏ = Enzyme.autodiff(fwd, Const((W, x) -> W * x), Duplicated(Wf, Ẇ), Const(xf))[1]
+    @test Array(ẏ) ≈ Array(Ẇ) * Array(xf)
+end


### PR DESCRIPTION
update after #3363 landed:

Fixes the remaining gradient in #2837 — the copy rules landed separately in #3363.

Reverse-mode `mul!` on GPU arrays returned a **zero matrix gradient** (and on newer `Enzyme_jll` an internal `cmpxchg` error): the backend BLAS call (`cublasSgemv` etc.) is a foreign ccall Enzyme can't differentiate through. Enzyme core differentiates CPU BLAS fine, just not the GPU path.

- **`mul!` forward + reverse rules** implementing the analytic gemm/gemv adjoint (`Ā += α·C̄·Bᵀ`, `B̄ += α·Aᵀ·C̄`, plus α/β scalar and batch handling), added to `EnzymeGPUArraysCoreExt`.
- **Dispatched on `AnyGPUArray`**, so it covers all GPU backends and wrapped operands (`transpose`/`adjoint`/`view`), while excluding CPU `Array` — leaving Enzyme core's CPU-BLAS path untouched. A plain shadow accumulates via in-place `mul!`; a wrapped shadow (e.g. `transpose(dW)`, which isn't a valid BLAS output) via broadcast.

Verified on an RTX 5090: gemv, gemm, a wrapped-transpose case, the issue MWE, and forward mode all match analytic gradients (`test/cuda.jl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
