### PR TITLE
Give a Const output buffer a shadow in the GPUArrays linalg rules

### DIFF
--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -59,20 +59,30 @@ end
 @inline _isconst(config, x::Annotation) =
     EnzymeRules.runtime_activity(config) && x.dval === x.val
 
-# One value per batch element.
-@inline _bsplat(::Val{1}, v) = v
-@inline _bsplat(::Val{N}, v) where {N} = ntuple(Returns(v), Val(N))
+# A fresh zeroed buffer per batch element. A struct instead of a closure so
+# `ntuple` gets something concrete.
+struct _ZeroLike{V}
+    val::V
+end
+@inline (f::_ZeroLike)(::Int) = zero(f.val)
+@inline _bzeros(::Val{1}, v) = zero(v)
+@inline _bzeros(::Val{N}, v) where {N} = ntuple(_ZeroLike(v), Val(N))
 
 #=
 Shadow of the returned output argument. Enzyme asks for one whenever the caller
 gave the call an active return activity, which it does independently of the
 output's own activity: a dynamically dispatched `generic_matmatmul!` gets
-`Duplicated` guessed from its return type even with a `Const` C. A constant has
-no shadow of its own, and Enzyme's representation of one is the primal itself,
-which is what `_isconst` above recognizes.
+`Duplicated` guessed from its return type even with a `Const` C.
+
+A `Const` output has no shadow to hand back. Returning its primal would alias
+the two: the reverse pass of whatever consumes the returned value accumulates
+into the shadow, which would then silently corrupt the user's buffer, and every
+batch element would alias the same array. A constant's derivative is zero, so
+give each batch element its own zeroed buffer instead; the rule's own reverse
+returns early on a `Const` C (`_isconst` above) and never reads it.
 =#
 @inline _outshadow(_, out::Annotation) = out.dval
-@inline _outshadow(config, out::Const) = _bsplat(Val(width(config)), out.val)
+@inline _outshadow(config, out::Const) = _bzeros(Val(width(config)), out.val)
 
 #=
 Augmented return for the rules here: output argument plus a tape. Enzyme checks

--- a/ext/EnzymeGPUArraysCoreExt.jl
+++ b/ext/EnzymeGPUArraysCoreExt.jl
@@ -59,6 +59,21 @@ end
 @inline _isconst(config, x::Annotation) =
     EnzymeRules.runtime_activity(config) && x.dval === x.val
 
+# One value per batch element.
+@inline _bsplat(::Val{1}, v) = v
+@inline _bsplat(::Val{N}, v) where {N} = ntuple(Returns(v), Val(N))
+
+#=
+Shadow of the returned output argument. Enzyme asks for one whenever the caller
+gave the call an active return activity, which it does independently of the
+output's own activity: a dynamically dispatched `generic_matmatmul!` gets
+`Duplicated` guessed from its return type even with a `Const` C. A constant has
+no shadow of its own, and Enzyme's representation of one is the primal itself,
+which is what `_isconst` above recognizes.
+=#
+@inline _outshadow(_, out::Annotation) = out.dval
+@inline _outshadow(config, out::Const) = _bsplat(Val(width(config)), out.val)
+
 #=
 Augmented return for the rules here: output argument plus a tape. Enzyme checks
 the primal/shadow types, so get them from `augmented_rule_return_type`. Use the
@@ -68,7 +83,7 @@ the primal/shadow types, so get them from `augmented_rule_return_type`. Use the
 @inline function _augreturn(config, ::Type{RT}, out::Annotation, tape) where {RT}
     return augmented_rule_return_type(config, RT)(
         needs_primal(config) ? out.val : nothing,
-        needs_shadow(config) ? out.dval : nothing,
+        needs_shadow(config) ? _outshadow(config, out) : nothing,
         tape,
     )
 end

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -169,6 +169,46 @@ output and doesn't happen on CUDA.
         )
         @test all(collect(dA1) .≈ 7.0)
         @test all(collect(dA2) .≈ -2.0)
+
+        #=
+        Now consume the returned value. `mul!(D, R, E)`'s reverse accumulates
+        into R's shadow, so that shadow must not be C itself: aliasing the two
+        would leave `dD·E'` in the user's `Const` buffer instead of `A·B`.
+        =#
+        function dyn_chain!(D, C, A, B, E)
+            R = dyn_gemm!(C, A, B)
+            mul!(D, R, E)
+            return nothing
+        end
+
+        q = 5
+        A0 = randn(m, k)
+        B0 = randn(k, n)
+        E0 = randn(n, q)
+        Cbuf = jl(zeros(m, n))
+        dA = jl(zeros(m, k))
+        Enzyme.autodiff(
+            Reverse, dyn_chain!, Const,
+            Duplicated(jl(zeros(m, q)), jl(ones(m, q))),
+            Const(Cbuf), Duplicated(jl(A0), dA), Const(jl(B0)), Const(jl(E0)),
+        )
+        @test collect(Cbuf) ≈ A0 * B0
+        # A `Const` C still blocks the pullback into A.
+        @test all(collect(dA) .≈ 0.0)
+
+        # Same at width 2, where each batch element needs its own shadow.
+        Cbuf2 = jl(zeros(m, n))
+        dA1b = jl(zeros(m, k))
+        dA2b = jl(zeros(m, k))
+        Enzyme.autodiff(
+            Reverse, dyn_chain!, Const,
+            BatchDuplicated(jl(zeros(m, q)), (jl(ones(m, q)), jl(fill(2.0, m, q)))),
+            Const(Cbuf2), BatchDuplicated(jl(A0), (dA1b, dA2b)),
+            Const(jl(B0)), Const(jl(E0)),
+        )
+        @test collect(Cbuf2) ≈ A0 * B0
+        @test all(collect(dA1b) .≈ 0.0)
+        @test all(collect(dA2b) .≈ 0.0)
     end
 
     # The same operand plain and transposed, both products matrix-vector: two

