### PR TITLE
Emit only the entry from nested_codegen!

### DIFF
--- a/docs/src/internal_api.md
+++ b/docs/src/internal_api.md
@@ -7,7 +7,7 @@
     without deprecation.
 
 ```@autodocs
-Modules = [Enzyme.Compiler]
+Modules = [Enzyme.Compiler, Enzyme.Compiler.Interpreter]
 Order = [:module, :type, :constant, :macro, :function]
 Filter = t -> !(t === Enzyme.Compiler.CheckNan)
 ```

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -135,7 +135,15 @@ end
 # FIXME: Should this take something like PTXCompilerParams/CUDAParams?
 struct PrimalCompilerParams <: AbstractEnzymeCompilerParams
     mode::API.CDerivativeMode
+
+    # Whether to emit only the entry, leaving callees as `jl_invoke` thunks
+    only_entry::Bool
 end
+
+PrimalCompilerParams(mode::API.CDerivativeMode) = PrimalCompilerParams(mode, false)
+
+params_only_entry(::AbstractCompilerParams) = false
+params_only_entry(params::PrimalCompilerParams) = params.only_entry
 
 function EnzymeCompilerParams(TT, mode, width, rt, run_enzyme, abiwrap,
                               modifiedBetween, returnPrimal, shadowInit,
@@ -211,14 +219,16 @@ if VERSION >= v"1.11.0-DEV.1552"
             true
         )
 
-    GPUCompiler.get_interpreter(job::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams}) =
-        Interpreter.EnzymeInterpreter(
+    function GPUCompiler.get_interpreter(job::CompilerJob{<:Any, <:AbstractEnzymeCompilerParams})
+        return Interpreter.EnzymeInterpreter(
             GPUCompiler.ci_cache_token(job),
             GPUCompiler.method_table(job),
             job.world,
             job.config.params.mode,
-            true
+            true;
+            only_entry = params_only_entry(job.config.params)
         )
+    end
 else
 
     # the codeinstance cache to use -- should only be used for the constructor
@@ -237,14 +247,16 @@ else
     GPUCompiler.ci_cache(job::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams}) =
         enzyme_ci_cache(job)
 
