### PR TITLE
Don't use easy_rule for det and add rules and tests for logdet

### DIFF
--- a/src/internal_rules/linalg.jl
+++ b/src/internal_rules/linalg.jl
@@ -495,7 +495,6 @@ function EnzymeRules.augmented_primal(
 ) where {RT,AT<:StridedMatrix}
     cache_A = EnzymeRules.overwritten(config)[2] ? copy(A.val) : A.val
     res = det(A.val)
-    dres = make_zero(res)
     retres = EnzymeRules.needs_primal(config) ? res : nothing
     dres = if EnzymeRules.width(config) == 1 && EnzymeRules.needs_shadow(config)
         zero(res)
@@ -614,3 +613,6 @@ function EnzymeRules.forward(
         return nothing
     end
 end
+
+EnzymeRules.has_easy_rule(::typeof(logdet), ::StridedMatrix) = true
+EnzymeRules.has_easy_rule(::typeof(det), ::StridedMatrix) = true

--- a/src/internal_rules/linalg.jl
+++ b/src/internal_rules/linalg.jl
@@ -487,25 +487,130 @@ function EnzymeRules.reverse(
     return (nothing, nothing, nothing, dα, dβ)
 end
 
-function cofactor(A)
-    cofA     = similar(A)
-    minorAij = similar(A, size(A, 1) - 1, size(A, 2) - 1)
-    for i in 1:size(A, 1), j in 1:size(A, 2)
-        fill!(minorAij, zero(eltype(A)))
-
-        # build minor matrix
-        for k in 1:size(A, 1), l in 1:size(A, 2)
-            if !(k == i || l == j)
-                ki = k < i ? k : k - 1
-                li = l < j ? l : l - 1
-                @inbounds minorAij[ki, li] = A[k, l]
-            end
+function EnzymeRules.augmented_primal(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(det)},
+    ::Type{RT},
+    A::Annotation{AT},
+) where {RT,AT<:StridedMatrix}
+    cache_A = EnzymeRules.overwritten(config)[2] ? copy(A.val) : A.val
+    res = det(A.val)
+    dres = make_zero(res)
+    retres = EnzymeRules.needs_primal(config) ? res : nothing
+    dres = if EnzymeRules.width(config) == 1 && EnzymeRules.needs_shadow(config)
+        zero(res)
+    elseif EnzymeRules.width(config) > 1 && EnzymeRules.needs_shadow(config)
+        ntuple(Val(EnzymeRules.width(config))) do i
+            Base.@_inline_meta
+            zero(res)
         end
-        @inbounds cofA[i, j] = (-1)^(i - 1 + j - 1) * det(minorAij)
+    else
+        nothing
     end
-    return cofA
+    cache = (res, cache_A)
+    return EnzymeRules.AugmentedReturn(retres, dres, cache)
 end
 
-# partial derivative of the determinant is the matrix of cofactors
-EnzymeRules.@easy_rule(LinearAlgebra.det(A::AbstractMatrix), (cofactor(A),))
+function EnzymeRules.reverse(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(det)},
+    dret::Active,
+    cache,
+    A::Annotation{<:StridedMatrix},
+)
+    ret, cache_A = cache
+    if !isa(A, Const)
+        A.dval .+= inv(cache_A)' * dot(ret, dret.val)
+    end
+    return (nothing,)
+end
+function EnzymeRules.reverse(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(det)},
+    ::Type{<:Const},
+    cache,
+    A::Annotation{<:Array},
+)
+    return (nothing,)
+end
 
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(det)},
+    ::Type{RT},
+    A::Annotation{<:StridedMatrix},
+) where {RT}
+    res = det(A.val)
+    dres = !isa(A, Const) ? res * sum(diag(A.val \ A.dval)) : zero(res)
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        return Duplicated(res, dres)
+    elseif EnzymeRules.needs_primal(config)
+        return res
+    elseif EnzymeRules.needs_shadow(config)
+        return dres
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(logdet)},
+    ::Type{RT},
+    A::Annotation{AT},
+) where {RT,AT<:StridedMatrix}
+    cache_A = EnzymeRules.overwritten(config)[2] ? copy(A.val) : A.val
+    res = logdet(A.val)
+    retres = EnzymeRules.needs_primal(config) ? res : nothing
+    dres = if EnzymeRules.width(config) == 1 && EnzymeRules.needs_shadow(config)
+        zero(res)
+    elseif EnzymeRules.width(config) > 1 && EnzymeRules.needs_shadow(config)
+        ntuple(Val(EnzymeRules.width(config))) do i
+            Base.@_inline_meta
+            zero(res)
+        end
+    else
+        nothing
+    end
+    return EnzymeRules.AugmentedReturn(retres, dres, cache_A)
+end
+
+function EnzymeRules.reverse(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(logdet)},
+    dret::Active,
+    cache_A,
+    A::Annotation{<:StridedMatrix},
+)
+    !isa(A, Const) && (A.dval .+= dret.val * inv(cache_A)')
+    return (nothing,)
+end
+
+function EnzymeRules.reverse(
+    config::EnzymeRules.RevConfig,
+    func::Const{typeof(logdet)},
+    ::Type{<:Const},
+    cache,
+    A::Annotation{<:StridedMatrix},
+)
+    return (nothing,)
+end
+
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    func::Const{typeof(logdet)},
+    ::Type{RT},
+    A::Annotation{<:StridedMatrix},
+) where {RT}
+    res = logdet(A.val)
+    dres = !isa(A, Const) ? sum(diag(A.val \ A.dval)) : zero(res)
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        return Duplicated(res, dres)
+    elseif EnzymeRules.needs_primal(config)
+        return res
+    elseif EnzymeRules.needs_shadow(config)
+        return dres
+    else
+        return nothing
+    end
+end

--- a/test/integration/Distributions/runtests.jl
+++ b/test/integration/Distributions/runtests.jl
@@ -332,15 +332,15 @@ _pdmat(A) = PDMat(_sym(A) + 5I)
                 _pdmat(randn(rng, 3, 3)),
             ),
             randn(rng, 2, 3);
-            broken=Both
+            broken=Forward
         ),
-        TestCase(MatrixBeta(5, 6.0, 7.0), rand(rng, MatrixBeta(5, 6.0, 6.0)); broken=Both),
+        TestCase(MatrixBeta(5, 6.0, 7.0), rand(rng, MatrixBeta(5, 6.0, 6.0)); broken=Forward),
         TestCase(
             MatrixFDist(6.0, 7.0, _pdmat(randn(rng, 5, 5))),
             rand(rng, MatrixFDist(6.0, 7.0, _pdmat(randn(rng, 5, 5))));
-            broken=Both
+            broken=Forward
         ),
-        TestCase(LKJ(5, 1.1), rand(rng, LKJ(5, 1.1)); broken=Both),
+        TestCase(LKJ(5, 1.1), rand(rng, LKJ(5, 1.1)); broken=Forward),
 
         #
         # Miscellaneous others
@@ -391,7 +391,7 @@ _pdmat(A) = PDMat(_sym(A) + 5I)
         # needs getrf derivative
         TestCase(
             x -> logpdf(vec(LKJ(2, 1.1)), x), [1.0, 0.489, 0.489, 1.0];
-            name="vec", broken=Both
+            name="vec", broken=Forward
         ),
         TestCase(
             function (X, v)

--- a/test/rules/internal_rules/linear_algebra_rules.jl
+++ b/test/rules/internal_rules/linear_algebra_rules.jl
@@ -579,15 +579,17 @@ end
     end
 end
 
-@testset "(matrix) det" begin
+@testset "(matrix) det/logdet" begin
     @testset "forward" begin
         @testset for RT in (Const,DuplicatedNoNeed,Duplicated,),
                      Tx in (Const,Duplicated,)
             xr = [4.0 3.0; 2.0 1.0]
             test_forward(LinearAlgebra.det, RT, (xr, Tx))
 
-            xc = [4.0+0.0im 3.0; 2.0-0.0im 1.0]
+            xc = ComplexF64[4.0+0.0im 3.0; 2.0-0.0im 1.0]
             test_forward(LinearAlgebra.det, RT, (xc, Tx))
+            xc = ComplexF64[4.0+0.0im 0.0; 0.0-0.0im 1.0]
+            test_forward(LinearAlgebra.logdet, RT, (xc, Tx))
         end
     end
     @testset "reverse" begin
@@ -595,8 +597,10 @@ end
             x = [4.0 3.0; 2.0 1.0]
             test_reverse(LinearAlgebra.det, RT, (x, Tx))
 
-            x = [4.0+0.0im 3.0; 2.0-0.0im 1.0]
+            x = ComplexF64[4.0+0.0im 3.0; 2.0-0.0im 1.0]
             test_reverse(LinearAlgebra.det, RT, (x, Tx))
+            x = [4.0 0.0; 0.0 1.0]
+            test_reverse(LinearAlgebra.logdet, RT, (x, Tx))
         end
     end
 end


### PR DESCRIPTION
I think the previous cofactors approach scales really horrendously, hopefully this is better. I also added some rules for `logdet` to hopefully fix https://github.com/EnzymeAD/Enzyme.jl/issues/1078