### PR TITLE
Let the format check read fork pull requests again

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -21,6 +21,10 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
+          # Required since actions/checkout@v7 to read a fork's code from a
+          # `pull_request_target` workflow. Runic only parses the sources, they
+          # are never executed, so no fork code runs in this trusted context.
+          allow-unsafe-pr-checkout: true
 
       - name: Add upstream remote
         run: |


### PR DESCRIPTION
Generated by Claude Opus-5:

## Problem

The `runic` check currently fails on **every pull request from a fork**, before Runic ever runs. It dies in the first step:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target'
workflow. ... To opt in, review the risks at
https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

`actions/checkout@v7` added that guard, and #3209 bumped this workflow from v6 to v7, so fork PRs have had a red `runic` check ever since — and, more importantly, formatting suggestions are never posted for external contributors.

The break is visible in the PR history: every fork PR opened after #3209 merged (2026-06-22) fails the check — #3293, #3298, #3302, #3354, #3363, #3365, #3366 — while the last fork PR opened before it (#3207) passed, and PRs from branches in this repository are unaffected (they aren't fork checkouts, so the guard doesn't apply). `Format.yml` is the only workflow here that uses `pull_request_target`.

## Fix

Set `allow-unsafe-pr-checkout: true`, restoring the pre-v7 behaviour.

## Why this is safe here

The guard exists because `pull_request_target` runs with the base repository's `GITHUB_TOKEN`, secrets and default-branch cache scope, so *executing* a fork's code there is a privilege-escalation risk. This job never executes the checked-out code:

- Runic is installed into the shared `@runic` environment, not the PR's project, so nothing from the PR's `Project.toml`/`Manifest.toml` is resolved, built or loaded.
- `git runic --diff` only parses the sources and re-prints them; it does not evaluate code or expand macros.
- The PR's diff reaches the comment step as an action input rather than inside a `run:` block, so it is not interpolated into a shell command.

So the fork's contents are treated purely as text. If a future step ever needs to *run* the PR's code, this opt-in should be revisited.

Two alternatives, if you would rather not opt in:

- Add `persist-credentials: false` to the checkout as extra hardening, so the base repository's token is not written into the workspace's git config. I left it out because the `git fetch upstream` below relies on the credentials checkout persists, and making that fetch anonymous seemed a worse trade than the risk it removes — happy to add it if you prefer.
- Split into an untrusted `pull_request` job that runs Runic and uploads the diff as an artifact, plus a `workflow_run` job that posts the comment. That is the pattern GitHub recommends, but it is a larger change to a workflow that otherwise works, so it seemed better as your call than as an unsolicited rewrite.

## Testing

I could not exercise this end-to-end, since a `pull_request_target` workflow only runs from the base repository's default branch — it takes effect once merged. Verified instead that `allow-unsafe-pr-checkout` is a real input of `actions/checkout@v7` (it is documented in the action's `action.yml`, and named in the error above), and that the workflow still parses as valid YAML with the expected inputs on the checkout step.