-    GPUCompiler.get_interpreter(job::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams}) =
-        Interpreter.EnzymeInterpreter(
+    function GPUCompiler.get_interpreter(job::CompilerJob{<:Any, <:AbstractEnzymeCompilerParams})
+        return Interpreter.EnzymeInterpreter(
             enzyme_ci_cache(job),
             GPUCompiler.method_table(job),
             job.world,
             job.config.params.mode,
-            true
+            true;
+            only_entry = params_only_entry(job.config.params)
         )
+    end
 end
 
 import GPUCompiler: @safe_debug, @safe_info, @safe_warn, @safe_error
@@ -1406,18 +1418,6 @@ const DumpPreNestedCheck = Ref(false)
 const DumpPreNestedOpt = Ref(false)
 const DumpPostNestedOpt = Ref(false)
 
-function emit_llvm_only_entry(@nospecialize(job::CompilerJob))
-    tls = task_local_storage()
-    key = Interpreter.OnlyEntryKey
-    prev = get(tls, key, false)
-    tls[key] = true
-    try
-        return GPUCompiler.emit_llvm(job)
-    finally
-        tls[key] = prev
-    end
-end
-
 function nested_codegen!(
     enzyme_context::EnzymeContext,
     mode::API.CDerivativeMode,
@@ -1446,11 +1446,11 @@ function nested_codegen!(
     #  - When OrcV2 only use a MaterializationUnit to avoid mutation of the module here
 
     target = DefaultCompilerTarget()
-    params = PrimalCompilerParams(mode)
+    params = PrimalCompilerParams(mode, Interpreter.only_entry_requested())
     job = CompilerJob(funcspec, CompilerConfig(target, params; kernel = false, libraries = true, toplevel = true, optimize = false, cleanup = false, only_entry = false, validate = false, entry_abi = :specfunc), world)
 
     GPUCompiler.prepare_job!(job)
-    otherMod, meta = emit_llvm_only_entry(job)
+    otherMod, meta = GPUCompiler.emit_llvm(job)
 
     interp = GPUCompiler.get_interpreter(job)
     prepare_llvm(interp, otherMod, job, meta)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1406,6 +1406,18 @@ const DumpPreNestedCheck = Ref(false)
 const DumpPreNestedOpt = Ref(false)
 const DumpPostNestedOpt = Ref(false)
 
+function emit_llvm_only_entry(@nospecialize(job::CompilerJob))
+    tls = task_local_storage()
+    key = Interpreter.OnlyEntryKey
+    prev = get(tls, key, false)
+    tls[key] = true
+    try
+        return GPUCompiler.emit_llvm(job)
+    finally
+        tls[key] = prev
+    end
+end
+
 function nested_codegen!(
     enzyme_context::EnzymeContext,
     mode::API.CDerivativeMode,
@@ -1438,8 +1450,8 @@ function nested_codegen!(
     job = CompilerJob(funcspec, CompilerConfig(target, params; kernel = false, libraries = true, toplevel = true, optimize = false, cleanup = false, only_entry = false, validate = false, entry_abi = :specfunc), world)
 
     GPUCompiler.prepare_job!(job)
-    otherMod, meta = GPUCompiler.emit_llvm(job)
-    
+    otherMod, meta = emit_llvm_only_entry(job)
+
     interp = GPUCompiler.get_interpreter(job)
     prepare_llvm(interp, otherMod, job, meta)
 

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -1506,4 +1506,96 @@ function abstract_call_known(
     )
 end
 
+"""
+    HAS_CODEINFO_LIST
+
+Whether `jl_emit_native` takes an explicit list of `CodeInstance => CodeInfo` pairs
+describing what to emit (as opposed to being handed a `MethodInstance` and walking the
+call graph itself). Only on such versions can `nested_codegen!` ask for the entry alone
+and have Julia stub out the callees; see `OnlyEntryKey`.
+"""
+const HAS_CODEINFO_LIST = VERSION >= v"1.12.0-DEV.1823"
+
+"""
+    OnlyEntryKey
+
+Task-local-storage key guarding the "emit the entry only" mode used by
+`Enzyme.Compiler.nested_codegen!`.
+
+When this flag is set, `GPUCompiler.ci_cache_populate` hands `jl_emit_native`
+only the entry `CodeInstance` instead of the whole transitively reachable callee graph.
+Julia's `resolve_workqueue` then patches up every call site that was left dangling by
+emitting a `jl_invoke` thunk (plus a specsig-to-fptr1 adapter where the call site uses the
+specialized ABI), so the callees dispatch into Julia's own natively compiled code rather
+than being re-emitted into Enzyme's private module.
+
+This matters because `nested_codegen!` is called once per rule per thunk, and the module it
+builds is checked, type-annotated, optimized and then retained by the JIT. Emitting the
+entry alone keeps that module small in all four respects. It is only correct because these
+modules are never differentiated (`run_enzyme = false`) and are linked in after `enzyme!`
+has already run, so Enzyme never needs to see through the calls that become thunks.
+
+The flag is task-local rather than global because it must not leak into unrelated jobs that
+share the interpreter — notably `Enzyme.onehot_internal`, which uses the same
+`PrimalCompilerParams` but consumes the emitted module as an `llvmcall` string and so needs
+its callees emitted.
+"""
+const OnlyEntryKey = gensym(:enzyme_only_entry)
+
+"""
+    OnlyEntry
+
+Master switch for the entry-only nested codegen described in `OnlyEntryKey`. Set to
+`false` to restore the previous behaviour of emitting the full callee graph.
+"""
+const OnlyEntry = Ref(HAS_CODEINFO_LIST)
+
+@inline function only_entry_requested()
+    HAS_CODEINFO_LIST || return false
+    OnlyEntry[] || return false
+    return get(task_local_storage(), OnlyEntryKey, false)::Bool
+end
+
+@static if HAS_CODEINFO_LIST
+
+    # Mirrors the entry-handling half of `GPUCompiler.ci_cache_populate`, minus the
+    # `collectinvokes!` worklist walk that pulls in the transitive callee graph.
+    function entry_codeinfo(@nospecialize(interp::EnzymeInterpreter), mi::MethodInstance)
+        CC = Core.Compiler
+        codeinfos = Pair{Core.CodeInstance, Core.CodeInfo}[]
+        ci = CC.typeinf_ext(interp, mi, CC.SOURCE_MODE_NOT_REQUIRED)
+        ci === nothing && return codeinfos
+        cimi = CC.get_ci_mi(ci)
+        src = if CC.use_const_api(ci)
+            @static if VERSION >= v"1.13.0-DEV.1121"
+                CC.codeinfo_for_const(
+                    interp, cimi, CC.WorldRange(ci.min_world, ci.max_world),
+                    ci.edges, ci.rettype_const
+                )
+            else
+                CC.codeinfo_for_const(interp, cimi, ci.rettype_const)
+            end
+        else
+            CC.typeinf_code(interp, cimi, true)
+        end
+        if src isa Core.CodeInfo
+            push!(codeinfos, ci => src)
+        end
+        return codeinfos
+    end
+
+    function GPUCompiler.ci_cache_populate(
+            @nospecialize(interp::EnzymeInterpreter), cache, mi::MethodInstance,
+            min_world::UInt, max_world::UInt
+        )
+        if only_entry_requested()
+            return entry_codeinfo(interp, mi)
+        end
+        return Base.@invoke GPUCompiler.ci_cache_populate(
+            interp::Any, cache::Any, mi::Any, min_world::Any, max_world::Any
+        )
+    end
+
+end
+
 end

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -83,6 +83,9 @@ struct EnzymeInterpreter{T} <: AbstractInterpreter
     # When false, leave the check for within_autodiff to the handler.
     within_autodiff_rewrite::Bool
 
+    # When true, `ci_cache_populate` returns the entry alone rather than the callee graph.
+    only_entry::Bool
+
     handler::T
 end
 
@@ -135,16 +138,17 @@ const LastRevWorld = Ref(Base.IdSet{Type}())
 const LastInaWorld = Ref(Base.IdSet{Type}())
 
 function EnzymeInterpreter(
-    cache_or_token,
-    mt::Union{Nothing,Core.MethodTable},
-    world::UInt,
-    forward_rules::Bool,
-    reverse_rules::Bool,
-    inactive_rules::Bool,
-    broadcast_rewrite::Bool = true,
-    within_autodiff_rewrite::Bool = true,
-    handler = nothing
-)
+        cache_or_token,
+        mt::Union{Nothing, Core.MethodTable},
+        world::UInt,
+        forward_rules::Bool,
+        reverse_rules::Bool,
+        inactive_rules::Bool,
+        broadcast_rewrite::Bool = true,
+        within_autodiff_rewrite::Bool = true,
+        handler = nothing;
+        only_entry::Bool = false
+    )
     @assert world <= Base.get_world_counter()
 
     parms = @static if VERSION >= v"1.12.0-DEV.1017"
@@ -225,6 +229,7 @@ function EnzymeInterpreter(
         inactive_rules::Bool,
         broadcast_rewrite::Bool,
         within_autodiff_rewrite::Bool,
+        only_entry::Bool,
         handler
     )
 end
@@ -237,26 +242,32 @@ EnzymeInterpreter(
     inactive_rules::Bool,
     broadcast_rewrite::Bool = true,
     within_autodiff_rewrite::Bool = true,
-    handler = nothing
-) = EnzymeInterpreter(cache_or_token, mt, world, mode == API.DEM_ForwardMode, mode == API.DEM_ReverseModeCombined || mode == API.DEM_ReverseModePrimal || mode == API.DEM_ReverseModeGradient, inactive_rules, broadcast_rewrite, within_autodiff_rewrite, handler)
+    handler = nothing;
+    only_entry::Bool = false
+) = EnzymeInterpreter(cache_or_token, mt, world, mode == API.DEM_ForwardMode, mode == API.DEM_ReverseModeCombined || mode == API.DEM_ReverseModePrimal || mode == API.DEM_ReverseModeGradient, inactive_rules, broadcast_rewrite, within_autodiff_rewrite, handler; only_entry)
 
-function EnzymeInterpreter(interp::EnzymeInterpreter;
-    cache_or_token = (@static if HAS_INTEGRATED_CACHE
-        interp.token
-    else
-        interp.code_cache
-    end),
-    mt = interp.method_table,
-    local_cache = interp.local_cache,
-    world = interp.world,
-    inf_params = interp.inf_params,
-    opt_params = interp.opt_params,
-    forward_rules = interp.forward_rules,
-    reverse_rules = interp.reverse_rules,
-    inactive_rules = interp.inactive_rules,
-    broadcast_rewrite = interp.broadcast_rewrite,
-    within_autodiff_rewrite = interp.within_autodiff_rewrite,
-    handler = interp.handler)
+function EnzymeInterpreter(
+        interp::EnzymeInterpreter;
+        cache_or_token = (
+            @static if HAS_INTEGRATED_CACHE
+                interp.token
+            else
+                interp.code_cache
+            end
+        ),
+        mt = interp.method_table,
+        local_cache = interp.local_cache,
+        world = interp.world,
+        inf_params = interp.inf_params,
+        opt_params = interp.opt_params,
+        forward_rules = interp.forward_rules,
+        reverse_rules = interp.reverse_rules,
+        inactive_rules = interp.inactive_rules,
+        broadcast_rewrite = interp.broadcast_rewrite,
+        within_autodiff_rewrite = interp.within_autodiff_rewrite,
+        only_entry = interp.only_entry,
+        handler = interp.handler
+    )
     return EnzymeInterpreter(
         cache_or_token,
         mt,
@@ -269,6 +280,7 @@ function EnzymeInterpreter(interp::EnzymeInterpreter;
         inactive_rules,
         broadcast_rewrite,
         within_autodiff_rewrite,
+        only_entry,
         handler
     )
 end
@@ -1512,22 +1524,22 @@ end
 Whether `jl_emit_native` takes an explicit list of `CodeInstance => CodeInfo` pairs
 describing what to emit (as opposed to being handed a `MethodInstance` and walking the
 call graph itself). Only on such versions can `nested_codegen!` ask for the entry alone
-and have Julia stub out the callees; see `OnlyEntryKey`.
+and have Julia stub out the callees; see `OnlyEntry`.
 """
 const HAS_CODEINFO_LIST = VERSION >= v"1.12.0-DEV.1823"
 
 """
-    OnlyEntryKey
+    OnlyEntry
 
-Task-local-storage key guarding the "emit the entry only" mode used by
-`Enzyme.Compiler.nested_codegen!`.
+Master switch for the entry-only nested codegen used by `Enzyme.Compiler.nested_codegen!`.
 
-When this flag is set, `GPUCompiler.ci_cache_populate` hands `jl_emit_native`
-only the entry `CodeInstance` instead of the whole transitively reachable callee graph.
-Julia's `resolve_workqueue` then patches up every call site that was left dangling by
-emitting a `jl_invoke` thunk (plus a specsig-to-fptr1 adapter where the call site uses the
-specialized ABI), so the callees dispatch into Julia's own natively compiled code rather
-than being re-emitted into Enzyme's private module.
+When enabled, `nested_codegen!` sets `only_entry` on its `PrimalCompilerParams`, and
+`GPUCompiler.ci_cache_populate` then hands `jl_emit_native` only the entry `CodeInstance`
+instead of the whole transitively reachable callee graph. Julia's `resolve_workqueue`
+patches up every call site left dangling by emitting a `jl_invoke` thunk (plus a
+specsig-to-fptr1 adapter where the call site uses the specialized ABI), so the callees
+dispatch into Julia's own natively compiled code rather than being re-emitted into Enzyme's
+private module.
 
 This matters because `nested_codegen!` is called once per rule per thunk, and the module it
 builds is checked, type-annotated, optimized and then retained by the JIT. Emitting the
@@ -1535,26 +1547,11 @@ entry alone keeps that module small in all four respects. It is only correct bec
 modules are never differentiated (`run_enzyme = false`) and are linked in after `enzyme!`
 has already run, so Enzyme never needs to see through the calls that become thunks.
 
-The flag is task-local rather than global because it must not leak into unrelated jobs that
-share the interpreter — notably `Enzyme.onehot_internal`, which uses the same
-`PrimalCompilerParams` but consumes the emitted module as an `llvmcall` string and so needs
-its callees emitted.
-"""
-const OnlyEntryKey = gensym(:enzyme_only_entry)
-
-"""
-    OnlyEntry
-
-Master switch for the entry-only nested codegen described in `OnlyEntryKey`. Set to
-`false` to restore the previous behaviour of emitting the full callee graph.
+Set to `false` to restore the previous behaviour of emitting the full callee graph.
 """
 const OnlyEntry = Ref(HAS_CODEINFO_LIST)
 
-@inline function only_entry_requested()
-    HAS_CODEINFO_LIST || return false
-    OnlyEntry[] || return false
-    return get(task_local_storage(), OnlyEntryKey, false)::Bool
-end
+@inline only_entry_requested() = HAS_CODEINFO_LIST && OnlyEntry[]
 
 @static if HAS_CODEINFO_LIST
 
@@ -1588,7 +1585,7 @@ end
             @nospecialize(interp::EnzymeInterpreter), cache, mi::MethodInstance,
             min_world::UInt, max_world::UInt
         )
-        if only_entry_requested()
+        if interp.only_entry
             return entry_codeinfo(interp, mi)
         end
         return Base.@invoke GPUCompiler.ci_cache_populate(


### PR DESCRIPTION
More 🤖 stuff, this time actually addressing the `only_entry` stuff called out in #3392:

nested_codegen! built its private module with the whole transitive callee graph of each rule, once per rule per thunk. For the qr_compact! pullback in #3392 that is 464 function definitions / 216,995 LLVM instructions, of which the pullback itself is ~2%. check_ir, set_module_types! and optimize! all walk that module, and the JIT then retains it, so the graph is paid for four times over.

Hand jl_emit_native only the entry CodeInstance instead. Julia's resolve_workqueue already covers this case ("make sure all referenced methods get fixed up, particularly if the user declined to compile them"): every dangling call site gets an emit_tojlinvoke thunk, plus an emit_specsig_to_fptr1 adapter where the site used the specialized ABI. The callees then dispatch into Julia's own globally cached native code rather than being re-emitted here, which is ABI-correct by construction and compiles each callee once for the whole process.

This is sound only because these modules are never differentiated (run_enzyme = false) and are linked in after enzyme! has run, so Enzyme never needs to see through the calls that become thunks.

Note that GPUCompiler's own only_entry flag does not work for this: it empties non-entry bodies after InternalizePass has made them internal, yielding internal-linkage declarations, and it emits the full graph first so it saves no irgen time. It is only used from reflection.jl, where the module is printed rather than JIT'd.

The flag is task-local so it cannot leak into onehot_internal, which shares PrimalCompilerParams but consumes its module as an llvmcall string and so needs its callees emitted. Gated to Julia 1.12+, where jl_emit_native takes an explicit codeinfos list; 1.10 and 1.11 are unchanged.

On a custom rule over A*B with sum/norm/tr and mul! in the pullback, the reverse rule's module drops from 52 defs / 28,185 instructions to 19 / 2,288, and a steady-state thunk build from 0.75s to 0.35s. The cost is that rule callees become boxed jl_invoke dispatches: +22% on 4x4 matrices where dispatch dominates, neutral by 64x64. Interpreter.OnlyEntry[] = false restores the old behaviour.