### PR TITLE
Add rules for BigFloat integer constructors

### DIFF
--- a/src/internal_rules/bigfloat.jl
+++ b/src/internal_rules/bigfloat.jl
@@ -67,6 +67,87 @@ function EnzymeRules.reverse(
     return ()
 end
 
+# `BigFloat(x::Clong)` / `BigFloat(x::Culong)` lower to `mpfr_set_si` / `mpfr_set_ui`,
+# for which there is no derivative, so any active use of an integer-constructed
+# BigFloat otherwise fails with `EnzymeNoDerivativeError`.
+function EnzymeRules.forward(
+    config::EnzymeRules.FwdConfig,
+    Ty::Const{Type{BigFloat}},
+    RT::Type{<:Union{DuplicatedNoNeed,Duplicated,BatchDuplicated,BatchDuplicatedNoNeed}},
+    x::Const{Ti},
+    rs::Const{Base.MPFR.MPFRRoundingMode}...;
+    kwargs...,
+    ) where {Ti <: Union{Clong, Culong}}
+    rvals = map(r -> r.val, rs)
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
+        if EnzymeRules.width(config) == 1
+            return remove_innerty(RT)(
+                Ty.val(x.val, rvals...; kwargs...),
+                Ty.val(zero(Ti), rvals...; kwargs...),
+            )
+        else
+            tup = ntuple(Val(EnzymeRules.width(config))) do i
+                Base.@_inline_meta
+                Ty.val(zero(Ti), rvals...; kwargs...)
+            end
+            return remove_innerty(RT)(Ty.val(x.val, rvals...; kwargs...), tup)
+        end
+    elseif EnzymeRules.needs_shadow(config)
+        if EnzymeRules.width(config) == 1
+            return Ty.val(zero(Ti), rvals...; kwargs...)
+        else
+            return ntuple(Val(EnzymeRules.width(config))) do i
+                Base.@_inline_meta
+                Ty.val(zero(Ti), rvals...; kwargs...)
+            end
+        end
+    elseif EnzymeRules.needs_primal(config)
+        return Ty.val(x.val, rvals...; kwargs...)
+    else
+        return nothing
+    end
+end
+
+function EnzymeRules.augmented_primal(
+    config::EnzymeRules.RevConfig,
+    Ty::Const{Type{BigFloat}},
+    RT::Type{<:Union{DuplicatedNoNeed,Duplicated,BatchDuplicated,BatchDuplicatedNoNeed}},
+    x::Const{Ti},
+    rs::Const{Base.MPFR.MPFRRoundingMode}...;
+    kwargs...,
+    ) where {Ti <: Union{Clong, Culong}}
+    rvals = map(r -> r.val, rs)
+    primal = if EnzymeRules.needs_primal(config)
+        Ty.val(x.val, rvals...; kwargs...)
+    else
+        nothing
+    end
+    shadow = if RT <: Const
+        nothing
+    elseif EnzymeRules.width(config) == 1
+        Ty.val(zero(Ti), rvals...; kwargs...)
+    else
+        ntuple(Val(EnzymeRules.width(config))) do i
+            Base.@_inline_meta
+            Ty.val(zero(Ti), rvals...; kwargs...)
+        end
+    end
+    return EnzymeRules.AugmentedReturn(primal, shadow, nothing)
+end
+
+function EnzymeRules.reverse(
+    config::EnzymeRules.RevConfig,
+    Ty::Const{Type{BigFloat}},
+    RT::Type{<:Union{DuplicatedNoNeed,Duplicated,BatchDuplicated,BatchDuplicatedNoNeed}},
+    tape,
+    x::Const{<:Union{Culong, Clong}},
+    rs::Const{Base.MPFR.MPFRRoundingMode}...;
+    kwargs...,
+)
+    # the integer argument carries no derivative
+    return ntuple(i -> nothing, Val(1 + length(rs)))
+end
+
 EnzymeRules.@easy_rule(+(a::BigFloat, b::Number), (1,1))
 EnzymeRules.@easy_rule(+(a::Number, b::BigFloat), (1,1))
 EnzymeRules.@easy_rule(+(a::BigFloat, b::BigFloat), (1,1))

--- a/test/rules/internal_rules/bigfloat.jl
+++ b/test/rules/internal_rules/bigfloat.jl
@@ -30,3 +30,33 @@ using Test
     @test autodiff(Enzyme.Forward, cos, Duplicated, Duplicated(a, da))[:1] ≈ -sin(a) * da 
     @test autodiff(Enzyme.Forward, tan, Duplicated, Duplicated(a, da))[:1] ≈ autodiff(Enzyme.Forward, tan, Duplicated, Duplicated(af64, daf64))[1]
 end
+
+@testset "BigFloat integer constructors" begin
+    a = BigFloat(1.234)
+    da = BigFloat(-0.23)
+
+    # BigFloat(::Clong) / BigFloat(::Culong) construct a constant, so the shadow is zero
+    @test autodiff(Enzyme.Forward, BigFloat, Duplicated, Const(2))[:1] ≈ 0
+    @test autodiff(Enzyme.Forward, BigFloat, Duplicated, Const(UInt(2)))[:1] ≈ 0
+
+    # ... but the primal value must still be right, and propagate through arithmetic
+    mul2(x) = x * BigFloat(2)
+    @test autodiff(Enzyme.Forward, mul2, Duplicated, Duplicated(a, da))[:1] ≈ 2 * da
+    umul2(x) = x * BigFloat(UInt(2))
+    @test autodiff(Enzyme.Forward, umul2, Duplicated, Duplicated(a, da))[:1] ≈ 2 * da
+
+    # the constructor also has to keep working under a non-default precision
+    setprecision(BigFloat, 512) do
+        @test precision(BigFloat(3)) == 512
+        mul3(x) = x * BigFloat(3)
+        @test autodiff(Enzyme.Forward, mul3, Duplicated, Duplicated(a, da))[:1] ≈ 3 * da
+    end
+
+    # `eps(::Type{BigFloat})` is `nextfloat(BigFloat(1)) - BigFloat(1)`, so it goes
+    # through the integer constructor; without a rule this fails to compile.
+    # NOTE: using the result of `eps(BigFloat)` in an *active* position (e.g.
+    # `x * eps(BigFloat)`) still segfaults -- Enzyme miscompiles the BigFloat
+    # construction inside `nextfloat`/`_duplicate` when it has to differentiate it.
+    epsconst(x) = x * x + zero(eps(BigFloat))
+    @test autodiff(Enzyme.Forward, epsconst, Duplicated, Duplicated(a, da))[:1] ≈ 2 * a * da
+end


### PR DESCRIPTION
`BigFloat(x::Clong)` and `BigFloat(x::Culong)` lower to `mpfr_set_si` / `mpfr_set_ui`, for which there is no derivative, so any active use of an integer-constructed BigFloat failed with `EnzymeNoDerivativeError`.

The argument is an integer, so the result never carries a derivative. This cannot be expressed as `inactive`, though: the result is a fresh mutable BigFloat that subsequent MPFR calls may write into, so it still needs a shadow to exist -- the same reason the existing no-argument `BigFloat()` rule allocates one. The shadow is built through the same constructor with a zero value, so it lands at the requested precision as a properly initialised MPFR value rather than raw zeroed memory.

Having a rule here also keeps Enzyme from compiling the body of these constructors at all, which matters beyond the missing derivative: `eps(::Type{BigFloat})` is `nextfloat(BigFloat(1)) - BigFloat(1)`, and compiling that construction inside an Enzyme-generated function miscompiles it into a BigFloat with an invalid `d::Memory`, segfaulting on first use. This repro segfaults before the change and passes after:

    f(out) = (out[1] = eps(BigFloat) > 0 ? 1.0 : 0.0; nothing)
    Enzyme.autodiff(Forward, Const(f), Const(zeros(3)))

Developed with 🤖 