### PR TITLE
Type Julia's by-value stack slots from their copy source

### DIFF
--- a/src/absint.jl
+++ b/src/absint.jl
@@ -1081,3 +1081,139 @@ function abs_cstring(@nospecialize(arg::LLVM.Value))::Tuple{Bool, String}
         end
     return (false, "")
 end
+
+"""
+    julia_type_at_offset(T, offset, size)
+
+Return the Julia type of the inline sub-object of `T` which starts at byte `offset` within
+`T` and is `size` bytes long, or `nothing` if `T` contains no such sub-object.
+"""
+function julia_type_at_offset(
+        @nospecialize(T::Type),
+        offset::Int,
+        size::Int,
+    )::Union{Nothing, Type}
+    # Bounded since each step descends into a strictly smaller inline field.
+    for _ in 1:64
+        if !Base.isconcretetype(T)
+            return nothing
+        end
+        if offset == 0 && actual_size(T) == size
+            return T
+        end
+        # Descend into the unique inline field which fully contains [offset, offset+size).
+        found = false
+        for i in 1:typed_fieldcount(T)
+            ft = typed_fieldtype(T, i)
+            if isghostty(ft) || !Base.isconcretetype(ft) || !Base.allocatedinline(ft)
+                continue
+            end
+            fo = typed_fieldoffset(T, i)
+            if offset >= fo && offset + size <= fo + actual_size(ft)
+                T = ft
+                offset -= fo
+                found = true
+                break
+            end
+        end
+        if !found
+            return nothing
+        end
+    end
+    return nothing
+end
+
+"""
+    stack_slot_julia_type(inst)
+
+Recover the Julia type of a stack slot that Julia allocated for a by-value copy
+of an inline sub-object of some other object (`y = x.fld`), by looking at where the slot's
+contents are copied from. Returns `nothing` unless every copy into the slot agrees.
+
+Such slots carry no type information of their own, yet on Julia 1.12+ the words holding GC
+pointers are poisoned (`memset 0xff` / `store -1`) rather than stored, since the pointers
+themselves are passed separately in the inline-roots array. Type analysis therefore ends up
+with holes precisely at the pointer fields, and cannot type the poisoning memsets.
+"""
+function stack_slot_julia_type(inst::LLVM.AllocaInst)::Union{Nothing, Type}
+    at = LLVM.LLVMType(LLVM.API.LLVMGetAllocatedType(inst))
+    # An `[N x ptr addrspace(10)]` slot is an inline-roots array, not a value copy.
+    if CountTrackedPointers(at).count != 0
+        return nothing
+    end
+    dl = LLVM.datalayout(LLVM.parent(LLVM.parent(LLVM.parent(inst))))
+    asize = Int(LLVM.sizeof(dl, at))
+    if asize == 0
+        return nothing
+    end
+    res = nothing
+    offty = LLVM.IntType(8 * sizeof(Int))
+    memcpy_id = LLVM.Intrinsic("llvm.memcpy").id
+    memmove_id = LLVM.Intrinsic("llvm.memmove").id
+    todo = Tuple{LLVM.Value, Int}[(inst, 0)]
+    while length(todo) != 0
+        v, off = pop!(todo)
+        for use in LLVM.uses(v)
+            u = LLVM.user(use)
+            if isa(u, LLVM.BitCastInst) || isa(u, LLVM.AddrSpaceCastInst)
+                push!(todo, (u, off))
+                continue
+            end
+            if isa(u, LLVM.GetElementPtrInst) &&
+                    all(Base.Fix2(isa, LLVM.ConstantInt), operands(u)[2:end])
+                b = LLVM.IRBuilder()
+                position!(b, u)
+                off2 = API.EnzymeComputeByteOffsetOfGEP(b, u, offty)
+                if isa(off2, LLVM.ConstantInt)
+                    push!(todo, (u, off + convert(Int, off2)))
+                end
+                continue
+            end
+
+            srcptr = nothing
+            if isa(u, LLVM.StoreInst) && operands(u)[2] == v
+                val = operands(u)[1]
+                # Only raw-bits copies say anything about the slot's layout. A stored
+                # pointer means this is Julia's inline-roots array (or a similar list of
+                # roots), which holds the GC pointers of some other value rather than a
+                # copy of it, and whose offsets therefore say nothing about that value.
+                if isa(val, LLVM.LoadInst) && !isa(value_type(val), LLVM.PointerType)
+                    srcptr = operands(val)[1]
+                end
+            elseif isa(u, LLVM.CallInst) && length(operands(u)) >= 3 && operands(u)[1] == v
+                cfn = LLVM.called_operand(u)
+                if isa(cfn, LLVM.Function)
+                    intr = LLVM.API.LLVMGetIntrinsicID(cfn)
+                    if intr == memcpy_id || intr == memmove_id
+                        srcptr = operands(u)[2]
+                    end
+                end
+            end
+            if srcptr === nothing
+                continue
+            end
+
+            sbase, soff = get_base_and_offset(srcptr)
+            legal, sty, sbyref = abs_typeof(sbase)
+            if !legal ||
+                    !(sbyref == GPUCompiler.MUT_REF || sbyref == GPUCompiler.BITS_REF) ||
+                    !Base.isconcretetype(sty)
+                continue
+            end
+            delta = soff - off
+            if delta < 0
+                continue
+            end
+            cand = julia_type_at_offset(sty, delta, asize)
+            if cand === nothing
+                continue
+            end
+            if res === nothing
+                res = cand
+            elseif res != cand
+                return nothing
+            end
+        end
+    end
+    return res
+end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -5935,6 +5935,20 @@ function GPUCompiler.compile_unhooked(output::Symbol, job::CompilerJob{<:EnzymeT
                     end
                 end
             end
+            if !haskey(metadata(inst), "enzymejl_allocart")
+                # Julia gives a by-value read of an inline sub-object out of another object
+                # (`y = x.fld`) its own stack slot, which carries no type of its own. On 1.12+
+                # the words of such a slot which hold GC pointers are poisoned (memset 0xff /
+                # store -1) rather than stored, as the pointers are passed separately in the
+                # inline-roots array, so type analysis is left with holes exactly at the
+                # pointer fields and cannot type the poisoning memsets. Recover the slot's
+                # Julia type from the typed object its contents are copied out of.
+                RT = stack_slot_julia_type(inst)
+                if RT !== nothing
+                    metadata(inst)["enzymejl_allocart"] = MDNode(LLVM.Metadata[MDString(string(convert(UInt, unsafe_to_pointer(RT))))])
+                    metadata(inst)["enzymejl_allocart_name"] = MDNode(LLVM.Metadata[MDString(string(RT))])
+                end
+            end
         end
 
         if !API.HasFromStack(inst) &&

--- a/test/absint.jl
+++ b/test/absint.jl
@@ -216,3 +216,39 @@ end
         @test Enzyme.gradient(set_runtime_activity(Reverse), absint_run_world, [1.0])[1] ≈ [3.0]
     end
 end
+
+struct TypeAtOffsetInner
+    p1::Vector{Float64}
+    p2::Vector{Float64}
+    b::Bool
+end
+
+struct TypeAtOffsetOuter
+    n::Int
+    o1::TypeAtOffsetInner
+    o2::TypeAtOffsetInner
+    tail::Vector{Float64}
+end
+
+mutable struct TypeAtOffsetBox
+    f::TypeAtOffsetOuter
+    u0::Vector{Float64}
+end
+
+@testset "julia_type_at_offset" begin
+    jtao = Enzyme.Compiler.julia_type_at_offset
+    # The whole object.
+    @test jtao(TypeAtOffsetOuter, 0, sizeof(TypeAtOffsetOuter)) === TypeAtOffsetOuter
+    # An inline field read out of a heap object, which is what Julia gives its own
+    # (otherwise untyped) stack slot on a by-value `x.fld`.
+    @test jtao(TypeAtOffsetBox, 0, sizeof(TypeAtOffsetOuter)) === TypeAtOffsetOuter
+    # A nested inline field.
+    o1 = fieldoffset(TypeAtOffsetOuter, 2)
+    @test jtao(TypeAtOffsetOuter, Int(o1), sizeof(TypeAtOffsetInner)) === TypeAtOffsetInner
+    @test jtao(TypeAtOffsetOuter, 0, sizeof(Int)) === Int
+    # Boxed fields are not inline, so nothing of theirs lives in the slot.
+    @test jtao(TypeAtOffsetOuter, Int(o1), sizeof(Int)) === nothing
+    # Ranges which do not line up with any inline sub-object.
+    @test jtao(TypeAtOffsetOuter, 1, sizeof(TypeAtOffsetOuter)) === nothing
+    @test jtao(TypeAtOffsetOuter, 0, sizeof(TypeAtOffsetOuter) + 8) === nothing
+end

--- a/test/rooted_args.jl
+++ b/test/rooted_args.jl
@@ -66,3 +66,69 @@ end
 	)
 end
 
+# On Julia 1.12+, a by-value read of a large inline immutable field containing GC pointers
+# out of a heap object (`f = prob.f`) is lowered by loading the pointer words into the
+# separate inline-roots array and poisoning the corresponding words of the value's own stack
+# slot with 0xff (`llvm.memset ... i8 -1` / `store i64 -1`). That slot carries no type
+# information of its own, so type analysis is left with holes exactly at the pointer fields
+# unless Enzyme recovers the slot's Julia type from the object it was copied out of.
+# xref https://github.com/EnzymeAD/Enzyme.jl/issues/3433
+struct PoisonSlotInner
+    p1::Vector{Float64}
+    p2::Vector{Float64}
+end
+
+struct PoisonSlotFn
+    n::Int
+    o1::PoisonSlotInner
+    o2::PoisonSlotInner
+    o3::PoisonSlotInner
+    o4::PoisonSlotInner
+    m::Int
+end
+
+mutable struct PoisonSlotProb
+    f::PoisonSlotFn
+    u0::Vector{Float64}
+end
+
+# Recursive so that it survives LLVM inlining and keeps an interior pointer of the slot
+# escaping, which is what stops the poisoning writes from being eliminated as dead.
+@noinline function poison_slot_inner_dot(a::PoisonSlotInner, x::Vector{Float64}, k::Int)
+    s = 0.0
+    for i in eachindex(x)
+        s += a.p1[i] * x[i] + a.p2[i] * x[i]
+    end
+    if k > 0
+        s += poison_slot_inner_dot(a, x, k - 1)
+    end
+    return s
+end
+
+@noinline function poison_slot_use(f::PoisonSlotFn, x::Vector{Float64})
+    return poison_slot_inner_dot(f.o1, x, 1) + f.n * x[1] + f.m * x[2]
+end
+
+function poison_slot_loss(prob::PoisonSlotProb, x::Vector{Float64})
+    f = prob.f
+    return poison_slot_use(f, x)
+end
+
+@testset "By-value inline struct read out of heap object" begin
+    inner = PoisonSlotInner([1.0, 2.0], [3.0, 4.0])
+    prob = PoisonSlotProb(
+        PoisonSlotFn(3, inner, inner, inner, inner, 5),
+        [0.0, 0.0],
+    )
+    x = [1.0, 2.0]
+    dx = zero(x)
+    autodiff(
+        set_runtime_activity(Reverse),
+        poison_slot_loss,
+        Active,
+        Const(prob),
+        Duplicated(x, dx),
+    )
+    # d/dx of 2 * sum(p1 .* x .+ p2 .* x) + n * x[1] + m * x[2]
+    @test dx ≈ [2 * (1.0 + 3.0) + 3, 2 * (2.0 + 4.0) + 5]
+end


### PR DESCRIPTION
Fixes #3433.

## What goes wrong

On Julia 1.12, `f = prob.f` for a large inline immutable field containing GC pointers is lowered to: load the pointer words into a **separate inline-roots array**, and fill the corresponding words of the value's own stack slot with 0xFF poison (`llvm.memset(..., i8 -1, ...)` / `store i64 -1`).

`getConstantAnalysis` already types `-1` as `Anything`, so the `store` form is harmless. The memset form reaches `AdjointGenerator::visitMemSetInst`, which only special-cases **zero** fills into undef memory, so an all-0xFF fill over a range type analysis could not type raises `EnzymeNoTypeError`:

```
Cannot deduce type of memset
  call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(16) %8,
                                i8 -1, i64 16, i1 false)
```

We already have the machinery that should have typed it — `enzyme_truetype` is attached to any memset whose destination base has a known Julia type, and `enzyme_type` parameter attributes carry the full type tree of by-ref arguments. Neither reached this slot:

* only **sret** slots are given an `enzymejl_allocart`, so `abs_typeof` fails on an ordinary by-value slot; and
* the typed consumer — here `get_initial_values`, which takes `prob.f` by value — is inlined by our own pipeline, so by the time the metadata pass runs the 304 byte slot is only ever GEP'd field by field. In the real failing IR `%"prob::ODEProblem.f"` is never passed whole to anything.

So the only type information left is what the surviving integer stores imply, and the reconstructed type has holes exactly where the poison lands.

## The fix

Recover the slot's Julia type from the object its contents are copied out of.

`stack_slot_julia_type` walks the alloca's uses through constant GEPs, finds the raw-bits stores and memcpys into it, resolves each source with `abs_typeof` + `get_base_and_offset`, and maps the common offset delta to an inline sub-object via `julia_type_at_offset`. All copies must agree, and the sub-object's size must match the slot exactly. The result is recorded as `enzymejl_allocart`, which the existing `enzyme_type` / `enzyme_truetype` paths then pick up unchanged.

Two guards matter. Julia's inline-roots array is *also* filled from a typed object, so it is excluded both by rejecting slots whose allocated type contains tracked pointers and by only learning from stores of raw bits rather than of pointers. Without them the roots array is mistyped as the value whose roots it holds, which breaks `unique` and `median` on 1.12 with `IllegalTypeAnalysisException` — worth keeping in mind if this heuristic is ever loosened.

Note this declares the poisoned words `Pointer`, matching what we already do for the same data via the `enzyme_type` parameter attribute of a by-ref argument with inline roots.

## Verification

Reproducer from the issue (ModelingToolkit + SciMLSensitivity, Julia 1.12.4): fails before, both gradients complete after — `A = [9.58793917669597]`, `B = [-0.8565044979537432, -0.6399690778617317]`.

Correctness, not just absence of the error: with the solver at `abstol = reltol = 1e-12`, the Enzyme gradient matches central finite differences to ~2e-9 relative error. (A first FD check at the reproducer's own `reltol = 1e-3` showed 39% disagreement; that is FD noise off an adaptive solve, not a wrong derivative.)

Tests: 783/783 pass on 1.11, 436/436 on 1.12 (baseline 428, plus the 8 added here).

## On the tests

`test/absint.jl` covers `julia_type_at_offset` directly, and `test/rooted_args.jl` differentiates the by-value inline-struct read end to end through split reverse mode.

I could **not** reduce the memset itself to a standalone test that fails without this change, and want to flag that rather than imply the tests are a regression guard for the reported failure. Reproducing it needs Julia to materialize the whole-struct slot for an out-of-line call that LLVM then inlines, leaving interior pointers escaping; `@noinline` sets LLVM `noinline` too, so the callee never gets inlined, and without it Julia inlines the read and the slot never materializes. Every synthetic shape I tried ended with either individual `store i64 -1` (which types fine) or no slot at all. The reporter hit the same wall. So the added tests pass before this change as well — they exercise the new path and guard it, but the issue's own failure still needs the SciML stack to reproduce.

## Reproducer caveat

In the package versions I resolved (ModelingToolkit v11.39.1, SciMLBase v3.49.2) gradient B fails on unpatched Enzyme **even when run alone**, so the order dependence in the issue's table does not reproduce here. That also means I could not cross-check the gradient against unpatched Enzyme, hence the finite-difference check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdDfztkEjWwGdcvLvSvg83
