### PR TITLE
Support SPIR-V device targets

### DIFF
--- a/src/jlrt.jl
+++ b/src/jlrt.jl
@@ -1,5 +1,38 @@
 # For julia runtime function emission
-    
+
+"""
+    is_device_triple(triple::String)
+
+Whether `triple` names a GPU/accelerator target. Such modules have no Julia
+runtime, so exceptions have to go through GPUCompiler's `gpu_report_exception`
+family instead of `jl_throw`.
+"""
+function is_device_triple(triple::String)
+    # NOTE: Metal (air64-apple-macosx) is deliberately not listed here yet; it has
+    #       never taken this path and enabling it is untested.
+    return occursin("ptx", triple) ||      # nvptx64-nvidia-cuda
+        occursin("amdgcn", triple) ||      # amdgcn-amd-amdhsa
+        occursin("spir", triple)           # spirv64-unknown-unknown / spir64-unknown-unknown
+end
+
+"""
+    coerce_ptr!(B, val, ty)
+
+Bring pointer `val` into the representation `ty`. Targets whose datalayout sets a
+non-zero global address space (`-G1`: SPIR-V, AMDGPU) put string constants in
+`addrspace(1)`, while the GPUCompiler runtime declarations take an `addrspace(0)`
+pointer, so an explicit `addrspacecast` is needed -- this is what GPUCompiler
+itself emits. On targets where both are `addrspace(0)` this is a no-op.
+"""
+function coerce_ptr!(B::LLVM.IRBuilder, @nospecialize(val::LLVM.Value), @nospecialize(ty::LLVM.LLVMType))
+    vty = value_type(val)
+    vty == ty && return val
+    if vty isa LLVM.PointerType && ty isa LLVM.PointerType
+        return addrspacecast!(B, val, ty)
+    end
+    return ptrtoint!(B, val, ty)
+end
+
 function emit_allocobj!(
     B::LLVM.IRBuilder,
     @nospecialize(tag::LLVM.Value),
@@ -1140,7 +1173,7 @@ function emit_error(B::LLVM.IRBuilder, @nospecialize(orig::Union{Nothing, LLVM.I
         stringv = globalstring_ptr!(B, stringv, "enz_exception")
     end
 
-    ct = if occursin("ptx", LLVM.triple(mod)) || occursin("amdgcn", LLVM.triple(mod))
+    ct = if is_device_triple(LLVM.triple(mod))
 	if string isa Tuple
 	    errty = errty.name.wrapper{Nothing, Nothing}
 	end
@@ -1150,7 +1183,7 @@ function emit_error(B::LLVM.IRBuilder, @nospecialize(orig::Union{Nothing, LLVM.I
         exc, _ =
             get_function!(mod, "gpu_report_exception", LLVM.FunctionType(vt, [ptr]))
 
-        stringv = ptrtoint!(B, stringv, ptr)
+        stringv = coerce_ptr!(B, stringv, ptr)
 
         call!(B, LLVM.function_type(exc), exc, [stringv])
 
@@ -1165,9 +1198,9 @@ function emit_error(B::LLVM.IRBuilder, @nospecialize(orig::Union{Nothing, LLVM.I
             for (i, frame) in enumerate(bt)
                 idx = ConstantInt(parameters(ft)[1], i)
                 func = globalstring_ptr!(B, String(frame.func), "di_func")
-                func = ptrtoint!(B, func, ptr)
+                func = coerce_ptr!(B, func, ptr)
                 file = globalstring_ptr!(B, String(frame.file), "di_file")
-                file = ptrtoint!(B, file, ptr)
+                file = coerce_ptr!(B, file, ptr)
                 line = ConstantInt(parameters(ft)[4], frame.line)
                 call!(B, ft, framefn, [idx, func, file, line])
             end

--- a/src/llvm/attributes.jl
+++ b/src/llvm/attributes.jl
@@ -417,6 +417,17 @@ function annotate!(mod::LLVM.Module)
         end
     end
 
+    # SPIR-V exposes the work-item/work-group identity as external globals
+    # (`@__spirv_BuiltInGlobalInvocationId` and friends) rather than as intrinsic
+    # calls the way PTX and AMDGPU do. They are read-only integer state, so there
+    # is nothing to differentiate; without this Enzyme bails out with
+    # "cannot compute with global variable that doesn't have marked shadow global".
+    for glob in LLVM.globals(mod)
+        if startswith(String(LLVM.name(glob)), "__spirv_BuiltIn")
+            API.SetMD(glob, "enzyme_inactive", LLVM.MDNode(LLVM.Metadata[]))
+        end
+    end
+
     for gname in keys(JuliaGlobalNameMap)
         globs = LLVM.globals(mod)
         if haskey(globs, gname)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,6 +225,15 @@ end
     return has_method(sig, mt.world, mt.mt) || has_method(sig, mt.world, nothing)
 end
 
+# Fallback for method table views we don't know about, such as the
+# `StackedMethodTable` GPUCompiler layers on top of the internal table.
+# `findsup` performs the same `jl_gf_invoke_lookup_worlds` lookup as the methods
+# above, but respects the view's own layering.
+@inline function has_method(@nospecialize(sig::Type), world::UInt, mt::Core.Compiler.MethodTableView)
+    match, _ = Core.Compiler.findsup(sig, mt)
+    return match !== nothing
+end
+
 @inline function lookup_world(
     @nospecialize(sig::Type),
     world::UInt,
@@ -280,6 +289,20 @@ end
     else
         return lookup_world(sig, mt.world, nothing, min_world, max_world)
     end
+end
+
+# See the `has_method` fallback above.
+@inline function lookup_world(
+    @nospecialize(sig::Type),
+    world::UInt,
+    mt::Core.Compiler.MethodTableView,
+    min_world::Ref{UInt},
+    max_world::Ref{UInt},
+)
+    match, valid_worlds = Core.Compiler.findsup(sig, mt)
+    min_world[] = max(min_world[], valid_worlds.min_world)
+    max_world[] = min(max_world[], valid_worlds.max_world)
+    return match
 end
 
 


### PR DESCRIPTION
Supersedes the stub in #3309 (which currently has a `|| ||` syntax error and only covers one of the gaps).

Makes Enzyme work on `GPUCompiler.SPIRVCompilerTarget`, as used by KernelAbstractions' POCL backend. Four independent gaps, each masking the next:

| # | Symptom | Cause | Fix |
|---|---|---|---|
| 1 | `MethodError: no method matching lookup_world(..., ::StackedMethodTable, ...)` | Enzyme only knew Julia's own `MethodTableView`s; GPUCompiler stacks its own table via CompilerCaching's `StackedMethodTable` | `MethodTableView` fallback via `Core.Compiler.findsup` (same `jl_gf_invoke_lookup_worlds` lookup, respects the view's layering) |
| 2 | `InvalidIRError: unsupported call to the Julia runtime (call to jl_throw)` | `emit_error` gated the `gpu_report_exception` path on `occursin("ptx"/"amdgcn", triple)` | factor out `is_device_triple`, recognise `"spir"` |
| 3 | `PtrToInt result must be integral` | `ptrtoint!` there is only correct by accident — `IRBuilder::CreateCast` folds it when src == dst type, which holds while globals are addrspace 0. SPIR-V/AMDGPU set `-G1`, so string constants land in `addrspace(1)` | `coerce_ptr!` addrspacecasts between pointer types, matching what GPUCompiler emits for the same call |
| 4 | `cannot compute with global variable that doesn't have marked shadow global @__spirv_BuiltInLocalInvocationId` | SPIR-V exposes work-item identity as external globals, not intrinsic calls | mark `@__spirv_BuiltIn*` `enzyme_inactive` in `annotate!` |

Note that #3 also affects AMDGPU in principle (its datalayout is `-G1` too), so this may fix a latent bug there.

### Status

Forward mode over a KernelAbstractions POCL kernel now compiles, runs on device and produces correct derivatives:

```
KA POCL FORWARD-MODE ENZYME: PASS  (dA[1:4] = [2.0, 4.0, 6.0, 8.0])
```

Native CPU Enzyme is unaffected (forward/reverse scalar + array, and the host error path still raises a Julia exception rather than taking the device path).

### Remaining blocker is upstream, not Enzyme

Reverse mode gets all the way to codegen and then segfaults the LLVM SPIR-V backend in `SPIRVInstructionSelector::selectExtractVal`. Minimal reproducer, no Enzyme involved:

```llvm
target triple = "spirv64-unknown-unknown"
define spir_kernel void @j({ { i64, i64, double } } %r, ptr addrspace(1) %out) {
  %a = extractvalue { { i64, i64, double } } %r, 0
  %b = extractvalue { i64, i64, double } %a, 2
  store double %b, ptr addrspace(1) %out, align 8
  ret void
}
```

`llc -filetype=obj` → SIGSEGV in `foldImm` ← `selectExtractVal` ← `selectIntrinsic`.

Characterisation:
- needs a **two-step** `extractvalue`; the fused `extractvalue ..., 0, 2` is fine
- needs the intermediate struct to have **three or more** fields (`{{i64,double}}` is fine, `{{i64,i64,i64}}` also crashes, so it is arity not int/float mixing)
- happens whether the aggregate comes from a call or a function argument

That is exactly the shape of Enzyme's augmented-primal tape return (`{ { i64, i64, double } }`), which is why reverse mode hits it and forward mode does not.

A second, distinct upstream bug shows up in forward mode if a dead Enzyme wrapper survives DCE — `spirv-val` rejects `OpCompositeExtract %_ptr_CrossWorkgroup_double` out of a struct whose member the backend typed as pointer-to-uchar. Worked around on the KernelAbstractions side in JuliaGPU/KernelAbstractions.jl#735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)