### PR TITLE
Don't re-classify functions whose ABI lower_convention rewrote

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1229,6 +1229,10 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
             continue
         end
 
+        if has_fn_attr(f, StringAttribute(LOWERED_CONVENTION_ATTR_KIND))
+            continue
+        end
+
         llRT, sret, returnRoots = get_return_info(RT)
         retRemoved, parmsRemoved = removed_ret_parms(f)
 
@@ -1379,6 +1383,9 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
             continue
         end
         fn = functions(mod)[fname]
+        if has_fn_attr(fn, StringAttribute(LOWERED_CONVENTION_ATTR_KIND))
+            continue
+        end
         attributes = function_attributes(fn)
         mi = nothing
         RT = nothing
@@ -5208,6 +5215,7 @@ function lower_convention(
 
     mi, rt = enzyme_custom_extract_mi(entry_f)
     attributes = function_attributes(wrapper_f)
+    push!(attributes, StringAttribute(LOWERED_CONVENTION_ATTR_KIND))
     push!(
         attributes,
         StringAttribute("enzymejl_mi", string(convert(UInt, pointer_from_objref(mi)))),

--- a/src/llvm/attrkinds.jl
+++ b/src/llvm/attrkinds.jl
@@ -8,3 +8,4 @@ const READONLY_ATTR_KIND = get_attr_kind_from_name("readonly")
 const READNONE_ATTR_KIND = get_attr_kind_from_name("readnone")
 const WRITEONLY_ATTR_KIND = get_attr_kind_from_name("writeonly")
 const PRESERVEPRIMAL_ATTR_KIND = "enzyme_preserve_primal"
+const LOWERED_CONVENTION_ATTR_KIND = "enzyme_lowered_convention"

--- a/test/rules/sret_lowered_convention.jl
+++ b/test/rules/sret_lowered_convention.jl
@@ -1,0 +1,46 @@
+using Enzyme
+using Enzyme.EnzymeCore: EnzymeRules
+using Test
+
+function cfun_sret_lowered(v::Vector{Float64})
+    z = ComplexF64(v[1], v[2])
+    return inv(z) * inv(z + 1)
+end
+
+mysum_sret_lowered(x::Vector{Float64}) = sum(x)
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfigWidth{1},
+        ::Const{typeof(mysum_sret_lowered)},
+        ::Type{RT},
+        x::Annotation{<:Vector{Float64}},
+    ) where {RT}
+    primal = EnzymeRules.needs_primal(config) ? mysum_sret_lowered(x.val) : nothing
+    return EnzymeRules.AugmentedReturn(primal, nothing, nothing)
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfigWidth{1},
+        ::Const{typeof(mysum_sret_lowered)},
+        dret::Active,
+        tape,
+        x::Annotation{<:Vector{Float64}},
+    )
+    if !isa(x, Const)
+        seed = ones(length(x.val))
+        dz = Enzyme.autodiff(
+            Forward, cfun_sret_lowered, Duplicated, Duplicated(x.val, seed)
+        )[1]
+        x.dval .+= dret.val .* real(dz)
+    end
+    return (nothing,)
+end
+
+@testset "sret lowered convention relinked into nested module" begin
+    x = [1.0, 2.0, 3.0]
+    dx = zero(x)
+
+    Enzyme.autodiff(Reverse, mysum_sret_lowered, Active, Duplicated(x, dx))
+
+    @test all(dx .≈ 0.085)
+end


### PR DESCRIPTION
Should hopefully fix https://github.com/EnzymeAD/Enzyme.jl/issues/3457

`lower_convention` replaces a function's LLVM ABI but keeps its `enzymejl_mi`/`enzymejl_rt` attributes, so anything re-deriving the ABI from those Julia types sees parameters that no longer exist. For `inv(::ComplexF64)`,

    void @julia_inv_NNN(ptr sret([2 x double]), ptr addrspace(11))

becomes

    [2 x double] @julia_inv_NNN_inner.1([2 x double])

Normally this is harmless: `set_module_types!` classifies arguments in a loop that runs before the handler loop which creates the wrapper, and the handler loop iterates a name list snapshotted before the wrapper existed, so the wrapper is processed by neither. Nested codegen breaks that invariant -- `check_ir` links a previously compiled module into the nested one before types are set on it, so the classification loop meets a fully formed wrapper, still derives a sret slot from the Julia return type, and fails with

    AssertionError: codegen_i=2 > length(codegen_types)=1

Mark the wrappers `lower_convention` emits and skip them in both loops, which restores the behaviour the non-nested path already had. Guarding only the classification loop would move the crash rather than fix it: the handler loop would otherwise run `lower_convention` on the wrapper a second time, re-running the same classification internally.

Not re-classifying is the right treatment rather than repairing the sret detection alone, since `lower_convention` also unboxes arguments and drops inline roots. The change is confined to paths that previously either asserted or silently derived a wrong `enzyme_type` for the sret parameter.

Generated with the help of 🤖 