### PR TITLE
Fix complex copies of GPU arrays for Enzyme (split from #3105)

### DIFF
--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -180,7 +180,7 @@ for (DstArr, SrcArr) in ARRAY_COPY_DIRECTIONS
 		doffs::Const,
 		src::Annotation{<:$SrcArr{T}},
 		soffs::Const,
-                n::Const) where {RT, T<: AbstractFloat}
+                n::Const) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
             func.val(dest.val, doffs.val, src.val, soffs.val, n.val)
             primal = EnzymeRules.needs_primal(config) ? dest.val : nothing
             shadow = if !(RT <: Const) && EnzymeRules.needs_shadow(config) &&
@@ -201,7 +201,7 @@ for (DstArr, SrcArr) in ARRAY_COPY_DIRECTIONS
 		doffs::Const,
 		src::Annotation{<:$SrcArr{T}},
 		soffs::Const,
-                n::Const) where {RT, T<: AbstractFloat}
+                n::Const) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
             if !(dest isa Const)
                 for batch in 1:EnzymeRules.width(config)
                     ddest = _shadow(dest, config, batch)

--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -4,11 +4,14 @@ using CUDA
 using Enzyme
 using Enzyme: EnzymeRules
 
-function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T <: AbstractFloat}
+# Complex is handled here because the shadow operations are element-wise: zeroing is a
+# `memset` sized by `sizeof(T)`, and accumulation is a broadcast, both of which are
+# agnostic to the real/complex split.
+function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
     Base.Libc.memset(ptr + off * sizeof(T), 0, n * sizeof(T))
     return nothing
 end
-function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T <: AbstractFloat}
+function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
     bytes = reinterpret(CuPtr{UInt8}, ptr + off * sizeof(T))
     CUDA.memset(bytes, UInt8(0), n * sizeof(T))
     return nothing
@@ -145,7 +148,7 @@ for (DstPtr, SrcPtr) in PTR_COPY_DIRECTIONS
 		src::Annotation{<:$SrcPtr{T}},
                 n::Const;
                 kwargs...,
-            ) where {RT, T <: AbstractFloat}
+            ) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
             if !(dest isa Const)
                 for batch in 1:EnzymeRules.width(config)
                     ddest = _shadow(dest, config, batch)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -21,6 +21,32 @@ using Test
     @testset "device memory" begin
         @test grad_roundtrip(x -> cu(x)) == Float32[2, 4, 6]
     end
+
+    #= The copy rules used to be real-only, so a complex copy fell through to Enzyme's
+    default handling and silently did nothing: the primal was never copied and the
+    cotangent never propagated. =#
+    @testset "complex copies, $T" for T in (ComplexF32, ComplexF64)
+        n = 8
+        x = CuArray(T[i + 2im * i for i in 1:n])
+        y = CUDA.zeros(T, n)
+        dx = CUDA.zeros(T, n)
+        dy = CuArray(ones(T, n))
+        x_before, dy_before = Array(x), Array(dy)
+
+        Enzyme.autodiff(
+            Reverse,
+            Const((dst, src) -> (copyto!(dst, src); nothing)),
+            Const,
+            Duplicated(y, dy),
+            Duplicated(x, dx),
+        )
+        CUDA.synchronize()
+
+        # the primal must actually run, and `y = x` pulls the cotangent back onto `x`
+        @test Array(y) == x_before
+        @test Array(dx) == dy_before
+        @test all(iszero, Array(dy))
+    end
     # Unified/host memory: `pointer(::CuArray{…,Unified/Host})` is inferred as `Union{CuPtr,Ptr}`, so the `pointer` rule cannot yet return a concrete
     @testset "unified memory" begin
         @test grad_roundtrip(x -> cu(x; unified = true)) == Float32[2, 4, 6]

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -23,29 +23,82 @@ using Test
     end
 
     #= The copy rules used to be real-only, so a complex copy fell through to Enzyme's
-    default handling and silently did nothing: the primal was never copied and the
-    cotangent never propagated. =#
+    default handling and failed. Each direction below reaches a different rule instance:
+    device<->device and host<->device cover all three of `ARRAY_COPY_DIRECTIONS`, and a
+    host destination is the only way to reach the `_zero!(::Ptr, …)` shadow reset.
+
+    The cotangent seed is deliberately *not* real: a real seed is a fixed point of
+    conjugation, so it cannot tell a correct copy adjoint apart from a conjugating one.
+    `dx` is likewise seeded non-zero, so accumulation is distinguishable from overwrite. =#
     @testset "complex copies, $T" for T in (ComplexF32, ComplexF64)
         n = 8
-        x = CuArray(T[i + 2im * i for i in 1:n])
-        y = CUDA.zeros(T, n)
-        dx = CUDA.zeros(T, n)
-        dy = CuArray(ones(T, n))
-        x_before, dy_before = Array(x), Array(dy)
+        seed, prior = T(1 + 2im), T(10 - 3im)
+        copy_kernel = (dst, src) -> (copyto!(dst, src); nothing)
 
