### PR TITLE
Handle poison incomings in nodecayed_phis! all_args prefilter

### DIFF
--- a/src/llvm/transforms.jl
+++ b/src/llvm/transforms.jl
@@ -818,6 +818,14 @@ function nodecayed_phis!(mod::LLVM.Module)
                                 end
                                 continue
                             end
+                            undeforpoison = isa(base, LLVM.UndefValue)
+                            @static if LLVM.version() >= v"12"
+                                undeforpoison |= isa(base, LLVM.PoisonValue)
+                            end
+                            if undeforpoison
+                                # undef/poison incomings impose no GC constraint
+                                continue
+                            end
                             all_args = false
                             break
                         end
@@ -843,6 +851,14 @@ function nodecayed_phis!(mod::LLVM.Module)
                                 for (v, _) in LLVM.incoming(base)
                                     push!(addrtodo, v)
                                 end
+                                continue
+                            end
+                            undeforpoison = isa(base, LLVM.UndefValue)
+                            @static if LLVM.version() >= v"12"
+                                undeforpoison |= isa(base, LLVM.PoisonValue)
+                            end
+                            if undeforpoison
+                                # undef/poison constrains neither base nor offset
                                 continue
                             end
 			    if offset === nothing

--- a/test/passes.jl
+++ b/test/passes.jl
@@ -437,3 +437,71 @@ end
     end
 
 end # VERSION >= v"1.12"
+
+# An addrspace(11) phi with argument-derived and poison incomings must be skipped by
+# the `all_args` prefilter; the rewriter cannot handle a bare addrspace(11) argument.
+@testset "nodecayed_phis! addrspace(11) phi with poison incoming" begin
+    @test @filecheck begin
+        # incomings: gep(arg, 8) and poison
+        @check_label "@kernel_gep"
+        @check_not "nodecayed"
+        @check "phi"
+        @check_same "addrspace(11)"
+        @check_same "%gep"
+        @check_same "poison"
+        # zero-offset variant: the argument itself and poison
+        @check_label "@kernel_direct"
+        @check_not "nodecayed"
+        @check "phi"
+        @check_same "addrspace(11)"
+        @check_same "%q"
+        @check_same "poison"
+        LLVM.Context() do ctx
+            mod = parse(
+                LLVM.Module, """
+                source_filename = "start"
+                target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+                target triple = "x86_64-linux-gnu"
+
+                define i8 @kernel_gep(i1 %cond, i8 addrspace(11)* %g) #0 {
+                top:
+                  br i1 %cond, label %ok, label %guard
+
+                ok:
+                  %gep = getelementptr inbounds i8, i8 addrspace(11)* %g, i64 8
+                  br label %merge
+
+                guard:
+                  br label %merge
+
+                merge:
+                  %p = phi i8 addrspace(11)* [ %gep, %ok ], [ poison, %guard ]
+                  %ld = load i8, i8 addrspace(11)* %p, align 1
+                  ret i8 %ld
+                }
+
+                define i8 @kernel_direct(i1 %cond, i8 addrspace(11)* %q) #0 {
+                top:
+                  br i1 %cond, label %ok2, label %guard2
+
+                ok2:
+                  br label %merge2
+
+                guard2:
+                  br label %merge2
+
+                merge2:
+                  %p2 = phi i8 addrspace(11)* [ %q, %ok2 ], [ poison, %guard2 ]
+                  %ld2 = load i8, i8 addrspace(11)* %p2, align 1
+                  ret i8 %ld2
+                }
+
+                attributes #0 = { "enzymejl_world"="1" }
+                """
+            )
+
+            Enzyme.Compiler.nodecayed_phis!(mod)
+            string(mod)
+        end
+    end
+end


### PR DESCRIPTION
Fixes #3409.

nodecayed_phis! skips addrspace(11) phis whose bases are all addrspace(11) arguments (the caller keeps them rooted, and no addrspace(10) parent exists inside the callee). A poison incoming defeats that prefilter — get_base_and_offset returns the poison itself, which is neither an Argument nor a PHIInst — so the phi is sent to the rewriter, whose getparent walks down to the bare addrspace(11) argument, has no case for it, and throws "Could not analyze garbage collection behavior". Poison/undef incomings are already handled inside getparent, so the asymmetry was only in the prefilter.

This accepts undef/poison bases in both prefilter loops: they impose no GC constraint, since on that edge the value cannot be legally used. In the second loop the acceptance sits before the offset-consistency check, because a poison base constrains neither the base nor the offset. Phis with any other kind of base are handled exactly as before, so the change can only turn a crash into a skip. The first loop's hunk is subsumed by the second and kept for symmetry — happy to drop it if preferred.

Added a regression test in test/passes.jl with the phi shape from the issue (gep-off-argument + poison, plus a zero-offset variant); it fails with the issue's error before the patch. The passes and optimize suites pass locally and the diff is runic-clean.

Downstream note: with this fix the GCNConv reproducer no longer hits the internal error; it surfaces the documented Union-type limitation (IllegalTypeAnalysisException) instead. GraphNeuralNetworks.jl is adding an EnzymeRules.inactive rule for that conversion, which makes the layer fully differentiable (JuliaGraphs/GraphNeuralNetworks.jl#703).

