### PR TITLE
Fix nondeterministic CUDA CI GC corruption (assert mod::LLVM.Module)

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5535,6 +5535,10 @@ function GPUCompiler.compile_unhooked(output::Symbol, job::CompilerJob{<:EnzymeT
     @safe_debug "Emit LLVM with" primal_job
     GPUCompiler.prepare_job!(primal_job)
     mod, meta = GPUCompiler.emit_llvm(primal_job)
+    # `emit_llvm` is not concretely inferred, so without this assertion every
+    # subsequent use of `mod` (e.g. `LLVM.context(mod)`) is a dynamic dispatch
+    # through jl_apply_generic, which forces boxing and GC-rooting across it.
+    mod = mod::LLVM.Module
     edges = enzyme_context.edges
 
     primal_interp = GPUCompiler.get_interpreter(primal_job)


### PR DESCRIPTION
Fixes the nondeterministic CUDA CI failures (e.g. [build 7744](https://buildkite.com/julialang/enzyme-dot-jl/builds/7744)).

## The change

```julia
mod, meta = GPUCompiler.emit_llvm(primal_job)
mod = mod::LLVM.Module
```

`GPUCompiler.emit_llvm` is declared `Tuple{typeof(emit_llvm), CompilerJob}` and is wrapped in GPUCompiler's `@locked` try/finally, so its return type is not concretely inferred. `mod` is therefore effectively `Any` for the rest of `compile_unhooked`, and every use of it is a dynamic dispatch.

## Symptoms

All CUDA jobs failing with `exit 255` are one bug, in two forms:

| | signature | example builds |
|---|---|---|
| (a) | `GC error (probable corruption)` → `SIGABRT` from `gc_dump_queue_and_abort` | 7615, 7718, 7728, 7744 |
| (b) | `SIGSEGV` with **no backtrace at all** (RIP garbage, nothing to unwind) | 7660, 7663, 7676, 7693, 7706, 7709, 7712, 7722, 7735, 7736 |

Not environment-specific: hits Julia 1.10/1.11/1.12, spread over ≥8 agents with no clustering, `jl_n_gcthreads == 0` (CI is single-threaded, so not a GC-thread race). The corrupted memory is the Julia heap during CPU-side compilation, not device memory.

Rate per CUDA job, excluding the separate since-fixed 1.12 systematic failure:

| builds | dates | rate |
|---|---|---|
| 7250–7450 | Jun 19 – Jul 6 | 0.50% |
| 7450–7600 | Jul 7 – 19 | 0.67% |
| 7600–7700 | Jul 19 – 26 | 2.3% |
| 7700–7745 | Jul 26 – Aug 3 | **6.5%** |

Earliest instances: 7297 (Jun 23), 7381 (Jun 28). The jump tracks #3363 (Jul 23), which added a second ~4-minute compile to `test/cuda.jl` — more exposure to an existing bug, not a new one. Crash probability scales with compile time, which is why the CUDA tests dominate: they hold the longest compiles. The bug itself is in the compilation path and is not CUDA-specific.

## Root cause

Reproduced locally on 2× RTX 5090 / Julia 1.11.9 with an environment matching CI exactly (Enzyme_jll 0.0.289, LLVM.jl 9.11.0, CUDACore 6.2.1, GPUCompiler 1.23.0). Both crash families reproduce with CI-identical signatures, including allocation counts within 0.1% (local `1,329,224,697` vs build 7744's `1,328,036,268`; local `335,314,185` vs build 7722's `335,621,168`).

Seven catches under gdb on `gc_dump_queue_and_abort` all agree exactly:

```
GC FRAME WALK   (culprit obj = 0x00007fffffff9c98)
  [ n ] frame=0x00007fffffff80a0 nroots=451   indirect=0
        root[415] = 0x00007fffffff9c98  >>> CULPRIT <<<
```

A **direct** GC root slot (`indirect=0`, so slots must hold `jl_value_t*`) holds a pointer into the C stack. The GC reads `addr-8` as the type tag and gets an `llvm::IntegerType*` — identifiable from the decoded layout (`TypeID 0x0d` = `IntegerTyID`, widths 8/16/32/64, shared `LLVMContext*`), the same in every catch.

A hardware watchpoint on that slot caught the write:

```
write #1 to root[415] slot 0x00007fffffff9bc8
  value = 0x00007fffffffaad8              <- stack address
  armed frame 0x00007fffffff8ec0 still in gcstack chain: True
  jl_apply_generic(F=0x7ffca05709c0, args=0x7fffffff7040, nargs=1)
  --- dispatched function ---
LLVM.context
```

```
mov %rbx,0x1d98(%rsp)
mov %rbx,0x2c18(%rsp)     <- root[415] = stack address
mov %r12,0x70(%rsp)
call *%r15                <- ijl_apply_generic
```

The stored address's own tag word is also a stack address (`-8: 0x00007fffffffabc0`), matching the `<?#0x…::(nil)>` printed in the crash dumps. In one capture the value was `0x00007fffffff9c98` — the exact address the GC aborts on.

So: `LLVM.context(mod)` at `compiler.jl:5839` is dynamically dispatched; Julia boxes and roots values live across `jl_apply_generic`; one of those roots holds a stack address. The slot is correctly zeroed at frame setup (the watchpoint confirms `current slot value = 0` at arming), so this is a genuine bad store, not an uninitialized slot. The value is transient — written and overwritten quickly — which is exactly why only ~2–5% of runs crash rather than all of them.

## Validation

Full `test/cuda.jl`, same machine and environment:

| | runs | crashes |
|---|---|---|
| before | 41 | 2 (~4.9%) |
| after | **108** | **0** |

At the measured baseline, 0/108 would occur by chance ~0.4% of the time. All 108 runs completed the full suite (7 testsets, `Reverse Kernel` passing); no failures of any kind.

## Confidence

The reproduction and the before/after measurement are solid. The causal chain — dynamic dispatch → boxing/rooting across `jl_apply_generic` → stack address in a direct root slot — is the most probable explanation given the captured write, but it is inference from that evidence rather than something demonstrated end to end. The change is independently worthwhile regardless: a dynamic dispatch in the hottest compile path is a real cost.

## Ruled out along the way

Recorded so they aren't re-tried:

- **`unsafe_pointer_to_objref` fabricating a fake object.** Instrumented all six call sites (`absint.jl:62/205/434/454`, `utils.jl:588/633`) to flag stack-range pointers; zero hits over a full suite run.
- **Uninitialized GC frame.** Julia's `LateLowerGCFrame` memsets the whole frame — the PTX specialization's prologue emits `memset(gcframe, 0, 3848)` covering all 481 slots — and the watchpoint confirms the slot is 0 at frame setup.
- **A stale/popped GC frame.** The frame is still linked into `ptls->current_task->gcstack` when written. (Writes to the same address from `combineInstructionsOverFunction` and friends all report *not* in chain — recycled stack after the frame pops.)
- **LLVM.jl `CustomMaterializationUnit`.** Its lazily-materialized ORC closures are properly rooted in `CUSTOM_MU_ROOTS`.
- **`compiler.jl:5967`'s `string(source_typ)`** as a hotspot — only 0.3% of profile samples; it's just where the GC happens to fire.

## Unrelated issues noticed

Not addressed here:

- `src/rules/parallelrules.jl:422` is the only `addrspacecast` of an alloca into the **Tracked** address space in the codebase. Casting a stack pointer to addrspace 10 makes `LateLowerGCFrame` root it — the same class of bug. Every other site casts `0 → Derived (11)` directly. It's on the `Threads.@threads` path, so it doesn't affect CUDA CI.
- `ext/EnzymeCUDAExt.jl`: `_accumulate!(acc, aoff, ...)` does `acc + aoff` (byte arithmetic on a `Ptr`) where `_zero!` correctly does `ptr + off * sizeof(T)`. Harmless today since every call site passes `aoff = 0`, but latent.
- Upstream CUDA.jl `CUDACore/ext/EnzymeCoreExt.jl:318`: `GC.@preserve args subtape, begin … end` parses as two macro arguments with `(subtape, block)` as the expression, so `subtape` isn't actually in the preserve list.

Separately: the gpuci agents log `(core dumped)` but core dumps only help if they're retained — worth checking `ulimit -c` / `core_pattern` there. A core file would have short-circuited most of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178T1Ewa8J2fGNhNYfftbAn