-        Enzyme.autodiff(
-            Reverse,
-            Const((dst, src) -> (copyto!(dst, src); nothing)),
-            Const,
-            Duplicated(y, dy),
-            Duplicated(x, dx),
+        # `dev` builds a device array, `hst` a host one, so a single body covers every
+        # host/device combination the rules are registered for.
+        dev, hst = (v -> CuArray(v)), identity
+        directions = (
+            ("device to device", dev, dev),
+            ("host to device", dev, hst),
+            ("device to host", hst, dev),
         )
-        CUDA.synchronize()
+        @testset "$name" for (name, to_dst, to_src) in directions
+            src_vals = T[i + 2im * i for i in 1:n]
+            src = to_src(copy(src_vals))
+            dst = to_dst(zeros(T, n))
+            dsrc = to_src(fill(prior, n))
+            ddst = to_dst(fill(seed, n))
 
-        # the primal must actually run, and `y = x` pulls the cotangent back onto `x`
-        @test Array(y) == x_before
-        @test Array(dx) == dy_before
-        @test all(iszero, Array(dy))
+            Enzyme.autodiff(
+                Reverse, Const(copy_kernel), Const,
+                Duplicated(dst, ddst), Duplicated(src, dsrc),
+            )
+            CUDA.synchronize()
+
+            # the primal must actually run
+            @test Array(dst) == src_vals
+            # `dst = src` accumulates the destination cotangent onto the source, unconjugated
+            @test Array(dsrc) == fill(prior + seed, n)
+            # and the destination cotangent is reset afterwards
+            @test all(iszero, Array(ddst))
+        end
+
+        # A `Const` source must leave the destination shadow zeroed without accumulating.
+        @testset "constant source" begin
+            src = CuArray(T[i + 2im * i for i in 1:n])
+            dst = CUDA.zeros(T, n)
+            ddst = CuArray(fill(seed, n))
+
+            Enzyme.autodiff(
+                Reverse, Const(copy_kernel), Const,
+                Duplicated(dst, ddst), Const(src),
+            )
+            CUDA.synchronize()
+
+            @test Array(dst) == Array(src)
+            @test all(iszero, Array(ddst))
+        end
+
+        # Width > 1 exercises the `_shadow(…, batch)` loop in the reverse rules.
+        @testset "batched" begin
+            src_vals = T[i + 2im * i for i in 1:n]
+            src = CuArray(copy(src_vals))
+            dst = CUDA.zeros(T, n)
+            dsrc = (CUDA.zeros(T, n), CUDA.zeros(T, n))
+            ddst = (CuArray(fill(seed, n)), CuArray(fill(2 * seed, n)))
+
+            Enzyme.autodiff(
+                Reverse, Const(copy_kernel), Const,
+                BatchDuplicated(dst, ddst), BatchDuplicated(src, dsrc),
+            )
+            CUDA.synchronize()
+
+            @test Array(dst) == src_vals
+            @test Array(dsrc[1]) == fill(seed, n)
+            @test Array(dsrc[2]) == fill(2 * seed, n)
+            @test all(all(iszero, Array(d)) for d in ddst)
+        end
     end
     # Unified/host memory: `pointer(::CuArray{…,Unified/Host})` is inferred as `Union{CuPtr,Ptr}`, so the `pointer` rule cannot yet return a concrete
     @testset "unified memory" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -4,8 +4,6 @@ using LinearAlgebra: mul!, dot, Symmetric
 using Test
 
 @testset "CUDA memory copies" begin
-    #= Exercise the reverse copy rules across CUDA's memory types. A host<->device
-    roundtrip gradient must recover `2x`. =#
     grad_roundtrip = function (to_gpu)
         x = Float32[1, 2, 3]
         dx = zeros(Float32, 3)
@@ -22,21 +20,11 @@ using Test
         @test grad_roundtrip(x -> cu(x)) == Float32[2, 4, 6]
     end
 
-    #= The copy rules used to be real-only, so a complex copy fell through to Enzyme's
-    default handling and failed. Each direction below reaches a different rule instance:
-    device<->device and host<->device cover all three of `ARRAY_COPY_DIRECTIONS`, and a
-    host destination is the only way to reach the `_zero!(::Ptr, …)` shadow reset.
-
-    The cotangent seed is deliberately *not* real: a real seed is a fixed point of
-    conjugation, so it cannot tell a correct copy adjoint apart from a conjugating one.
-    `dx` is likewise seeded non-zero, so accumulation is distinguishable from overwrite. =#
     @testset "complex copies, $T" for T in (ComplexF32, ComplexF64)
         n = 8
         seed, prior = T(1 + 2im), T(10 - 3im)
         copy_kernel = (dst, src) -> (copyto!(dst, src); nothing)
 
-        # `dev` builds a device array, `hst` a host one, so a single body covers every
-        # host/device combination the rules are registered for.
         dev, hst = (v -> CuArray(v)), identity
         directions = (
             ("device to device", dev, dev),
@@ -56,15 +44,11 @@ using Test
             )
             CUDA.synchronize()
 
-            # the primal must actually run
             @test Array(dst) == src_vals
-            # `dst = src` accumulates the destination cotangent onto the source, unconjugated
             @test Array(dsrc) == fill(prior + seed, n)
-            # and the destination cotangent is reset afterwards
             @test all(iszero, Array(ddst))
         end
 
-        # A `Const` source must leave the destination shadow zeroed without accumulating.
         @testset "constant source" begin
             src = CuArray(T[i + 2im * i for i in 1:n])
             dst = CUDA.zeros(T, n)
@@ -80,7 +64,6 @@ using Test
             @test all(iszero, Array(ddst))
         end
 
-        # Width > 1 exercises the `_shadow(…, batch)` loop in the reverse rules.
         @testset "batched" begin
             src_vals = T[i + 2im * i for i in 1:n]
             src = CuArray(copy(src_vals))
@@ -101,17 +84,6 @@ using Test
         end
     end
 
-    #= The pointer-level rules are registered separately from the array-level ones, and
-    their `augmented_primal` carries no eltype bound while their `reverse` was restricted
-    to `AbstractFloat`. A complex copy reaching them therefore survived the augmented pass
-    and died on the reverse one with a `MethodError`.
-
-    A copy that reaches these rules from user code also goes through `pointer`, which has
-    its own correctness bug (see the commented-out rule in the extension): the primal copy
-    does not land and the shadows are left untouched. That affects real and complex alike,
-    so rather than pin down values that are known-wrong, assert the property this widening
-    is actually about -- complex behaves exactly as its real counterpart does. The
-    assertion stays honest once the `pointer` bug is fixed and both become correct. =#
     @testset "pointer level, $R vs $C" for (R, C) in
             ((Float32, ComplexF32), (Float64, ComplexF64))
         ptr_copy = function (S)
@@ -138,10 +110,8 @@ using Test
             )
         end
 
