### PR TITLE
Box tape aggregates that Julia will not store inline

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -2014,7 +2014,8 @@ function zero_allocation(B::LLVM.API.LLVMBuilderRef, LLVMType::LLVM.API.LLVMType
     B = LLVM.IRBuilder(B)
     LLVMType = LLVM.LLVMType(LLVMType)
     obj = LLVM.Value(obj)
-    jlType = Compiler.tape_type(LLVMType)
+    # raw tape storage: needs the layout-faithful type, not the boxed one
+    jlType = Compiler.tape_type(LLVMType; boxnested = false)
     zeroAll = isTape == 0
     func = LLVM.parent(position(B))
     mod = LLVM.parent(func)
@@ -2243,12 +2244,25 @@ function julia_allocator(B::LLVM.IRBuilder, @nospecialize(LLVMType::LLVM.LLVMTyp
 
         esizeof(X) = X == Any ? sizeof(Int) : sizeof(X)
 
-        TT = Compiler.tape_type(LLVMType)
+        # raw tape storage: needs the layout-faithful type, not the boxed one.
+        # `TT_nested` mirrors `LLVMType` field for field and is what the zeroing
+        # walk below needs; `TT` is the type the allocation is tagged with, and
+        # only has to agree on byte layout.
+        TT_nested = Compiler.tape_type(LLVMType; boxnested = false)
+        TT = TT_nested
         if esizeof(TT) != convert(Int, AlignedSize)
-            GPUCompiler.@safe_error "Enzyme aligned size and Julia size disagree" AlignedSize =
-                convert(Int, AlignedSize) esizeof(TT) fieldtypes(TT) LLVMType=strip(string(LLVMType))
-            emit_error(B, nothing, "Enzyme: Tape allocation failed.") # TODO: Pick appropriate orig
-            return LLVM.API.LLVMValueRef(LLVM.UndefValue(LLVMType).ref)
+            # Julia does not lay this type out the way Enzyme wrote it, typically
+            # because a nested field of 32768 bytes or more gets boxed.  Fall back
+            # to a flat type with the same byte offsets, see `raw_storage_type`.
+            TT2 = Compiler.raw_storage_type(datalayout(mod), LLVMType)
+            if TT2 !== nothing && esizeof(TT2) == convert(Int, AlignedSize)
+                TT = TT2
+            else
+                GPUCompiler.@safe_error "Enzyme aligned size and Julia size disagree" AlignedSize =
+                    convert(Int, AlignedSize) esizeof(TT) fieldtypes(TT) LLVMType=strip(string(LLVMType))
+                emit_error(B, nothing, "Enzyme: Tape allocation failed.") # TODO: Pick appropriate orig
+                return LLVM.API.LLVMValueRef(LLVM.UndefValue(LLVMType).ref)
+            end
         end
         @assert esizeof(TT) == convert(Int, AlignedSize)
         if Count isa LLVM.ConstantInt
@@ -2309,7 +2323,7 @@ function julia_allocator(B::LLVM.IRBuilder, @nospecialize(LLVMType::LLVM.LLVMTyp
         if ZI != C_NULL
             unsafe_store!(
                 ZI,
-                zero_allocation(B, TT, LLVMType, obj, AlignedSize, Size, false),
+                zero_allocation(B, TT_nested, LLVMType, obj, AlignedSize, Size, false),
             ) #=ZeroAll=#
         end
         AS = Tracked
@@ -2845,7 +2859,10 @@ function enzyme!(
             typeInfo,
             uncacheable_args,
             nowrite_shadows,
-            false,
+            # Enzyme normally decides for itself whether a tape is heap allocated.
+            # `ENZYME_FORCE_ANONYMOUS_TAPE=1` forces it on for everything, which is
+            # the only way to get test coverage of that path from Julia.
+            get(ENV, "ENZYME_FORCE_ANONYMOUS_TAPE", "0") == "1",
             runtimeActivity,
             strongZero,
             width,
@@ -2858,7 +2875,11 @@ function enzyme!(
         tape = API.EnzymeExtractTapeTypeFromAugmentation(augmented)
         utape = API.EnzymeExtractUnderlyingTapeTypeFromAugmentation(augmented)
         if utape != C_NULL
-            TapeType = EnzymeTapeToLoad{Compiler.tape_type(LLVMType(utape))}
+            # anonymous tape: the augmented forward hands back a pointer to raw
+            # heap storage holding `utape` in Enzyme's own layout, so the element
+            # type must stay layout-faithful -- there is no Julia field here for
+            # a box to live in.  See `to_tape_type`.
+            TapeType = EnzymeTapeToLoad{Compiler.tape_type(LLVMType(utape); boxnested = false)}
             tape = utape
         elseif tape != C_NULL
             TapeType = Compiler.tape_type(LLVMType(tape))
@@ -3258,7 +3279,11 @@ function create_abi_wrapper(
         tape = API.EnzymeExtractTapeTypeFromAugmentation(augmented)
         utape = API.EnzymeExtractUnderlyingTapeTypeFromAugmentation(augmented)
         if utape != C_NULL
-            TapeType = EnzymeTapeToLoad{Compiler.tape_type(LLVMType(utape))}
+            # anonymous tape: the augmented forward hands back a pointer to raw
+            # heap storage holding `utape` in Enzyme's own layout, so the element
+            # type must stay layout-faithful -- there is no Julia field here for
+            # a box to live in.  See `to_tape_type`.
+            TapeType = EnzymeTapeToLoad{Compiler.tape_type(LLVMType(utape); boxnested = false)}
         elseif tape != C_NULL
             TapeType = Compiler.tape_type(LLVMType(tape))
         else
@@ -3377,15 +3402,25 @@ function create_abi_wrapper(
         end
     end
 
+    anonymous_tape = false
     if needs_tape
         tape = API.EnzymeExtractTapeTypeFromAugmentation(augmented)
         utape = API.EnzymeExtractUnderlyingTapeTypeFromAugmentation(augmented)
-        if utape != C_NULL
+        anonymous_tape = utape != C_NULL
+        if anonymous_tape
             tape = utape
         end
         if tape != C_NULL
             tape = LLVM.LLVMType(tape)
-            jltape = convert(LLVM.LLVMType, Compiler.tape_type(tape); allow_boxed = true)
+            jltape = if anonymous_tape
+                # The anonymous tape lives in raw heap storage.  Take the object
+                # pointer and load Enzyme's exact tape type from it below, rather
+                # than having `enzyme_call` load a (potentially enormous)
+                # aggregate out of an addrspace(10) pointer and pass it by value.
+                T_prjlvalue
+            else
+                convert(LLVM.LLVMType, Compiler.tape_type(tape); allow_boxed = true)
+            end
             push!(T_wrapperargs, jltape)
             arg_roots = inline_roots_type(tape)
             if arg_rooting && arg_roots != 0
@@ -3652,6 +3687,10 @@ function create_abi_wrapper(
         # Fix calling convention within julia that Tuple{Float,Float} ->[2 x float] rather than {float, float}
         # and that Bool -> i8, not i1
         tparm = params[i]
+        if anonymous_tape
+            # raw heap storage: read Enzyme's tape type straight back out of it
+            tparm = unbox_tape_value!(builder, tparm, tape)
+        end
         tparm = calling_conv_fixup(builder, tparm, tape)
         push!(realparms, tparm)
         i += 1
@@ -3767,6 +3806,17 @@ function create_abi_wrapper(
                     end
                 end
                 eval = fixup_abi(i, eval)
+                if i == 1
+                    # The tape leaves Enzyme in Enzyme's own layout but is stored
+                    # into a slot Julia typed as `TapeType`; rewrite it into
+                    # Julia's layout, boxing the aggregates Julia will not store
+                    # inline.  `calling_conv_fixup` undoes this in the reverse
+                    # wrapper.  See `to_tape_type`.
+                    jltapety = convert(LLVM.LLVMType, sret_types[1]; allow_boxed = true)
+                    if value_type(eval) != jltapety
+                        eval = julia_conv_fixup(builder, eval, jltapety)
+                    end
+                end
                 ptr = inbounds_gep!(
                     builder,
                     jltype,
@@ -7012,22 +7062,14 @@ const DumpLLVMCall = Ref(false)
         if needs_tape && !(isghostty(TapeType) || Core.Compiler.isconstType(TapeType))
             tape = callparams[end]
             if TapeType <: EnzymeTapeToLoad
-                llty = Compiler.from_tape_type(eltype(TapeType))
-	        
-		        arg_roots = inline_roots_type(llty)
+                # The wrapper takes the tape object pointer and loads Enzyme's
+                # tape type from it itself, so nothing to do here.
+                arg_roots = inline_roots_type(
+                    Compiler.from_tape_type(eltype(TapeType)),
+                )
                 if needs_rooting && arg_roots != 0
                     throw(AssertionError("Should check about rooted tape calling conv"))
                 end
-
-                tape = bitcast!(
-                    builder,
-                    tape,
-                    LLVM.PointerType(llty, LLVM.addrspace(value_type(tape))),
-                )
-                tape = load!(builder, llty, tape)
-                API.SetMustCache!(tape)
-                callparams[end] = tape
-
             else
                 llty = Compiler.from_tape_type(TapeType)
                 arg_roots = inline_roots_type(llty)

--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -597,6 +597,21 @@ function calling_conv_fixup(
         push!(lhs_n, 0)
         return calling_conv_fixup(builder, val, tape, prev, lhs_n, ridxs, emesg)
     end
+    # An aggregate that Julia refuses to store inline (see `to_tape_type`) is
+    # boxed on the Julia side; load it back out of the box.
+    if isa(ctype, LLVM.PointerType) &&
+       LLVM.addrspace(ctype) == Tracked &&
+       (isa(tape, LLVM.StructType) || isa(tape, LLVM.ArrayType) || isa(tape, LLVM.VectorType))
+        if length(lidxs) != 0
+            val = API.e_extract_value!(builder, val, lidxs)
+        end
+        val = unbox_tape_value!(builder, val, tape)
+        return if length(ridxs) != 0
+            API.e_insert_value!(builder, prev, val, ridxs)
+        else
+            val
+        end
+    end
 
 
     msg2 = sprint() do io
@@ -618,4 +633,113 @@ function calling_conv_fixup(
         )
     end
     throw(AssertionError(msg2))
+end
+
+# Elements of an LLVM aggregate addressable with extractvalue/insertvalue, or
+# nothing otherwise.  Vectors are deliberately excluded: they are indexed with
+# extractelement, and being always primitive-typed they never hold the boxed
+# aggregates this is used to walk.
+function aggregate_elements(@nospecialize(ty::LLVM.LLVMType))
+    if isa(ty, LLVM.StructType)
+        return LLVM.LLVMType[e for e in elements(ty)]
+    elseif isa(ty, LLVM.ArrayType)
+        return LLVM.LLVMType[eltype(ty) for _ = 1:length(ty)]
+    else
+        return nothing
+    end
+end
+
+# Allocate a Julia object holding `val` (an aggregate in Enzyme's tape layout)
+# and return the resulting `ptr addrspace(10)`.  Counterpart of
+# `unbox_tape_value!`; see the comment on `to_tape_type` for why this is needed.
+# `tape_type` is called here at top level, so the object's own type is the
+# unboxed one -- only aggregates nested inside it get boxed in turn.
+function box_tape_value!(builder::LLVM.IRBuilder, @nospecialize(val::LLVM.Value))
+    T = tape_type(LLVM.value_type(val))::DataType
+    jlty = convert(LLVM.LLVMType, T; allow_boxed = true)
+    jval = julia_conv_fixup(builder, val, jlty)
+    box = emit_allocobj!(builder, T, "enzyme_boxed_tape")
+    dst = addrspacecast!(builder, box, LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[]), Derived))
+    if !LLVM.is_opaque(LLVM.value_type(dst))
+        dst = bitcast!(builder, dst, LLVM.PointerType(jlty, Derived))
+    end
+    extract_struct_into!(builder, dst, jval, "enzyme_boxed_tape")
+    emit_writebarrier!(builder, get_julia_inner_types(builder, box, jval))
+    return box
+end
+
+# Load an aggregate of LLVM type `tape` back out of the box built by
+# `box_tape_value!`.
+function unbox_tape_value!(
+    builder::LLVM.IRBuilder,
+    @nospecialize(val::LLVM.Value),
+    @nospecialize(tape::LLVM.LLVMType),
+)
+    ptr = addrspacecast!(builder, val, LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[]), Derived))
+    if !LLVM.is_opaque(LLVM.value_type(ptr))
+        ptr = bitcast!(builder, ptr, LLVM.PointerType(tape, Derived))
+    end
+    return load!(builder, tape, ptr)
+end
+
+# Inverse of `calling_conv_fixup`: rewrite `val`, which is in Enzyme's internal
+# tape layout, into `jlty`, the layout Julia gives the corresponding tape type.
+# The two only differ in the i1-vs-i8 spelling of `Bool`, in struct-vs-array
+# spellings of homogeneous aggregates, and in aggregates Julia stores boxed.
+function julia_conv_fixup(
+    builder::LLVM.IRBuilder,
+    @nospecialize(val::LLVM.Value),
+    @nospecialize(jlty::LLVM.LLVMType),
+)::LLVM.Value
+    vty = LLVM.value_type(val)
+    if vty == jlty
+        return val
+    end
+
+    jkids = aggregate_elements(jlty)
+    vkids = aggregate_elements(vty)
+    if jkids !== nothing && vkids !== nothing && length(jkids) == length(vkids)
+        res = LLVM.UndefValue(jlty)
+        for i = 1:length(jkids)
+            sub = extract_value!(builder, val, i - 1)
+            sub = julia_conv_fixup(builder, sub, jkids[i])
+            res = insert_value!(builder, res, sub, i - 1)
+        end
+        return res
+    end
+
+    # Bool is i1 inside Enzyme's tape but i8 in Julia's layout
+    if isa(jlty, LLVM.IntegerType) && isa(vty, LLVM.IntegerType)
+        return if LLVM.width(jlty) > LLVM.width(vty)
+            zext!(builder, val, jlty)
+        else
+            trunc!(builder, val, jlty)
+        end
+    end
+
+    if isa(jlty, LLVM.PointerType) &&
+       isa(vty, LLVM.PointerType) &&
+       LLVM.addrspace(jlty) == LLVM.addrspace(vty)
+        return pointercast!(builder, val, jlty)
+    end
+
+    # Julia stores this aggregate boxed (see `to_tape_type`)
+    if isa(jlty, LLVM.PointerType) && LLVM.addrspace(jlty) == Tracked && vkids !== nothing
+        box = box_tape_value!(builder, val)
+        return if LLVM.value_type(box) == jlty
+            box
+        else
+            pointercast!(builder, box, jlty)
+        end
+    end
+
+    if isa(jlty, LLVM.ArrayType) && length(jlty) == 1 && eltype(jlty) == vty
+        return insert_value!(builder, LLVM.UndefValue(jlty), val, 0)
+    end
+
+    throw(
+        AssertionError(
+            "Enzyme Internal Error: Illegal tape layout fixup\njlty = $(string(jlty))\nvty = $(string(vty))\nval = $(string(val))",
+        ),
+    )
 end

--- a/src/typeutils/conversion.jl
+++ b/src/typeutils/conversion.jl
@@ -1,5 +1,29 @@
+# The tape ABI assumes that the Julia lowering of the tape type is
+# memory-layout-identical to Enzyme's own LLVM tape type: the augmented forward
+# stores the tape using Enzyme's layout into a slot typed by the Julia tape type,
+# and the reverse pass reads it back.  Julia only keeps a struct-typed field
+# inline in an enclosing object when `Base.allocatedinline` holds for it, and
+# that fails as soon as the type has pointers *and* any of its own fields is
+# larger than 32767 bytes -- `jl_fielddesc16_t` only has a 15-bit size field, so
+# the layout falls back to `fielddesc_type == 2`, which `jl_datatype_isinlinealloc`
+# rejects.  Such a field is boxed by Julia, so the two layouts diverge and the
+# tape can neither be stored nor read back (see `calling_conv_fixup`).
+#
+# Model that explicitly: any nested aggregate Julia would not store inline is
+# mapped to `Any`, and `julia_conv_fixup` / `calling_conv_fixup` box and unbox it
+# in the ABI wrappers.  The Julia type of the box's contents is recovered by
+# calling `tape_type` on the corresponding LLVM type again, which is a top-level
+# call and hence not boxed itself.
+@inline function tape_type_stored_inline(@nospecialize(TT::Type))::Bool
+    return Base.isconcretetype(TT) && Base.allocatedinline(TT)
+end
+
 # return result and if contains any
-function to_tape_type(Type::LLVM.API.LLVMTypeRef)::Tuple{DataType,Bool}
+function to_tape_type(
+    Type::LLVM.API.LLVMTypeRef,
+    nested::Bool = false,
+    boxnested::Bool = true,
+)::Tuple{DataType,Bool}
     tkind = LLVM.API.LLVMGetTypeKind(Type)
     if tkind == LLVM.API.LLVMStructTypeKind
         tys = DataType[]
@@ -8,18 +32,21 @@ function to_tape_type(Type::LLVM.API.LLVMTypeRef)::Tuple{DataType,Bool}
         syms = Symbol[]
         for i = 1:nelems
             e = LLVM.API.LLVMStructGetTypeAtIndex(Type, i - 1)
-            T, sub = to_tape_type(e)
+            T, sub = to_tape_type(e, true, boxnested)
             containsAny |= sub
             push!(tys, T)
             push!(syms, Symbol(i))
         end
         Tup = Tuple{tys...}
-        if containsAny
-            res = (syms...,)
-            return NamedTuple{res,Tup}, false
+        res = if containsAny
+            NamedTuple{(syms...,),Tup}
         else
-            return Tup, false
+            Tup
         end
+        if nested && boxnested && !tape_type_stored_inline(res)
+            return Any, true
+        end
+        return res, false
     end
     if tkind == LLVM.API.LLVMPointerTypeKind
         addrspace = LLVM.API.LLVMGetPointerAddressSpace(Type)
@@ -39,25 +66,33 @@ function to_tape_type(Type::LLVM.API.LLVMTypeRef)::Tuple{DataType,Bool}
     end
     if tkind == LLVM.API.LLVMArrayTypeKind
         e = LLVM.API.LLVMGetElementType(Type)
-        T, sub = to_tape_type(e)
+        T, sub = to_tape_type(e, true, boxnested)
         len = Int(LLVM.API.LLVMGetArrayLength(Type))
         Tup = NTuple{len,T}
-        if sub
-            return NamedTuple{ntuple(Core.Symbol, Val(len)),Tup}, false
+        res = if sub
+            NamedTuple{ntuple(Core.Symbol, Val(len)),Tup}
         else
-            return Tup, false
+            Tup
         end
+        if nested && boxnested && !tape_type_stored_inline(res)
+            return Any, true
+        end
+        return res, false
     end
     if tkind == LLVM.API.LLVMVectorTypeKind
         e = LLVM.API.LLVMGetElementType(Type)
-        T, sub = to_tape_type(e)
+        T, sub = to_tape_type(e, true, boxnested)
         len = Int(LLVM.API.LLVMGetVectorSize(Type))
         Tup = NTuple{len,Core.VecElement{T}}
-        if sub
-            return NamedTuple{ntuple(Core.Symbol, Val(len)),Tup}, false
+        res = if sub
+            NamedTuple{ntuple(Core.Symbol, Val(len)),Tup}
         else
-            return Tup, false
+            Tup
         end
+        if nested && boxnested && !tape_type_stored_inline(res)
+            return Any, true
+        end
+        return res, false
     end
     if tkind == LLVM.API.LLVMIntegerTypeKind
         N = LLVM.API.LLVMGetIntTypeWidth(Type)
@@ -105,8 +140,12 @@ function to_tape_type(Type::LLVM.API.LLVMTypeRef)::Tuple{DataType,Bool}
     error("Can't construct tape type for $Type $(string(Type)) $tkind")
 end
 
-function tape_type(@nospecialize(LLVMType::LLVM.LLVMType))
-    TT, isAny = to_tape_type(LLVMType.ref)
+# `boxnested = false` returns the type as it was computed before nested boxing
+# existed: faithful to Enzyme's LLVM layout, but possibly not something Julia can
+# store inline.  Only correct where the type is used to size/zero raw tape
+# storage rather than to describe a Julia field.
+function tape_type(@nospecialize(LLVMType::LLVM.LLVMType); boxnested::Bool = true)
+    TT, isAny = to_tape_type(LLVMType.ref, false, boxnested)
     if isAny
         return AnonymousStruct(Tuple{Any})
     end
@@ -115,6 +154,8 @@ end
 
 from_tape_type(::Type{T}) where {T<:AbstractFloat} = convert(LLVMType, T)
 from_tape_type(::Type{T}) where {T<:Integer} = convert(LLVMType, T)
+# `Tuple{}` matches `NTuple{Size,T}` with `T` unbound, so it needs its own method
+from_tape_type(::Type{Tuple{}}) = LLVM.StructType(LLVM.LLVMType[])
 from_tape_type(::Type{NTuple{Size,T}}) where {Size,T} =
     LLVM.ArrayType(from_tape_type(T), Size)
 from_tape_type(::Type{Core.VecElement{T}}) where {T} = from_tape_type(T)
@@ -136,3 +177,91 @@ function from_tape_type(::Type{B}) where {B<:Tuple}
     end
 end
 
+
+# Enzyme's heap-allocated tapes and caches are raw storage: Enzyme writes them in
+# its own LLVM layout, and the only thing Julia contributes is an allocation of
+# the right size whose type lets the GC find the tracked pointers inside.  The
+# nested type from `to_tape_type` cannot always serve that role -- Julia boxes any
+# field of 32768 bytes or more that contains pointers, so the type ends up
+# describing far less memory than the allocation holds (`sizeof` 248 instead of
+# 34144, say).
+#
+# `raw_storage_type` sidesteps the nesting entirely: it flattens the LLVM type to
+# its leaves and rebuilds a flat NamedTuple, using explicit `NTuple{n, UInt8}`
+# padding so every leaf lands on its original byte offset.  Pointer leaves stay
+# `Any`, so the GC still traces them.  Padding runs are split below the 32767-byte
+# field limit so the result also stays inline-allocatable where it can be, which
+# is what `NTuple{N, TT}` needs when Enzyme allocates more than one element.
+const JL_MAX_INLINE_FIELD_SIZE = 32767
+
+function push_padding!(tys::Vector{DataType}, nbytes::Int)
+    while nbytes > 0
+        chunk = min(nbytes, JL_MAX_INLINE_FIELD_SIZE)
+        push!(tys, NTuple{chunk,UInt8})
+        nbytes -= chunk
+    end
+    return nothing
+end
+
+function collect_leaf_types!(
+    leaves::Vector{Tuple{Int,DataType}},
+    dl::LLVM.DataLayout,
+    @nospecialize(ty::LLVM.LLVMType),
+    offset::Int,
+)
+    if isa(ty, LLVM.StructType) && !LLVM.ispacked(ty)
+        for (i, e) in enumerate(LLVM.elements(ty))
+            collect_leaf_types!(leaves, dl, e, offset + Int(LLVM.offsetof(dl, ty, i - 1)))
+        end
+        return nothing
+    end
+    if isa(ty, LLVM.ArrayType)
+        e = eltype(ty)
+        stride = Int(LLVM.abi_size(dl, e))
+        for i = 1:length(ty)
+            collect_leaf_types!(leaves, dl, e, offset + (i - 1) * stride)
+        end
+        return nothing
+    end
+    # Primitives, pointers, and anything we do not split (packed structs,
+    # vectors) become leaves -- but only when Julia gives them the same size,
+    # otherwise the offsets computed above would be fiction.
+    T = to_tape_type(ty.ref, false, false)[1]
+    esz = T === Any ? sizeof(Ptr{Cvoid}) : sizeof(T)
+    esz == Int(LLVM.abi_size(dl, ty)) ||
+        throw(ArgumentError("no faithful Julia type for $(string(ty))"))
+    push!(leaves, (offset, T))
+    return nothing
+end
+
+# Returns `nothing` when no faithful type could be built, so callers can keep
+# their existing diagnostics rather than allocating something mislaid out.
+function raw_storage_type(dl::LLVM.DataLayout, @nospecialize(ty::LLVM.LLVMType))
+    total = Int(LLVM.abi_size(dl, ty))
+    leaves = Tuple{Int,DataType}[]
+    try
+        collect_leaf_types!(leaves, dl, ty, 0)
+    catch
+        return nothing
+    end
+    tys = DataType[]
+    placed = Tuple{Int,Int}[]   # (field index, intended byte offset)
+    pos = 0
+    for (off, T) in leaves
+        off < pos && return nothing
+        off > pos && push_padding!(tys, off - pos)
+        push!(tys, T)
+        push!(placed, (length(tys), off))
+        pos = off + (T === Any ? sizeof(Ptr{Cvoid}) : sizeof(T))
+    end
+    pos > total && return nothing
+    pos < total && push_padding!(tys, total - pos)
+    res = NamedTuple{ntuple(Core.Symbol, length(tys)),Tuple{tys...}}
+    # Only usable if Julia agrees on the size and put every leaf exactly where
+    # Enzyme's layout has it -- otherwise the GC would trace the wrong words.
+    sizeof(res) == total || return nothing
+    for (idx, off) in placed
+        Int(fieldoffset(res, idx)) == off || return nothing
+    end
+    return res
+end

--- a/test/bigtape.jl
+++ b/test/bigtape.jl
@@ -1,0 +1,81 @@
+using Enzyme, Test
+using LinearAlgebra
+using Random
+using FiniteDifferences
+
+# A tape whose nested sub-tape is 32768 bytes or more cannot be stored inline by
+# Julia (`jl_fielddesc16_t` only has a 15-bit size field, so `allocatedinline`
+# gives up and the field is boxed), while Enzyme keeps writing it inline.  The
+# augmented forward then stores a tape Julia cannot hold and the reverse pass
+# cannot read it back, which used to surface as
+#
+#   AssertionError: Enzyme Internal Error: Illegal calling convention fixup
+#     ctype = LLVM.PointerType(ptr addrspace(10))
+#
+# out of `calling_conv_fixup`.  Three ingredients are needed together to build
+# such a tape:
+#
+#   1. `map` over a container with an abstract element type, whose closure
+#      differentiates through the abstractly-typed element.  This puts Enzyme on
+#      its runtime-generic path, where the tape is only partially known.
+#   2. A `@noinline` callee picked by a runtime value, with several call sites,
+#      so its tape is a merge of several sub-tapes.
+#   3. Enough work in that callee for the merged sub-tape to cross the size
+#      threshold.  Below it (a 5-matmul chain, or fewer than 4 call sites) the
+#      same program compiles fine.
+
+const BIGTAPE_N = 8
+
+# Scaled so that a chain of seven products stays O(1) and the finite-difference
+# check below is well conditioned.
+bigtape_mat(rng) = randn(rng, BIGTAPE_N, BIGTAPE_N) ./ sqrt(BIGTAPE_N)
+
+const BIGTAPE_A, BIGTAPE_B, BIGTAPE_C, BIGTAPE_D = let rng = MersenneTwister(1234)
+    (bigtape_mat(rng), bigtape_mat(rng), bigtape_mat(rng), bigtape_mat(rng))
+end
+
+# Callee with a large reverse-mode tape.
+@noinline function bigtape_chain(x::Matrix{Float64})
+    t1 = BIGTAPE_A * x
+    t2 = t1 * BIGTAPE_B
+    t3 = x' * t2
+    t4 = t3 * BIGTAPE_C
+    t5 = t4 * t1
+    t6 = t5 * BIGTAPE_D
+    t7 = t6 * t3
+    return tr(t7) / tr(t5)
+end
+
+# Several call sites of `bigtape_chain`, selected by a runtime value, so the
+# tape Enzyme builds for `bigtape_dispatch` merges all of their sub-tapes.
+@noinline function bigtape_dispatch(k::Vector{Int}, x)
+    k[1] == 0 && return bigtape_chain(x)
+    k[1] == -1 && return bigtape_chain(x)
+    k[1] == -2 && return bigtape_chain(x)
+    k[1] == -3 && return bigtape_chain(x)
+    return bigtape_chain(x)
+end
+
+# `Any` value type: `op` in the closure below is only known as `Any`, which is
+# what forces the runtime-generic path.
+const BIGTAPE_TERMS = let rng = MersenneTwister(5678)
+    Pair{Vector{Int}, Any}[[1, 2] => bigtape_mat(rng), [1, 3] => bigtape_mat(rng)]
+end
+
+bigtape_f(x) = sum(
+    map(BIGTAPE_TERMS) do (k, op)
+        tr(op * x) * bigtape_dispatch(k, x)
+    end
+)
+
+@testset "boxed nested tape aggregate" begin
+    x = bigtape_mat(MersenneTwister(91011))
+    dx = zero(x)
+
+    _, primal = Enzyme.autodiff(
+        set_runtime_activity(ReverseWithPrimal), Const(bigtape_f), Active, Duplicated(x, dx)
+    )
+
+    @test primal ≈ bigtape_f(x)
+    @test dx ≈ FiniteDifferences.grad(central_fdm(5, 1), bigtape_f, x)[1] rtol = 1.0e-5
+end


### PR DESCRIPTION
OK I threw a 🤖 at #3429 and here's the result:

The tape ABI assumes Julia's lowering of the tape type is memory-layout identical to Enzyme's LLVM tape type: the augmented forward stores the tape using Enzyme's layout into a slot typed by the Julia tape type, and the reverse pass reads it back. Julia only keeps a struct-typed field inline when `Base.allocatedinline` holds, and that fails once a type has pointers and any field of 32768 bytes or more -- `jl_fielddesc16_t` has a 15-bit size field, so the layout falls back to `fielddesc_type == 2`, which `jl_datatype_isinlinealloc` rejects. Julia then boxes the field, the two layouts diverge, and the tape can neither be stored nor read back.

Model that explicitly rather than letting the layouts silently disagree:

- `to_tape_type` maps any nested aggregate Julia would not store inline to `Any`, and `julia_conv_fixup` / `calling_conv_fixup` box and unbox it in the ABI wrappers.
- `tape_type(...; boxnested = false)` keeps the old layout-faithful type for the places that size or zero raw tape storage rather than describe a Julia field: `zero_allocation`, `julia_allocator`, and the anonymous-tape paths.
- `raw_storage_type` builds a flat NamedTuple with explicit `NTuple{n, UInt8}` padding so every leaf keeps its original byte offset, for allocations whose nested type cannot be laid out faithfully. Pointer leaves stay `Any` so the GC still traces them, and it returns `nothing` unless Julia agrees on both the total size and every field offset.
- The anonymous tape is passed as an object pointer and loaded in the wrapper instead of being loaded as a by-value aggregate out of an addrspace(10) pointer.

`ENZYME_FORCE_ANONYMOUS_TAPE=1` forces heap-allocated tapes on for everything, which is the only way to reach that path from Julia in tests.