### PR TITLE
Propagate return activity through generic calls

### DIFF
--- a/src/internal_rules/core.jl
+++ b/src/internal_rules/core.jl
@@ -559,8 +559,12 @@ function EnzymeRules.forward(config, ::Const{typeof(Base.finalizer)}, _, f::Cons
         end
     end
 
-    if EnzymeRules.needs_primal(config)
+    if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
         return o
+    elseif EnzymeRules.needs_shadow(config)
+        return o.dval
+    elseif EnzymeRules.needs_primal(config)
+        return o.val
     else
         return nothing
     end

--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -2,6 +2,26 @@ struct BuiltinWrapper{F}
     f::F
 end
 
+# Native analysis decides whether a return is constant or no-need. Its Julia
+# type still decides how a differentiable value is represented.
+@inline function runtime_generic_return_activity(
+    ::Type{T},
+    ::Val{Activity},
+    mode::API.CDerivativeMode,
+) where {T,Activity}
+    if Activity == API.DFT_CONSTANT
+        return Const{T}
+    elseif Activity == API.DFT_OUT_DIFF
+        return Active{T}
+    end
+
+    annotation = guess_activity(T, mode)
+    if Activity == API.DFT_DUP_NONEED && annotation <: Duplicated
+        return DuplicatedNoNeed{T}
+    end
+    return annotation
+end
+
 @generated function (w::BuiltinWrapper{F})(args::Vararg{Any,N}) where {F, N}
    cargs = Expr[]
    for i in 1:N
@@ -303,13 +323,15 @@ function body_runtime_generic_fwd(N, Width, wrapped, primtypes, dfns)
         end
         args = ($(wrapped...),)
 
-        # TODO: Annotation of return value
-        # tt0 = Tuple{$(primtypes...)}
         tt = Tuple{$(ElTypes...)}
         tt′ = Tuple{$(Types...)}
         FT = Core.Typeof(f)
         rt = Compiler.primal_return_type(Forward, FT, tt)
-        annotation = guess_activity(rt, API.DEM_ForwardMode)
+        annotation = runtime_generic_return_activity(
+            rt,
+            returnActivity,
+            API.DEM_ForwardMode,
+        )
 
         if annotation <: DuplicatedNoNeed
             annotation = Duplicated{rt}
@@ -361,6 +383,7 @@ function func_runtime_generic_fwd(N, Width)
     quote
         function runtime_generic_fwd(
             activity::Type{Val{ActivityTup}},
+            returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -368,7 +391,7 @@ function func_runtime_generic_fwd(N, Width)
             f::F,
             df::DF,
             $(allargs...),
-        ) where {ActivityTup,RuntimeActivity,StrongZero,ReturnType,F,DF,$(typeargs...)}
+        ) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,ReturnType,F,DF,$(typeargs...)}
             $body
         end
     end
@@ -376,6 +399,7 @@ end
 
 @generated function runtime_generic_fwd(
     activity::Type{Val{ActivityTup}},
+    returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -383,7 +407,7 @@ end
     f::F,
     df::DF,
     allargs...,
-) where {ActivityTup,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
+) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, _, _, _, dfns = setup_macro_wraps(true, N, Width, :allargs)
     return body_runtime_generic_fwd(N, Width, wrapped, primtypes, dfns)
@@ -522,9 +546,15 @@ function body_runtime_generic_augfwd(N, Width, wrapped, primttypes, active_refs,
             tt = Tuple{$(ElTypes...)}
 
             rt = Compiler.primal_return_type(Reverse, FT, tt)
-            annotation0 = guess_activity(rt, API.DEM_ReverseModePrimal)
+            annotation0 = runtime_generic_return_activity(
+                rt,
+                returnActivity,
+                API.DEM_ReverseModePrimal,
+            )
 
-            annotationA = if $Width != 1 && annotation0 <: Duplicated
+            annotationA = if $Width != 1 && annotation0 <: DuplicatedNoNeed
+                BatchDuplicatedNoNeed{rt,$Width}
+            elseif $Width != 1 && annotation0 <: Duplicated
                 BatchDuplicated{rt,$Width}
             elseif $Width != 1 && annotation0 <: MixedDuplicated
                 BatchMixedDuplicated{rt,$Width}
@@ -583,6 +613,7 @@ function func_runtime_generic_augfwd(N, Width)
     quote
         function runtime_generic_augfwd(
             activity::Type{Val{ActivityTup}},
+            returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -591,7 +622,7 @@ function func_runtime_generic_augfwd(N, Width)
             f::F,
             df::DF,
             $(allargs...),
-        )::ReturnType where {ActivityTup,MB,ReturnType,RuntimeActivity,StrongZero,F,DF,$(typeargs...)}
+        )::ReturnType where {ActivityTup,ReturnActivity,MB,ReturnType,RuntimeActivity,StrongZero,F,DF,$(typeargs...)}
             $body
         end
     end
@@ -599,6 +630,7 @@ end
 
 @generated function runtime_generic_augfwd(
     activity::Type{Val{ActivityTup}},
+    returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -607,7 +639,7 @@ end
     f::F,
     df::DF,
     allargs...,
-)::ReturnType where {ActivityTup,MB,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
+)::ReturnType where {ActivityTup,ReturnActivity,MB,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, _, _, active_refs, dfns =
         setup_macro_wraps(false, N, Width, :allargs)
@@ -752,9 +784,15 @@ function body_runtime_generic_rev(N, Width, Atomic, wrapped, primttypes, shadowa
             end
             tt = Tuple{$(ElTypes...)}
             rt = Compiler.primal_return_type(Reverse, FT, tt)
-            annotation0 = guess_activity(rt, API.DEM_ReverseModePrimal)
+            annotation0 = runtime_generic_return_activity(
+                rt,
+                returnActivity,
+                API.DEM_ReverseModePrimal,
+            )
 
-            annotation = if $Width != 1 && annotation0 <: Duplicated
+            annotation = if $Width != 1 && annotation0 <: DuplicatedNoNeed
+                BatchDuplicatedNoNeed{rt,$Width}
+            elseif $Width != 1 && annotation0 <: Duplicated
                 BatchDuplicated{rt,$Width}
             elseif $Width != 1 && annotation0 <: MixedDuplicated
                 BatchMixedDuplicated{rt, $Width}
@@ -808,6 +846,7 @@ function func_runtime_generic_rev(N, Width, Atomic)
     quote
         function runtime_generic_rev(
             activity::Type{Val{ActivityTup}},
+            returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -817,7 +856,7 @@ function func_runtime_generic_rev(N, Width, Atomic)
             f::F,
             df::DF,
             $(allargs...),
-        ) where {ActivityTup,RuntimeActivity,StrongZero,MB,TapeType,F,DF,$(typeargs...)}
+        ) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,MB,TapeType,F,DF,$(typeargs...)}
             $body
         end
     end
