### PR TITLE
Fix differentiation of functions containing Core.BFloat16

### DIFF
--- a/src/typetree.jl
+++ b/src/typetree.jl
@@ -80,6 +80,11 @@ end
 @inline function typetree_primitive(::Type{Float64})
     return API.DT_Double
 end
+@static if VERSION >= v"1.11-"
+    @inline function typetree_primitive(::Type{Core.BFloat16})
+        return API.DT_BFloat16
+    end
+end
 
 
 @static if VERSION >= v"1.11-"

--- a/src/typeutils/conversion.jl
+++ b/src/typeutils/conversion.jl
@@ -88,6 +88,11 @@ function to_tape_type(Type::LLVM.API.LLVMTypeRef)::Tuple{DataType,Bool}
     if tkind == LLVM.API.LLVMHalfTypeKind
         return Float16, false
     end
+    @static if isdefined(Core, :BFloat16)
+        if tkind == LLVM.API.LLVMBFloatTypeKind
+            return Core.BFloat16, false
+        end
+    end
     if tkind == LLVM.API.LLVMFloatTypeKind
         return Float32, false
     end

--- a/test/ext/bfloat16s.jl
+++ b/test/ext/bfloat16s.jl
@@ -3,6 +3,22 @@ using Test
 using BFloat16s
 
 @testset "bfloat16s" begin
-    @test_broken Enzyme.gradient(Reverse, sum, ones(BFloat16, 10))[1] ≈ ones(BFloat16, 10)
+    @static if isdefined(Core, :BFloat16) && Core.BFloat16 === BFloat16
+        @test Enzyme.gradient(Reverse, sum, ones(BFloat16, 10))[1] ≈ ones(BFloat16, 10)
+    else
+        @test_broken Enzyme.gradient(Reverse, sum, ones(BFloat16, 10))[1] ≈
+            ones(BFloat16, 10)
+    end
     @test_broken Enzyme.gradient(Forward, sum, ones(BFloat16, 10))[1] ≈ ones(BFloat16, 10)
+end
+
+@static if isdefined(Core, :BFloat16) && Core.BFloat16 === BFloat16
+    # https://github.com/EnzymeAD/Enzyme.jl/issues/3430
+    bf16_conv(x) = sum(abs2, BFloat16.(x))
+    @testset "bfloat16 in otherwise Float32 IR (#3430)" begin
+        x = Float32[1.0, 2.0, 3.0]
+        dx = zero(x)
+        Enzyme.autodiff(Reverse, bf16_conv, Active, Duplicated(x, dx))
+        @test dx == 2 .* Float32.(BFloat16.(x))
+    end
 end


### PR DESCRIPTION
Fixes #3430.

On Julia ≥ 1.11, `Core.BFloat16` is listed in `TypeTreePrimitives` but had no `typetree_primitive` method, so the generated `typetree_inner` became `TypeTree(nothing, ...)` and any function whose IR contains BFloat16 crashed during type analysis with `MethodError: Cannot convert an object of type Nothing to an object of type Enzyme.API.CConcreteType`.

Two changes:
- `src/typetree.jl`: add `typetree_primitive(::Type{Core.BFloat16}) = API.DT_BFloat16`.
- `src/typeutils/conversion.jl`: with the typetree fixed, tape construction then failed on `LLVMBFloatTypeKind` ("Can't construct tape type for ... LLVMBFloatTypeKind"); map it to `Core.BFloat16`. The reverse direction already works through the generic `AbstractFloat` method of `from_tape_type` via `jl_type_to_llvm`.

The issue's MWE now differentiates correctly, and as a side effect `gradient(Reverse, sum, ones(BFloat16, 10))` works on Julia ≥ 1.11, so its `@test_broken` is promoted to `@test` there (Forward mode still fails with `AssertionError: !hasNoRet` and stays broken). Added a regression test for the MWE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)