### PR TITLE
Fix Vararg-in-UnionAll deprecation in absint

### DIFF
--- a/src/absint.jl
+++ b/src/absint.jl
@@ -139,8 +139,18 @@ function absint(@nospecialize(arg::LLVM.Value), partial::Bool = false, istracked
 
                 if legal
                     res = Ty{found...}
-                    for u in unionalls
-                        res = UnionAll(u, res)
+                    if res isa Core.TypeofVararg
+                        # A bare `Vararg` cannot be wrapped in a `UnionAll`
+                        # (deprecated: `Vararg{T} where T`). Widen each partial
+                        # typevar to its upper bound instead.
+                        if !isempty(unionalls)
+                            found = Any[f in unionalls ? f.ub : f for f in found]
+                            res = Ty{found...}
+                        end
+                    else
+                        for u in unionalls
+                            res = UnionAll(u, res)
+                        end
                     end
                     return (true, res)
                 end


### PR DESCRIPTION
When abstractly interpreting `Core.apply_type(Vararg, X)` with a partial (statically unknown) argument, `absint` introduced a fresh `TypeVar` and wrapped the result via `UnionAll(u, res)`. Because `res` is a bare `Vararg` (not a `Tuple`), this produced the deprecated `Vararg{T} where T` and emitted:

```
Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
  ... absint(arg::LLVM.Value, ...) @ Enzyme.Compiler src/absint.jl
```

during downstream test runs (reported from Flux's Enzyme tests).

**Fix:** detect the bare-`Vararg` case and widen each partial typevar to its upper bound instead of wrapping in a `UnionAll`. This is semantically identical — `UnionAll(u, Vararg{u})` for an unbounded `u` already evaluated to `Vararg{Any}` — while avoiding the deprecated code path. The other `UnionAll` in this file always wraps a `Tuple`, so it is unaffected.

Verified in isolation under `julia --depwarn=error`: the old path raises exactly this deprecation, the new path returns `Vararg{Any}` cleanly.

Fixes the Enzyme-side deprecation reported in FluxML/Flux.jl#2570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)