@@ -825,6 +864,7 @@ end
 
 @generated function runtime_generic_rev(
     activity::Type{Val{ActivityTup}},
+    returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -834,7 +874,7 @@ end
     f::F,
     df::DF,
     allargs...,
-) where {ActivityTup,MB,RuntimeActivity,StrongZero,Width,Atomic,TapeType,F,DF}
+) where {ActivityTup,ReturnActivity,MB,RuntimeActivity,StrongZero,Width,Atomic,TapeType,F,DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, batchshadowargs, _, active_refs, dfns =
         setup_macro_wraps(false, N, Width, :allargs)
@@ -1884,7 +1924,8 @@ function generic_setup(
     endcast = true,
     firstconst_after_tape = true,
     runtime_activity = true,
-    strong_zero = true
+    strong_zero = true,
+    return_activity = nothing,
 )
     width = get_width(gutils)
     mode = get_mode(gutils)
@@ -2009,6 +2050,9 @@ function generic_setup(
     if runtime_activity
         pushfirst!(vals, unsafe_to_llvm(B, Val(get_runtime_activity(gutils))))
     end
+    if return_activity !== nothing
+        pushfirst!(vals, unsafe_to_llvm(B, Val(return_activity)))
+    end
     etup0 = emit_tuple!(B, ActivityList)
     etup = emit_apply_type!(B, Base.Val, LLVM.Value[etup0])
     if isa(etup, LLVM.Instruction)
@@ -2076,7 +2120,8 @@ function common_generic_fwd(offset, B, orig, gutils, normalR, shadowR)
         gutils,
         offset,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
     AT = LLVM.ArrayType(T_prjlvalue, 1 + Int(width))
     if unsafe_load(shadowR) != C_NULL
@@ -2155,7 +2200,8 @@ function common_generic_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR)
         gutils,
         offset,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
     AT = LLVM.ArrayType(T_prjlvalue, 2 + Int(width))
 
@@ -2241,7 +2287,17 @@ function common_generic_rev(offset, B, orig, gutils, tape)::Cvoid
 
     @assert tape !== C_NULL
     width = get_width(gutils)
-    generic_setup(orig, runtime_generic_rev, Nothing, gutils, offset, B, true; tape) #=start=#
+    generic_setup(
+        orig,
+        runtime_generic_rev,
+        Nothing,
+        gutils,
+        offset,
+        B,
+        true;
+        tape,
+        return_activity = activep,
+    ) #=start=#
     return nothing
 end
 
@@ -2287,7 +2343,8 @@ function common_apply_latest_fwd(offset, B, orig, gutils, normalR, shadowR)
         gutils,
         offset + 1,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
 
     if unsafe_load(shadowR) != C_NULL
@@ -2357,7 +2414,8 @@ function common_apply_latest_augfwd(offset, B, orig, gutils, normalR, shadowR, t
         gutils,
         offset + 1,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
 
     if unsafe_load(shadowR) != C_NULL
@@ -2421,7 +2479,17 @@ function common_apply_latest_rev(offset, B, orig, gutils, tape)::Cvoid
     end
     if !is_constant_value(gutils, orig) || !is_constant_inst(gutils, orig)
         width = get_width(gutils)
-        generic_setup(orig, runtime_generic_rev, Nothing, gutils, offset + 1, B, true; tape) #=start=#
+        generic_setup(
+            orig,
+            runtime_generic_rev,
+            Nothing,
+            gutils,
+            offset + 1,
+            B,
+            true;
+            tape,
+            return_activity = activep,
+        ) #=start=#
     end
 
     return nothing
@@ -2773,7 +2841,8 @@ function common_invoke_fwd(offset, B, orig, gutils, normalR, shadowR)
         gutils,
         offset + 1,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
     AT = LLVM.ArrayType(T_prjlvalue, 1 + Int(width))
 
@@ -2848,7 +2917,8 @@ function common_invoke_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR)
         gutils,
         offset + 1,
         B,
-        false,
+        false;
+        return_activity = activep,
     ) #=start=#
     AT = LLVM.ArrayType(T_prjlvalue, 2 + Int(width))
 
@@ -2914,7 +2984,17 @@ function common_invoke_rev(offset, B, orig, gutils, tape)
     end
 
     width = get_width(gutils)
-    generic_setup(orig, runtime_generic_rev, Nothing, gutils, offset + 1, B, true; tape) #=start=#
+    generic_setup(
+        orig,
+        runtime_generic_rev,
+        Nothing,
+        gutils,
+        offset + 1,
+        B,
+        true;
+        tape,
+        return_activity = activep,
+    ) #=start=#
 
     return nothing
 end

--- a/src/rules/jitrules.jl
+++ b/src/rules/jitrules.jl
@@ -5,10 +5,10 @@ end
 # Native analysis decides whether a return is constant or no-need. Its Julia
 # type still decides how a differentiable value is represented.
 @inline function runtime_generic_return_activity(
-    ::Type{T},
-    ::Val{Activity},
-    mode::API.CDerivativeMode,
-) where {T,Activity}
+        ::Type{T},
+        ::Val{Activity},
+        mode::API.CDerivativeMode,
+    ) where {T, Activity}
     if Activity == API.DFT_CONSTANT
         return Const{T}
     elseif Activity == API.DFT_OUT_DIFF