--- a/test/ext/jlarrays.jl
+++ b/test/ext/jlarrays.jl
@@ -1,5 +1,5 @@
 using Enzyme, Test, JLArrays
-using LinearAlgebra: mul!, dot, transpose, adjoint, Symmetric
+using LinearAlgebra: LinearAlgebra, mul!, dot, transpose, adjoint, Symmetric
 
 function jlres(x)
     2 * collect(x)
@@ -122,6 +122,53 @@ output and doesn't happen on CUDA.
             Const(jl(randn(k, n))),
         )
         @test all(collect(dA) .≈ 7.0)
+    end
+
+    #=
+    The same `Const` output, but with `generic_matmatmul!` reached through a
+    dynamic dispatch, which is what some GPUArrays versions emit out of `mul!`.
+    The call's return activity is then guessed from its return type alone:
+    `Duplicated`, whatever C's own activity is, so Enzyme asks the rule for the
+    shadow of a `Const` output.
+    =#
+    @testset "Const output buffer, dynamic dispatch" begin
+        @static if VERSION < v"1.12.0-DEV"
+            function dyn_gemm!(C, A, B)
+                return Base.inferencebarrier(LinearAlgebra.generic_matmatmul!)(
+                    C, 'N', 'N', A, B, LinearAlgebra.MulAddMul(true, false)
+                )
+            end
+        else
+            function dyn_gemm!(C, A, B)
+                return Base.inferencebarrier(LinearAlgebra.generic_matmatmul!)(
+                    C, 'N', 'N', A, B, true, false
+                )
+            end
+        end
+        function dyn_matmul!(C, A, B)
+            dyn_gemm!(C, A, B)
+            return nothing
+        end
+
+        m, k, n = 3, 4, 2
+        dA = jl(fill(7.0, m, k))
+        Enzyme.autodiff(
+            Reverse, dyn_matmul!, Const,
+            Const(jl(zeros(m, n))), Duplicated(jl(randn(m, k)), dA),
+            Const(jl(randn(k, n))),
+        )
+        @test all(collect(dA) .≈ 7.0)
+
+        # Same at width 2, where the shadow of the `Const` output is a tuple.
+        dA1 = jl(fill(7.0, m, k))
+        dA2 = jl(fill(-2.0, m, k))
+        Enzyme.autodiff(
+            Reverse, dyn_matmul!, Const,
+            Const(jl(zeros(m, n))),
+            BatchDuplicated(jl(randn(m, k)), (dA1, dA2)), Const(jl(randn(k, n))),
+        )
+        @test all(collect(dA1) .≈ 7.0)
+        @test all(collect(dA2) .≈ -2.0)
     end
 
     # The same operand plain and transposed, both products matrix-vector: two


### PR DESCRIPTION
`EnzymeRules.augmented_primal` for the GPUArrays `generic_matmatmul!` /
`generic_matvecmul!` rules read `out.dval` whenever `needs_shadow(config)`,
which errors with `type Const has no field dval` when the output buffer is
`Const`:

```
type Const has no field dval
```

That happens when the rule is reached through a dynamic dispatch, which some
GPUArrays versions emit out of `mul!`. `runtime_generic_augfwd` guesses the
call's return activity from its return type alone, so the rule is asked for a
shadow of the output whatever C's own activity is. The error surfaces at the
`llvmcall` in `enzyme_call` with none of the rule's own frames, since the
augmented-forward function is separately JIT'd.

A `Const` output has no shadow to hand back, so give it a freshly zeroed
buffer, one per batch element. Returning the primal instead would alias the
two: nothing downstream re-checks `dval === val` unless runtime activity is
on, so once the returned value is consumed the consumer's reverse pass
accumulates into the shadow and silently leaves that cotangent in the user's
`Const` buffer — and at width > 1 every batch element would share one array.
A constant's derivative is zero, and the rule's own reverse returns early on a
`Const` C, so the buffer is only ever a sink.

All four matmatmul/matvecmul rules share `_augreturn`, so all four are covered.

### Tests

`test/ext/jlarrays.jl` gets a "Const output buffer, dynamic dispatch" testset:
the erroring call at width 1 and 2, plus a chained `R = dyn_gemm!(C, A, B);
mul!(D, R, E)` that consumes the returned value and asserts the `Const` buffer
still holds `A·B` afterwards. 36/36 pass with the fix; the chained assertions
fail if the shadow aliases the primal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
