### PR TITLE
Cache nested rule codegen across thunk builds

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -135,11 +135,15 @@ function guess_activity end
 mutable struct EnzymeContext
     modules_to_link::Vector{LLVM.Module}
     edges::Vector{Any}
-    nested_cache::Dict{Core.MethodInstance, String}
+    # Per-build record of the nested modules already linked into this build, mapping the
+    # compiled method instance and derivative mode to the name of its entry function.
+    # This only tracks LLVM state local to the current build; the reusable product of a
+    # nested build is cached process-wide in `Compiler.NESTED_CODEGEN_CACHE`.
+    nested_cache::Dict{Tuple{Core.MethodInstance, API.CDerivativeMode}, String}
     EnzymeContext() = new(
         LLVM.Module[],
         Any[],
-        Dict{Core.MethodInstance, String}()
+        Dict{Tuple{Core.MethodInstance, API.CDerivativeMode}, String}()
     )
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1406,28 +1406,59 @@ const DumpPreNestedCheck = Ref(false)
 const DumpPreNestedOpt = Ref(false)
 const DumpPostNestedOpt = Ref(false)
 
-function nested_codegen!(
-    enzyme_context::EnzymeContext,
-    mode::API.CDerivativeMode,
-    mod::LLVM.Module,
-    funcspec::Core.MethodInstance,
-    world::UInt,
-    alwaysinline::Bool=false,
-)
-    cache_key = funcspec
-    if haskey(enzyme_context.nested_cache, cache_key)
-        fname = enzyme_context.nested_cache[cache_key]
-        if haskey(functions(mod), fname)
-            return functions(mod)[fname]
-        end
-        for m in enzyme_context.modules_to_link
-            if haskey(functions(m), fname)
-                return functions(m)[fname]
-            end
-        end
-        error("Cached function $fname not found in any module!")
-    end
+"""
+    NestedCodegenResult
 
+The reusable product of one nested (rule body) codegen: the fully processed module, the
+name of its entry function, and the Julia edges discovered while processing it.
+
+The module is held as bitcode rather than as an `LLVM.Module` because every thunk build
+runs inside its own `GPUCompiler.JuliaContext`, which is disposed once the build finishes.
+An `LLVM.Module` cannot outlive that context, but its serialized form can, and re-parsing
+it into the active context is orders of magnitude cheaper than regenerating it.
+"""
+struct NestedCodegenResult
+    bitcode::Vector{UInt8}
+    entry::String
+    edges::Vector{Any}
+end
+
+"""
+Process-wide cache of nested codegen results, shared across thunk builds.
+
+The key is everything that changes the emitted module: the method instance being
+compiled, the derivative mode (which selects `frule` vs `rrule` handling in
+`set_module_types!`), and the world age (which selects the code being compiled).
+Note that `mode` was previously absent from the key, which was safe only because it is
+constant within a single build.
+"""
+const NESTED_CODEGEN_CACHE = Dict{Tuple{Core.MethodInstance, API.CDerivativeMode, UInt}, NestedCodegenResult}()
+
+# The cached bitcode is retained for the life of the process, so bound how much of it we
+# keep. On overflow the whole cache is dropped rather than evicting individual entries:
+# these modules are purely a compile-time speedup, so losing one costs time, not
+# correctness, and a coarse policy avoids tracking per-entry recency.
+const NESTED_CODEGEN_CACHE_BYTES = Ref{Int}(0)
+const NESTED_CODEGEN_CACHE_MAX_BYTES = Ref{Int}(256 * 1024 * 1024)
+
+function clear_nested_codegen_cache!()
+    empty!(NESTED_CODEGEN_CACHE)
+    NESTED_CODEGEN_CACHE_BYTES[] = 0
+    return nothing
+end
+
+"""
+    build_nested_codegen(mode, funcspec, world)
+
+Emit, check, type and optimize the module implementing `funcspec`, returning both the
+module itself (for the caller to link) and a `NestedCodegenResult` snapshot of it that can
+be replayed in a later build.
+"""
+function build_nested_codegen(
+        mode::API.CDerivativeMode,
+        funcspec::Core.MethodInstance,
+        world::UInt,
+    )::Tuple{LLVM.Module, NestedCodegenResult}
     # 3) Use the MI to create the correct augmented fwd/reverse
     # TODO:
     #  - GPU support