@@ -383,7 +383,7 @@ function func_runtime_generic_fwd(N, Width)
     quote
         function runtime_generic_fwd(
             activity::Type{Val{ActivityTup}},
-            returnActivity::Val{ReturnActivity},
+                returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -391,7 +391,7 @@ function func_runtime_generic_fwd(N, Width)
             f::F,
             df::DF,
             $(allargs...),
-        ) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,ReturnType,F,DF,$(typeargs...)}
+            ) where {ActivityTup, ReturnActivity, RuntimeActivity, StrongZero, ReturnType, F, DF, $(typeargs...)}
             $body
         end
     end
@@ -399,7 +399,7 @@ end
 
 @generated function runtime_generic_fwd(
     activity::Type{Val{ActivityTup}},
-    returnActivity::Val{ReturnActivity},
+        returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -407,7 +407,7 @@ end
     f::F,
     df::DF,
     allargs...,
-) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
+    ) where {ActivityTup, ReturnActivity, RuntimeActivity, StrongZero, Width, ReturnType, F, DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, _, _, _, dfns = setup_macro_wraps(true, N, Width, :allargs)
     return body_runtime_generic_fwd(N, Width, wrapped, primtypes, dfns)
@@ -553,7 +553,7 @@ function body_runtime_generic_augfwd(N, Width, wrapped, primttypes, active_refs,
             )
 
             annotationA = if $Width != 1 && annotation0 <: DuplicatedNoNeed
-                BatchDuplicatedNoNeed{rt,$Width}
+                BatchDuplicatedNoNeed{rt, $Width}
             elseif $Width != 1 && annotation0 <: Duplicated
                 BatchDuplicated{rt,$Width}
             elseif $Width != 1 && annotation0 <: MixedDuplicated
@@ -613,7 +613,7 @@ function func_runtime_generic_augfwd(N, Width)
     quote
         function runtime_generic_augfwd(
             activity::Type{Val{ActivityTup}},
-            returnActivity::Val{ReturnActivity},
+                returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -622,7 +622,7 @@ function func_runtime_generic_augfwd(N, Width)
             f::F,
             df::DF,
             $(allargs...),
-        )::ReturnType where {ActivityTup,ReturnActivity,MB,ReturnType,RuntimeActivity,StrongZero,F,DF,$(typeargs...)}
+            )::ReturnType where {ActivityTup, ReturnActivity, MB, ReturnType, RuntimeActivity, StrongZero, F, DF, $(typeargs...)}
             $body
         end
     end
@@ -630,7 +630,7 @@ end
 
 @generated function runtime_generic_augfwd(
     activity::Type{Val{ActivityTup}},
-    returnActivity::Val{ReturnActivity},
+        returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -639,7 +639,7 @@ end
     f::F,
     df::DF,
     allargs...,
-)::ReturnType where {ActivityTup,ReturnActivity,MB,RuntimeActivity,StrongZero,Width,ReturnType,F,DF}
+    )::ReturnType where {ActivityTup, ReturnActivity, MB, RuntimeActivity, StrongZero, Width, ReturnType, F, DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, _, _, active_refs, dfns =
         setup_macro_wraps(false, N, Width, :allargs)
@@ -791,7 +791,7 @@ function body_runtime_generic_rev(N, Width, Atomic, wrapped, primttypes, shadowa
             )
 
             annotation = if $Width != 1 && annotation0 <: DuplicatedNoNeed
-                BatchDuplicatedNoNeed{rt,$Width}
+                BatchDuplicatedNoNeed{rt, $Width}
             elseif $Width != 1 && annotation0 <: Duplicated
                 BatchDuplicated{rt,$Width}
             elseif $Width != 1 && annotation0 <: MixedDuplicated
@@ -846,7 +846,7 @@ function func_runtime_generic_rev(N, Width, Atomic)
     quote
         function runtime_generic_rev(
             activity::Type{Val{ActivityTup}},
-            returnActivity::Val{ReturnActivity},
+                returnActivity::Val{ReturnActivity},
             runtimeActivity::Val{RuntimeActivity},
             strongZero::Val{StrongZero},
             width::Val{$Width},
@@ -856,7 +856,7 @@ function func_runtime_generic_rev(N, Width, Atomic)
             f::F,
             df::DF,
             $(allargs...),
-        ) where {ActivityTup,ReturnActivity,RuntimeActivity,StrongZero,MB,TapeType,F,DF,$(typeargs...)}
+            ) where {ActivityTup, ReturnActivity, RuntimeActivity, StrongZero, MB, TapeType, F, DF, $(typeargs...)}
             $body
         end
     end
