### PR TITLE
Update MvNormal broken marker on Julia 1.12

### DIFF
--- a/test/integration/Distributions/runtests.jl
+++ b/test/integration/Distributions/runtests.jl
@@ -281,7 +281,10 @@ _pdmat(A) = PDMat(_sym(A) + 5I)
         TestCase(MvNormal([0.2, 0.3], Symmetric(Diagonal([0.5, 0.4]))), [-0.1, 0.05]),
         TestCase(MvNormal([0.2, 0.3], Diagonal([0.5, 0.4])), [-0.1, 0.05]),
         # TODO Broken tests, see https://github.com/EnzymeAD/Enzyme.jl/issues/1991
-        TestCase(MvNormal([-0.15], _pdmat([1.1]')), [-0.05]; broken=Forward),
+        TestCase(
+            MvNormal([-0.15], _pdmat([1.1]')), [-0.05];
+            broken = (VERSION < v"1.12" ? Forward : Neither)
+        ),
         TestCase(
             MvNormal([0.2, -0.15], _pdmat([1.0 0.9; 0.7 1.1])), [0.05, -0.05];
             broken=Forward


### PR DESCRIPTION
The one-dimensional `PDMat` forward-mode case now passes on Julia 1.12 while remaining broken on older Julia versions. Make only that marker version-specific; the adjacent two-dimensional case stays broken.

Closes #3471