### PR TITLE
fix symbols in `body_runtime_generic_rev`

### DIFF
--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -639,7 +639,16 @@ function nonzero_active_data(x::T) where {T}
     return false
 end
 
-function body_runtime_generic_rev(N, Width, Atomic, wrapped, primttypes, shadowargs, active_refs)
+function body_runtime_generic_rev(
+    N,
+    Width,
+    Atomic,
+    wrapped,
+    primttypes,
+    shadowargs,
+    active_refs,
+    dfns,
+)
     outs = Vector{Expr}(undef, N*Width)
     for i = 1:N
         for w = 1:Width
@@ -701,15 +710,11 @@ function body_runtime_generic_rev(N, Width, Atomic, wrapped, primttypes, shadowa
             end
         end
     else
-        fargs = [:df]
-        for i = 2:Width
-            push!(fargs, Symbol("df_$i"))
-        end
         quote
             if df isa Base.RefValue && !(f isa Base.RefValue)
-                BatchMixedDuplicated(f, ($(fargs...),))
+                BatchMixedDuplicated(f, ($(dfns...),))
             else
-                BatchDuplicated(f, ($(fargs...),))
+                BatchDuplicated(f, ($(dfns...),))
             end
         end
     end
@@ -803,7 +808,16 @@ function func_runtime_generic_rev(N, Width, Atomic)
     _, _, primtypes, allargs, typeargs, wrapped, batchshadowargs, _, active_refs, dfns =
         setup_macro_wraps(false, N, Width)
     body =
-        body_runtime_generic_rev(N, Width, Atomic, wrapped, primtypes, batchshadowargs, active_refs)
+        body_runtime_generic_rev(
+            N,
+            Width,
+            Atomic,
+            wrapped,
+            primtypes,
+            batchshadowargs,
+            active_refs,
+            dfns,
+        )
 
     quote
         function runtime_generic_rev(
@@ -846,6 +860,7 @@ end
         primtypes,
         batchshadowargs,
         active_refs,
+        dfns,
     )
 end
 

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -1059,46 +1059,16 @@ end
     )
 end
 
-@testset "Batched active with runtime activity" begin
-    struct Inner
-        a::Float64
-        r::Tuple{UnitRange{Int64}}
+@testset "BatchDuplicated closure in generic call" begin
+    struct Cl
+        a::Vector{Float64}
     end
-    (t::Inner)(x) = fill(x[1], sum(length, t.r))
-    struct Outer
-        v::Vector{Inner}
-    end
-    function (t::Outer)(x::AbstractVector)
-        y = Vector{Float64}(undef, 2)
-        y[1] = t.v[1](x)[1]
-        y[2] = t.v[1](x)[1]
-        return y
-    end
-    outer = Outer([Inner(1.0, (1:1,))])
-    d_outer1 = Outer([Inner(0.0, (1:1,))])
-    d_outer2 = Outer([Inner(0.0, (1:1,))])
-    x = ones(2)
-    dx1 = zeros(2)
-    dx2 = zeros(2)
-
-    augres = Enzyme.Compiler.runtime_generic_augfwd(
-        Val{(true, true)},
-        Val(true), Val(false), Val(2),
-        Val((true, false)),
-        Val(Enzyme.Compiler.AnyArray(2 + Int(2))),
-        outer, d_outer1, d_outer2,
-        x, dx1, dx2,
-    )
-
-    Enzyme.Compiler.runtime_generic_rev(
-        Val{(true, true)},
-        Val(true), Val(false), Val(2),
-        Val((true, false)),
-        Val(false),
-        augres[end],
-        outer, d_outer1, d_outer2,
-        x, dx1, dx2,
-    )
+    (c::Cl)(x) = c.a[1] * x
+    caller(c, x) = Base.inferencebarrier(c)(x)::Float64
+    c = Cl([2.0])
+    d1 = Cl([0.0])
+    d2 = Cl([0.0])
+    Enzyme.autodiff(Reverse, caller, BatchDuplicated(c, (d1, d2)), Active(3.0))
 end
 
 @testset "Uncached batch sizes" begin

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -1059,6 +1059,48 @@ end
     )
 end
 
+@testset "Batched active with runtime activity" begin
+    struct Inner
+        a::Float64
+        r::Tuple{UnitRange{Int64}}
+    end
+    (t::Inner)(x) = fill(x[1], sum(length, t.r))
+    struct Outer
+        v::Vector{Inner}
+    end
+    function (t::Outer)(x::AbstractVector)
+        y = Vector{Float64}(undef, 2)
+        y[1] = t.v[1](x)[1]
+        y[2] = t.v[1](x)[1]
+        return y
+    end
+    outer = Outer([Inner(1.0, (1:1,))])
+    d_outer1 = Outer([Inner(0.0, (1:1,))])
+    d_outer2 = Outer([Inner(0.0, (1:1,))])
+    x = ones(2)
+    dx1 = zeros(2)
+    dx2 = zeros(2)
+
+    augres = Enzyme.Compiler.runtime_generic_augfwd(
+        Val{(true, true)},
+        Val(true), Val(false), Val(2),
+        Val((true, false)),
+        Val(Enzyme.Compiler.AnyArray(2 + Int(2))),
+        outer, d_outer1, d_outer2,
+        x, dx1, dx2,
+    )
+
+    Enzyme.Compiler.runtime_generic_rev(
+        Val{(true, true)},
+        Val(true), Val(false), Val(2),
+        Val((true, false)),
+        Val(false),
+        augres[end],
+        outer, d_outer1, d_outer2,
+        x, dx1, dx2,
+    )
+end
+
 @testset "Uncached batch sizes" begin
     genericsin(x) = Base.invokelatest(sin, x)
     res = Enzyme.autodiff(Forward, genericsin, BatchDuplicated(2.0, NTuple{10, Float64}((Float64(i) for i in 1:10))))[1]


### PR DESCRIPTION
This fixes #3466. To be perfectly honest, I'm not sure what I'm doing, but the fix here mirrors exactly what was done in #2442 for the forward pass, I'm guessing that it just wasn't caught for the reverse counterpart.