@@ -864,7 +864,7 @@ end
 
 @generated function runtime_generic_rev(
     activity::Type{Val{ActivityTup}},
-    returnActivity::Val{ReturnActivity},
+        returnActivity::Val{ReturnActivity},
     runtimeActivity::Val{RuntimeActivity},
     strongZero::Val{StrongZero},
     width::Val{Width},
@@ -874,7 +874,7 @@ end
     f::F,
     df::DF,
     allargs...,
-) where {ActivityTup,ReturnActivity,MB,RuntimeActivity,StrongZero,Width,Atomic,TapeType,F,DF}
+    ) where {ActivityTup, ReturnActivity, MB, RuntimeActivity, StrongZero, Width, Atomic, TapeType, F, DF}
     N = div(length(allargs) + 2, Width + 1) - 1
     _, _, primtypes, _, _, wrapped, batchshadowargs, _, active_refs, dfns =
         setup_macro_wraps(false, N, Width, :allargs)
@@ -1924,8 +1924,8 @@ function generic_setup(
     endcast = true,
     firstconst_after_tape = true,
     runtime_activity = true,
-    strong_zero = true,
-    return_activity = nothing,
+        strong_zero = true,
+        return_activity = nothing,
 )
     width = get_width(gutils)
     mode = get_mode(gutils)

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -1041,9 +1041,39 @@ end
     @test xact.dval[2] ≈ dy2 * 2
 end
 
+@noinline function nested_generic_const_result!(out, x)
+    copyto!(out, x)
+    return out
+end
+
+const NESTED_GENERIC_CONST_RESULT = Ref{Any}(nested_generic_const_result!)
+
+function discard_nested_generic_result(out, x)
+    NESTED_GENERIC_CONST_RESULT[](out, x)
+    return nothing
+end
+
+@testset "Nested generic constant return activity" begin
+    out = zeros(3)
+    x = [1.0, 2.0, 3.0]
+    dx = fill(7.0, 3)
+
+    Enzyme.autodiff(
+        Reverse,
+        discard_nested_generic_result,
+        Const,
+        Const(out),
+        Duplicated(x, dx),
+    )
+
+    @test out == x
+    @test dx == fill(7.0, 3)
+end
+
 @testset "Batched inactive" begin
     augres = Enzyme.Compiler.runtime_generic_augfwd(
-        Val{(false, false, false)}, Val(false), Val(false), Val(2), Val((true, true, true)),
+        Val{(false, false, false)}, Val(Enzyme.API.DFT_CONSTANT),
+        Val(false), Val(false), Val(2), Val((true, true, true)),
         Val(Enzyme.Compiler.AnyArray(2 + Int(2))),
         ==, nothing, nothing,
         :foo, nothing, nothing,
@@ -1051,7 +1081,8 @@ end
     )
 
     Enzyme.Compiler.runtime_generic_rev(
-        Val{(false, false, false)}, Val(false), Val(false), Val(2), Val((true, true, true)),
+        Val{(false, false, false)}, Val(Enzyme.API.DFT_CONSTANT),
+        Val(false), Val(false), Val(2), Val((true, true, true)),
         Val(false), augres[end],
         ==, nothing, nothing,
         :foo, nothing, nothing,
@@ -1251,6 +1282,7 @@ end
 @testset "Union i8" begin
     args = (
         Val{(false, false, false)},
+        Val(Enzyme.API.DFT_CONSTANT),
         Val(false),
         Val(false),
         Val(1),
@@ -1270,6 +1302,7 @@ end
 
     args2 = (
         Val{(false, false, false)},
+        Val(Enzyme.API.DFT_CONSTANT),
         Val(false),
         Val(false),
         Val(1),


### PR DESCRIPTION
Propagate Enzyme’s computed return activity through runtime generic calls instead of guessing from Julia’s return type.

This fixes Const output buffers in JLArrays and makes the existing finalizer rule honor primal-only return configs. Includes a nested generic-call regression test.

Tested: advanced, ext/jlarrays, and finalizers on Julia 1.12.