### PR TITLE
Fix reverse-mode race on Active scalars captured by Threads.@threads (#3378)

### DIFF
--- a/src/rules/parallelrules.jl
+++ b/src/rules/parallelrules.jl
@@ -160,7 +160,7 @@ function (st::ReversePFor{ThunkTy, FT, AnyJL, byRef, TT})(tid) where {ThunkTy, F
     else
         @inbounds st.tapes[tid]
     end
-    
+
     if byRef
         st.thunk(Const(referenceCaller), st.ft, Const(tid), tres)
     else
@@ -168,6 +168,52 @@ function (st::ReversePFor{ThunkTy, FT, AnyJL, byRef, TT})(tid) where {ThunkTy, F
     end
 
     nothing
+end
+
+# Build a thread-private copy of a reverse-mode shadow closure. Mutable / inactive captures
+# (arrays, boxes, integers, ranges, ...) are shared with the caller's shadow: their shadow
+# carries the incoming cotangents the reverse pass *reads* (e.g. the loop's `dout`), and
+# their in-place accumulation must land back in the caller. Active immutable captures (floats,
+# and immutable structs containing them) are zeroed so each thread accumulates into its own
+# partial; the partials are summed back into the caller's shadow after the parallel region
+# (see `runtime_pfor_rev`). This avoids the data race of multiple threads doing a non-atomic
+# read-modify-write of a shared active scalar shadow.
+#
+# `make_zero` is not used: by default it *zeros* the mutable shadows (an incoming `dout`
+# would be read as zeros, giving a zero gradient). It can be made to share them by pre-seeding
+# its `seen::IdDict` with each mutable object mapped to itself, but collecting those objects
+# is the same traversal done here, so we share-and-zero directly with a literal `zero` on the
+# leaves (robust for non-finite shadow values, unlike an `x - x` form).
+@inline zero_active_shadow(x::T) where {T <: AbstractFloat} = zero(x)
+@inline zero_active_shadow(x::T) where {T <: Complex} = zero(x)
+@inline function zero_active_shadow(x::T) where {T}
+    (guaranteed_const(T) || mutable_register(T)) && return x
+    return splatnew(
+        T, ntuple(Val(fieldcount(T))) do i
+            Base.@_inline_meta
+            zero_active_shadow(getfield(x, i))
+        end
+    )
+end
+
+struct ReversePForSplit{ThunkTy, VT, PT, AnyJL, TT}
+    thunk::ThunkTy
+    val::VT
+    privates::PT
+    tapes::TT
+end
+
+function (st::ReversePForSplit{ThunkTy, VT, PT, AnyJL, TT})(tid) where {ThunkTy, VT, PT, AnyJL, TT}
+    tres = if !AnyJL
+        unsafe_load(st.tapes, tid)
+    else
+        @inbounds st.tapes[tid]
+    end
+
+    ft_tid = Duplicated(st.val, @inbounds st.privates[tid])
+    st.thunk(Const(referenceCaller), ft_tid, Const(tid), tres)
+
+    return nothing
 end
 
 function runtime_pfor_rev(
@@ -178,7 +224,26 @@ function runtime_pfor_rev(
     tapes,
     threading_args...,
 ) where {ThunkTy,FT,AnyJL,byRef}
-    Base.Threads.threading_run(ReversePFor{ThunkTy, FT, AnyJL, byRef, typeof(tapes)}(thunk, ft, tapes), threading_args...)
+    if byRef && FT <: Duplicated && ft.dval isa Base.RefValue
+        # Give each thread its own shadow closure so accumulation of active immutable
+        # captures (e.g. an `Active` scalar written inside the loop) does not race, then
+        # reduce the per-thread partials back into the caller's shadow.
+        master = ft.dval
+        n = Base.Threads.threadpoolsize()
+        privates = Vector{typeof(master)}(undef, n)
+        for i in 1:n
+            @inbounds privates[i] = Base.RefValue(zero_active_shadow(master[]))
+        end
+        Base.Threads.threading_run(
+            ReversePForSplit{ThunkTy, typeof(ft.val), typeof(privates), AnyJL, typeof(tapes)}(thunk, ft.val, privates, tapes),
+            threading_args...,
+        )
+        for i in 1:n
+            master[] = recursive_add(master[], (@inbounds privates[i])[], identity, mutable_register)
+        end
+    else
+        Base.Threads.threading_run(ReversePFor{ThunkTy, FT, AnyJL, byRef, typeof(tapes)}(thunk, ft, tapes), threading_args...)
+    end
     if !AnyJL
         Libc.free(tapes)
     end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -78,6 +78,20 @@ end
     dout = [1.0, 1.0]
     res = autodiff(Reverse, f_multi, Const, Duplicated(out, dout), Active(2.0))
     @test res[1][2] ≈ 2.0
+
+    # Amplified check: with many iterations and threads, a non-atomic per-thread
+    # accumulation of the active variable's adjoint loses contributions under
+    # contention. `d(in)` must equal `length(out)` on every run (see issue #3378).
+    N = 2000
+    let out = zeros(N), dout = ones(N)
+        autodiff(Reverse, f_multi, Const, Duplicated(out, dout), Active(2.0))
+    end
+    @test all(1:50) do _
+        out = zeros(N)
+        dout = ones(N)
+        res = autodiff(Reverse, f_multi, Const, Duplicated(out, dout), Active(2.0))
+        res[1][2] ≈ N
+    end
 end
 
 @testset "Closure-less threads $(Threads.nthreads())" begin


### PR DESCRIPTION
Fixes #3378.

## Problem

Reverse-mode autodiff of a `Threads.@threads` loop that writes an **`Active` scalar** loses gradient contributions under thread contention:

```julia
function f_multi(out, in)
    Threads.@threads for idx in 1:length(out)
        out[idx] = in
    end
    return nothing
end
res = autodiff(Reverse, f_multi, Const, Duplicated(out, dout), Active(2.0))
# res[1][2] should be dout[1] + dout[2] = 2.0, but races to 1.0
```

The captured scalar `in` lives in an **immutable** closure whose shadow is a single `Base.RefValue` shared by every thread (`ft = Duplicated{Base.RefValue{closure}}`). Because the field is immutable, each thread's adjoint accumulates via a non-atomic whole-struct read-modify-write of that shared `Ref`, so concurrent updates race and contributions are lost. The array capture (`out`/`dout`) doesn't race — it's a shared mutable pointer accumulated at distinct indices.

## Fix

In `runtime_pfor_rev`, when the shadow is a shared `Ref` closure, give each thread its own shadow closure and reduce afterward:

- **Mutable / inactive captures** (arrays, boxes, ...) are **shared** with the caller's shadow. Their shadow carries the incoming cotangents the reverse pass *reads* (e.g. the loop's `dout`), and their in-place accumulation must reach the caller.
- **Active immutable captures** (floats, immutable structs of floats) are **zeroed** so each thread accumulates into its own partial.
- After the parallel region the partials are summed back into the caller's shadow with `recursive_add(..., mutable_register)` (which leaves the shared mutable data untouched).

## Verification

- Amplified reproducer (N=2000, 8 threads): before **2–9 bad / 100**, min 1750; after **0 bad**, min 2000 (0 bad over 1000 runs).
- `test/threads.jl` passes with 4 and 8 threads; added an amplified check to the "Advanced, Active-var Threads" testset since the 2-element case only raced occasionally.

## Open design question 🙏

`zero_active_shadow` is a *share-mutable / zero-active* traversal that overlaps with the existing `make_zero` / `recursive_add` machinery but is not either of them:

- `make_zero` **zeros** mutable shadows by default — which would read an incoming `dout` as zeros and give a zero gradient. It *can* share them by pre-seeding its `seen::IdDict` with each mutable object mapped to itself, but collecting those objects is the same traversal implemented here.
- The reduction reuses `recursive_add(x, y, identity, mutable_register)`.

So this adds a third variant of the "walk a shadow" pattern. **Should it be unified with `make_zero`/`recursive_add`, and are users meant to be able to extend it for their own types?** Feedback welcome — happy to refactor toward whatever the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)