### PR TITLE
Support forward Jacobians inside Reactant kernels

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -55,6 +55,7 @@ jobs:
           - Flux
           - Lux
           - Oceananigans
+          - Reactant
           - SciML
           - KernelAbstractions
           - MatrixAlgebraKit

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -500,6 +500,14 @@ end
 	res
 end
 
+@inline function tupstack(
+        data::Tuple{Vararg{A}},
+        outshape::Tuple{Vararg{Int}},
+        inshape::Tuple{Vararg{Int}},
+    ) where {A <: AbstractArray}
+    return reshape(stack(data), (outshape..., inshape...))
+end
+
 @inline specialize_output(output, input) = output
 
 """

--- a/test/integration/Reactant/Project.toml
+++ b/test/integration/Reactant/Project.toml
@@ -1,0 +1,12 @@
+[deps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+Enzyme = {path = "../../.."}
+EnzymeCore = {path = "../../../lib/EnzymeCore"}
+
+[compat]
+Reactant = "0.2.283"

--- a/test/integration/Reactant/runtests.jl
+++ b/test/integration/Reactant/runtests.jl
@@ -1,0 +1,11 @@
+using Enzyme: Enzyme
+using Reactant: Reactant, @jit
+using Test
+
+square(x) = x .^ 2
+enzyme_jacobian(x) = only(Enzyme.jacobian(Enzyme.Forward, square, x))
+
+@testset "Forward Jacobian" begin
+    x = Reactant.to_rarray(Float32[1, 2])
+    @test Array(@jit enzyme_jacobian(x)) == Float32[2 0; 0 4]
+end


### PR DESCRIPTION
> Closed by @wsmoses in favor of implementing the traced-array dispatches in Reactant: https://github.com/EnzymeAD/Reactant.jl/pull/1882.
>
> If this PR is revisited, please ignore it until it has been reviewed by @ChrisRackauckas.

## Closed head

At the retained PR head `d4c34bc9`, forward-mode `Enzyme.jacobian` assembled array-valued derivatives with a `tupstack` method restricted to ordinary `Array`s. The PR added an `AbstractArray` fallback using `stack` and `reshape`, while preserving the optimized `Array` specialization.

The exact new test failed against upstream `a865b354` and passed on Julia 1.10.12, 1.11.9, and 1.12.6. The focused `sugar` suite passed 226 non-broken assertions, and the ordinary-array benchmark retained 8,984-byte allocation counts.

## Follow-up investigation

The Enzyme-only follow-up at https://github.com/ChrisRackauckas-Claude/Enzyme.jl/commit/b270a2da942f0968e763c2a1c75aa0aa0bd86a7f is on the fork branch but is not part of this closed PR. It additionally makes chunked forward Jacobians traceable without changing ordinary-array performance. With unmodified DifferentiationInterface main, its out-of-place `AutoEnzyme` Jacobian passes inside Reactant; DI's generic in-place Jacobian still constructs basis arrays with scalar indexing, so the current NonlinearSolve work retains its direct-pushforward wrapper for that case.

No replacement Enzyme PR was opened because the maintainer explicitly selected the Reactant-side solution.

## Links

- Reactant-side work: https://github.com/EnzymeAD/Reactant.jl/pull/1882
- DifferentiationInterface issue: https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1066
- Closed DI implementation attempt: https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1067
- NonlinearSolve integration: https://github.com/SciML/NonlinearSolve.jl/pull/1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a07-4f58-7d73-90d2-5e7aa3ba9fd7
