### PR TITLE
Fix Windows JIT unwind info for Enzyme frames (#3374)

### DIFF
--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -174,6 +174,20 @@ function add_trampoline!(jd, (lljit, lctm, ism), entry, target)
 end
 
 function prepare!(mod)
+    # On Windows, LLVM's GlobalOpt demotes internal functions to `private` linkage,
+    # which emits no object symbol. Julia's per-symbol Win64 JIT unwind registrar
+    # (create_PRUNTIME_FUNCTION) then skips those functions, so their frames get no
+    # RUNTIME_FUNCTION and a fault (e.g. a GC safepoint) landing on one defeats
+    # Windows exception dispatch. Promote them back to `internal` here -- the last
+    # step before JIT emission, after all optimization -- so they keep a local
+    # symbol and get registered. See EnzymeAD/Enzyme.jl#3374.
+    if Sys.iswindows()
+        for f in functions(mod)
+            if !LLVM.isdeclaration(f) && LLVM.linkage(f) == LLVM.API.LLVMPrivateLinkage
+                LLVM.linkage!(f, LLVM.API.LLVMInternalLinkage)
+            end
+        end
+    end
     for f in collect(functions(mod))
         ptr = fix_ptr_lookup(LLVM.name(f))
         if ptr === nothing


### PR DESCRIPTION
Fixes #3374 — the `threads/2` access-violation crash on Windows (reverse autodiff over `jl_new_task` with `--threads>=2`).

## Root cause

The crash is the *legitimate* GC stop-the-world safepoint guard-page fault in `ijl_gc_safepoint`, hit during `wait(task)` in the reverse pass. On Windows it is normally serviced after `RtlDispatchException` walks the stack — but the walk dies on an Enzyme JIT frame (`poptask`) that has **no registered unwind info**, so the fault fast-fails to `0xC0000005` without ever reaching Julia's safepoint handler.

Why that frame has no unwind info:

- Julia emits these inner functions as `external`, but the optimization pipeline (`internalize` → LLVM `GlobalOpt`) demotes `internal` + `unnamed_addr` functions to **`private`** linkage.
- `private` functions emit **no object symbol**.
- Julia's per-symbol Win64 JIT unwind registrar (`create_PRUNTIME_FUNCTION` in `debuginfo.cpp`) only registers `ST_Function` **symbols**, so private (symbol-less) functions get no `RUNTIME_FUNCTION` entry → their frames are not unwindable.

Confirmed via `DumpPostOpt`: `define private fastcc void @julia_poptask_...` (40/43 functions in the module are `private`/`internal`), and `RtlLookupFunctionEntry` returns null for that frame while normal Julia JIT frames and Enzyme's thunk *entry* symbol both resolve.

This is independent of the personality / `uwtable` (the registrar keys on symbols, not those), and it is the underlying reason JuliaLang/julia#62435 (a first-chance vectored exception handler) makes the crash disappear — that PR sidesteps the broken stack walk rather than fixing the missing unwind info.

## Fix

Promote `private`-linkage defined functions back to `internal` in `prepare!` — the last step before JIT emission. `internal` keeps them module-local but emits a local symbol, so Julia's registrar covers them and the frames become unwindable.

This must live at Enzyme's final pre-JIT step: a promotion in GPUCompiler's `optimize!` does **not** work, because Enzyme runs its own `post_optimize!`/`GlobalOpt` afterward which re-demotes to `private`.

## Verification

On **stock Julia 1.12.6** (without JuliaLang/julia#62435):

- The #3374 reproducer survives **5/5** runs (`--threads=2`, pkgimages enabled), vs. reliable `0xC0000005` before.
- Full `test/threads.jl` passes at `--threads=2`.

## Notes

- `internal` (vs `private`) keeps a local symbol for each JIT'd function on Windows — a small symbol-table size increase, no correctness/perf impact on the generated code.
- A parallel GPUCompiler-side change could help non-Enzyme native/CPU JIT users on Windows, but it is neither necessary nor sufficient for Enzyme and is left out of scope here.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