-        # before the widening this threw `MethodError: no method matching reverse(…)`
         @test ptr_copy(C) == ptr_copy(R)
     end
-    # Unified/host memory: `pointer(::CuArray{…,Unified/Host})` is inferred as `Union{CuPtr,Ptr}`, so the `pointer` rule cannot yet return a concrete
     @testset "unified memory" begin
         @test grad_roundtrip(x -> cu(x; unified = true)) == Float32[2, 4, 6]
     end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -100,6 +100,47 @@ using Test
             @test all(all(iszero, Array(d)) for d in ddst)
         end
     end
+
+    #= The pointer-level rules are registered separately from the array-level ones, and
+    their `augmented_primal` carries no eltype bound while their `reverse` was restricted
+    to `AbstractFloat`. A complex copy reaching them therefore survived the augmented pass
+    and died on the reverse one with a `MethodError`.
+
+    A copy that reaches these rules from user code also goes through `pointer`, which has
+    its own correctness bug (see the commented-out rule in the extension): the primal copy
+    does not land and the shadows are left untouched. That affects real and complex alike,
+    so rather than pin down values that are known-wrong, assert the property this widening
+    is actually about -- complex behaves exactly as its real counterpart does. The
+    assertion stays honest once the `pointer` bug is fixed and both become correct. =#
+    @testset "pointer level, $R vs $C" for (R, C) in
+            ((Float32, ComplexF32), (Float64, ComplexF64))
+        ptr_copy = function (S)
+            n = 8
+            src = CuArray(S[i for i in 1:n])
+            dst = CUDA.zeros(S, n)
+            dsrc = CUDA.zeros(S, n)
+            ddst = CuArray(ones(S, n))
+            kernel = function (d, s)
+                GC.@preserve d s begin
+                    unsafe_copyto!(pointer(d), pointer(s), n)
+                end
+                return nothing
+            end
+            Enzyme.autodiff(
+                Reverse, Const(kernel), Const,
+                Duplicated(dst, ddst), Duplicated(src, dsrc),
+            )
+            CUDA.synchronize()
+            return (
+                copied = Array(dst) == Array(src),
+                src_shadow_zero = all(iszero, Array(dsrc)),
+                dst_shadow_zero = all(iszero, Array(ddst)),
+            )
+        end
+
+        # before the widening this threw `MethodError: no method matching reverse(…)`
+        @test ptr_copy(C) == ptr_copy(R)
+    end
     # Unified/host memory: `pointer(::CuArray{…,Unified/Host})` is inferred as `Union{CuPtr,Ptr}`, so the `pointer` rule cannot yet return a concrete
     @testset "unified memory" begin
         @test grad_roundtrip(x -> cu(x; unified = true)) == Float32[2, 4, 6]


### PR DESCRIPTION
Fixes some type signatures on rules and adds tests to make sure they're hit now.