@@ -1439,7 +1470,7 @@ function nested_codegen!(
 
     GPUCompiler.prepare_job!(job)
     otherMod, meta = GPUCompiler.emit_llvm(job)
-    
+
     interp = GPUCompiler.get_interpreter(job)
     prepare_llvm(interp, otherMod, job, meta)
 
@@ -1449,25 +1480,18 @@ function nested_codegen!(
         permit_inlining!(f)
     end
 
-    edges = enzyme_context.edges
-    push!(edges, funcspec)
+    # Collected into a private vector rather than straight onto the context so that the
+    # same edges can be replayed into every later build that reuses this module.
+    edges = Any[funcspec]
 
-    LLVM.@dispose pb=LLVM.NewPMPassBuilder() begin
-        registerEnzymeAndPassPipeline!(pb)
-        LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
-            LLVM.add!(mpm, PreserveNVVMPass())
-        end
-        LLVM.run!(pb, mod)
-    end
-    
     if DumpPreNestedCheck[]
-	API.EnzymeDumpModuleRef(otherMod.ref)
+        API.EnzymeDumpModuleRef(otherMod.ref)
     end
 
     check_ir(interp, job, otherMod)
-            
+
     if DumpPreNestedOpt[]
-	API.EnzymeDumpModuleRef(otherMod.ref)
+        API.EnzymeDumpModuleRef(otherMod.ref)
     end
 
     # Skipped inline of blas
@@ -1477,19 +1501,83 @@ function nested_codegen!(
 
     # Apply first stage of optimization's so that this module is at the same stage as `mod`
     optimize!(otherMod, JIT.get_tm())
-    
+
     if DumpPostNestedOpt[]
-	API.EnzymeDumpModuleRef(otherMod.ref)
+        API.EnzymeDumpModuleRef(otherMod.ref)
     end
-    
+
+    # Snapshot before the caller mutates linkage/attributes for this particular use site,
+    # so what is cached is the plain processed module.
+    result = NestedCodegenResult(convert(Vector{UInt8}, otherMod), entry, edges)
+    return otherMod, result
+end
+
+function cache_nested_codegen!(
+        key::Tuple{Core.MethodInstance, API.CDerivativeMode, UInt},
+        result::NestedCodegenResult,
+    )
+    nbytes = length(result.bitcode)
+    if NESTED_CODEGEN_CACHE_BYTES[] + nbytes > NESTED_CODEGEN_CACHE_MAX_BYTES[]
+        clear_nested_codegen_cache!()
+    end
+    NESTED_CODEGEN_CACHE[key] = result
+    NESTED_CODEGEN_CACHE_BYTES[] += nbytes
+    return nothing
+end
+
+function nested_codegen!(
+        enzyme_context::EnzymeContext,
+        mode::API.CDerivativeMode,
+        mod::LLVM.Module,
+        funcspec::Core.MethodInstance,
+        world::UInt,
+        alwaysinline::Bool = false,
+    )
+    # This module was already linked into the module under construction.
+    build_key = (funcspec, mode)
+    if haskey(enzyme_context.nested_cache, build_key)
+        fname = enzyme_context.nested_cache[build_key]
+        if haskey(functions(mod), fname)
+            return mark_alwaysinline!(functions(mod)[fname], alwaysinline)
+        end
+        for m in enzyme_context.modules_to_link
+            if haskey(functions(m), fname)
+                return mark_alwaysinline!(functions(m)[fname], alwaysinline)
+            end
+        end
+        error("Cached function $fname not found in any module!")
+    end
+
+    LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
+        registerEnzymeAndPassPipeline!(pb)
+        LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
+            LLVM.add!(mpm, PreserveNVVMPass())
+        end
+        LLVM.run!(pb, mod)
+    end
+
+    cache_key = (funcspec, mode, world)
+    result = get(NESTED_CODEGEN_CACHE, cache_key, nothing)
+    local otherMod::LLVM.Module
+    if result === nothing
+        otherMod, result = build_nested_codegen(mode, funcspec, world)
+        cache_nested_codegen!(cache_key, result)
+    else
+        otherMod = parse(LLVM.Module, result.bitcode)
+    end
+
+    # Replayed on every build, not just the one that generated the module, so that each
+    # resulting CodeInstance records the same dependencies and is invalidated alike.
+    append!(enzyme_context.edges, result.edges)
+
+    entry = result.entry
+
     # 4) Record module to link
     push!(enzyme_context.modules_to_link, otherMod)
 
     # Declare the function in mod so it can be called
     lfn = functions(otherMod)[entry]
-    if alwaysinline
-        push!(function_attributes(lfn), EnumAttribute("alwaysinline"))
-    end
+    mark_alwaysinline!(lfn, alwaysinline)
 
     linkage!(lfn, LLVM.API.LLVMExternalLinkage)
     FT = LLVM.function_type(lfn)
@@ -1512,8 +1600,22 @@ function nested_codegen!(
         push!(return_attributes(decl), attr)
     end
 
-    enzyme_context.nested_cache[cache_key] = LLVM.name(decl)
+    enzyme_context.nested_cache[build_key] = LLVM.name(decl)
     return decl
+end
+
+"""
+    mark_alwaysinline!(fn, alwaysinline)
+
+Add the `alwaysinline` attribute to `fn` if `alwaysinline` is set and it is not already
+present, returning `fn`. Applied per use site rather than baked into the cached module,
+since the same nested module can be requested with and without inlining.
+"""
+function mark_alwaysinline!(fn::LLVM.Function, alwaysinline::Bool)
+    if alwaysinline && !has_fn_attr(fn, EnumAttribute("alwaysinline"))
+        push!(function_attributes(fn), EnumAttribute("alwaysinline"))
+    end
+    return fn
 end
 
 function removed_ret_parms(orig::LLVM.CallInst)

--- a/test/rules/nestedcache.jl
+++ b/test/rules/nestedcache.jl
@@ -1,0 +1,88 @@
+module NestedCache
+
+using Enzyme
+using Enzyme: EnzymeRules
+using LinearAlgebra
+using Test
+
+import .EnzymeRules: augmented_primal, reverse
+using .EnzymeRules
+
+# A custom-ruled function whose rule bodies pull in enough code (mul!, norm, Dict) that
+# `nested_codegen!` has real work to do for them. See EnzymeAD/Enzyme.jl#3392.
+function heavy(x::Float64)
+    A = fill(x, 8, 8)
+    return norm(A * A) + sum(A)
+end
+
+const SCRATCH = Dict{Symbol, Matrix{Float64}}()
+
+function heavy_deriv(x::Float64)
+    A = get(SCRATCH, :A, nothing)
+    if A === nothing
+        A = zeros(8, 8)
+        SCRATCH[:A] = A
+    end
+    fill!(A, x)
+    B = similar(A)
+    mul!(B, A, A)
+    dB = B ./ norm(B)
+    dA = similar(A)
+    mul!(dA, dB, transpose(A))
+    mul!(dA, transpose(A), dB, 1.0, 1.0)
+    return sum(dA) + length(A)
+end
+
+function augmented_primal(config::RevConfig, func::Const{typeof(heavy)}, ::Type{<:Active}, x::Active{Float64})
+    primal = needs_primal(config) ? heavy(x.val) : nothing
+    return AugmentedReturn(primal, nothing, nothing)
+end
+
+function reverse(config::RevConfig, func::Const{typeof(heavy)}, dret::Active, tape, x::Active{Float64})
+    return (heavy_deriv(x.val) * dret.val,)
+end
+
+# Distinct outer functions, so each `autodiff` is a separate thunk build, but all of them
+# need the identical `augmented_primal`/`reverse` method instances.
+outer1(x) = heavy(x) * 1.0
+outer2(x) = heavy(x) + 0.0
+outer3(x) = heavy(x) - 0.0
+
+# Enzyme builds its thunk while the *calling* function is compiled, so each build has to be
+# its own freshly-compiled expression for the cache to be observed in between.
+function build_and_run(fname::Symbol)
+    before = length(Enzyme.Compiler.NESTED_CODEGEN_CACHE)
+    res = Core.eval(@__MODULE__, :(autodiff(Reverse, $fname, Active, Active(1.3))))
+    return res[1][1], before, length(Enzyme.Compiler.NESTED_CODEGEN_CACHE)
+end
+
+@testset "nested codegen cache" begin
+    Enzyme.Compiler.clear_nested_codegen_cache!()
+    @test length(Enzyme.Compiler.NESTED_CODEGEN_CACHE) == 0
+
+    expected = heavy_deriv(1.3)
+
+    d1, before1, after1 = build_and_run(:outer1)
+    # The first build compiles both rule bodies and populates the cache.
+    @test after1 > before1
+    @test d1 ≈ expected
+
+    # Subsequent builds need the same rule method instances and must reuse them rather
+    # than recompiling: the entry count stays put, and the derivative is unchanged.
+    for fname in (:outer2, :outer3)
+        d, before, after = build_and_run(fname)
+        @test before == after
+        @test d ≈ expected
+    end
+
+    @test Enzyme.Compiler.NESTED_CODEGEN_CACHE_BYTES[] > 0
+
+    # Clearing forces the next build to regenerate the modules from scratch, which must
+    # still produce the same answer.
+    Enzyme.Compiler.clear_nested_codegen_cache!()
+    @test Enzyme.Compiler.NESTED_CODEGEN_CACHE_BYTES[] == 0
+    outer4(x) = heavy(x) / 1.0
+    @test autodiff(Reverse, outer4, Active, Active(1.3))[1][1] ≈ expected
+end
+
+end # module NestedCache


### PR DESCRIPTION
This is an attempt to fix https://github.com/enzymead/enzyme.jl/issues/3392 using the info gleaned in the comment there.  Here's the 🤖 summary:

`enzyme_context.nested_cache` lives on `EnzymeContext`, which is constructed fresh inside `GPUCompiler.compile_unhooked`, so it was per-thunk-build and discarded afterwards. Distinct outer functions calling the same custom-ruled function all need the identical `EnzymeRules.augmented_primal`/`reverse` MethodInstance, and each one re-emitted, re-checked, re-typed and re-optimized it from scratch.

Split the build out into `build_nested_codegen` and add `NESTED_CODEGEN_CACHE`, a process-wide cache keyed on `(MethodInstance, mode, world)`. The previous key was just the MethodInstance, ignoring `mode` -- safe only because `mode` is constant within a single build.

Entries hold bitcode rather than an `LLVM.Module`: every thunk build runs in its own `GPUCompiler.JuliaContext`, which is disposed when the build finishes, so a module cannot outlive it but its serialized form can. Re-parsing into the active context is far cheaper than regenerating, and mirrors what `move_to_threadsafe` already does before JIT emission.

The per-build cache stays as an inner layer so a module is still only linked once per build. Edges are collected into a private vector and replayed on every reuse, so each resulting CodeInstance records the same dependencies. Retention is bounded by `NESTED_CODEGEN_CACHE_MAX_BYTES`, with `clear_nested_codegen_cache!()` to drop it.

Also fixes `alwaysinline` being silently dropped when a nested module was requested twice in one build with different inlining: it is now applied per use site via `mark_alwaysinline!` rather than baked into the cached module.

On five thunk builds sharing one rule whose body pulls in mul!/norm/Dict, steady-state build time drops from 0.736s to 0.434s; the fraction grows with rule-body size.

I'll point my `ksh/enz_fact` branch at this and see if it helped.