### PR TITLE
GPU gradient fixes

### DIFF
--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -7,11 +7,11 @@ using Enzyme: EnzymeRules
 # Complex is handled here because the shadow operations are element-wise: zeroing is a
 # `memset` sized by `sizeof(T)`, and accumulation is a broadcast, both of which are
 # agnostic to the real/complex split.
-function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
+function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T}
     Base.Libc.memset(ptr + off * sizeof(T), 0, n * sizeof(T))
     return nothing
 end
-function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
+function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T}
     bytes = reinterpret(CuPtr{UInt8}, ptr + off * sizeof(T))
     CUDA.memset(bytes, UInt8(0), n * sizeof(T))
     return nothing
@@ -67,6 +67,15 @@ end
 
 @inline function _shadow(x, config, batch)
     return EnzymeRules.width(config) == 1 ? x.dval : x.dval[batch]
+end
+
+# With `set_runtime_activity` Enzyme hands a rule a `Duplicated` whose shadow is the primal
+# itself, for a value it could not prove inactive statically. Accumulating a cotangent into
+# such a shadow, or zeroing it, writes to the primal data.
+@inline function _active_shadow(x, config, batch)
+    x isa Const && return nothing
+    dval = _shadow(x, config, batch)
+    return dval === x.val ? nothing : dval
 end
 
 # This rule should _NOT_ be needed. Without it there appears to be
@@ -148,14 +157,13 @@ for (DstPtr, SrcPtr) in PTR_COPY_DIRECTIONS
 		src::Annotation{<:$SrcPtr{T}},
                 n::Const;
                 kwargs...,
-            ) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
+            ) where {RT, T}
             if !(dest isa Const)
                 for batch in 1:EnzymeRules.width(config)
-                    ddest = _shadow(dest, config, batch)
-		    if !(src isa Const)
-			dsrc = _shadow(src, config, batch)
-    			_accumulate!(dsrc, 0, ddest, 0, n.val)
-                    end
+                    ddest = _active_shadow(dest, config, batch)
+                    isnothing(ddest) && continue
+                    dsrc = _active_shadow(src, config, batch)
+                    isnothing(dsrc) || _accumulate!(dsrc, 0, ddest, 0, n.val)
                     _zero!(ddest, 0, n.val)
                 end
             end
@@ -180,7 +188,7 @@ for (DstArr, SrcArr) in ARRAY_COPY_DIRECTIONS
 		doffs::Const,
 		src::Annotation{<:$SrcArr{T}},
 		soffs::Const,
-                n::Const) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
+                n::Const) where {RT, T}
             func.val(dest.val, doffs.val, src.val, soffs.val, n.val)
             primal = EnzymeRules.needs_primal(config) ? dest.val : nothing
             shadow = if !(RT <: Const) && EnzymeRules.needs_shadow(config) &&
@@ -201,15 +209,17 @@ for (DstArr, SrcArr) in ARRAY_COPY_DIRECTIONS
 		doffs::Const,
 		src::Annotation{<:$SrcArr{T}},
 		soffs::Const,
-                n::Const) where {RT, T <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
+                n::Const) where {RT, T}
             if !(dest isa Const)
                 for batch in 1:EnzymeRules.width(config)
-                    ddest = _shadow(dest, config, batch)
-		    if !(src isa Const)
-			dsrc = _shadow(src, config, batch)
-			_accumulate!(@view(dsrc[soffs.val:soffs.val+n.val-1]), @view(ddest[doffs.val:doffs.val+n.val-1]))
+                    ddest = _active_shadow(dest, config, batch)
+                    isnothing(ddest) && continue
+                    dsrc = _active_shadow(src, config, batch)
+                    if !isnothing(dsrc)
+                        _accumulate!(@view(dsrc[soffs.val:soffs.val+n.val-1]),
+                                     @view(ddest[doffs.val:doffs.val+n.val-1]))
                     end
-		    _zero!(pointer(ddest, doffs.val), 0, n.val)
+                    _zero!(pointer(ddest, doffs.val), 0, n.val)
                 end
             end
             return (nothing, nothing, nothing, nothing, nothing)

--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -4,14 +4,23 @@ using CUDA
 using Enzyme
 using Enzyme: EnzymeRules
 
-# Complex is handled here because the shadow operations are element-wise: zeroing is a
-# `memset` sized by `sizeof(T)`, and accumulation is a broadcast, both of which are
-# agnostic to the real/complex split.
+# The requirement of `T` is that all-bits-zero is a valid zero cotangent and that `+`
+# accumulates cotangents. This holds for floats, `Complex` of floats, and for isbits
+# structs built from them, including ones that mix floats with integers/`Bool`s.
+@inline function _check_shadow_eltype(::Type{T}) where {T}
+    isbitstype(T) || throw(ArgumentError(
+        "Enzyme's CUDA copy rules zero and accumulate shadows with a memset and a " *
+        "broadcast, which need an isbits element type, but got $T"))
+    return nothing
+end
+
 function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T}
+    _check_shadow_eltype(T)
     Base.Libc.memset(ptr + off * sizeof(T), 0, n * sizeof(T))
     return nothing
 end
 function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T}
+    _check_shadow_eltype(T)
     bytes = reinterpret(CuPtr{UInt8}, ptr + off * sizeof(T))
     CUDA.memset(bytes, UInt8(0), n * sizeof(T))
     return nothing

--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -4,9 +4,10 @@ using CUDA
 using Enzyme
 using Enzyme: EnzymeRules
 
-# The requirement of `T` is that all-bits-zero is a valid zero cotangent and that `+`
-# accumulates cotangents. This holds for floats, `Complex` of floats, and for isbits
-# structs built from them, including ones that mix floats with integers/`Bool`s.
+# The requirement of `T` is that it is isbits, so that a shadow can be zeroed leaf by leaf
+# and accumulated with a broadcast, and that `+` adds cotangents. This holds for floats,
+# `Complex` of floats, and for isbits structs built from them, including ones that mix
+# floats with integers/`Bool`s.
 @inline function _check_shadow_eltype(::Type{T}) where {T}
     isbitstype(T) || throw(ArgumentError(
         "Enzyme's CUDA copy rules zero and accumulate shadows with a memset and a " *
@@ -14,15 +15,53 @@ using Enzyme: EnzymeRules
     return nothing
 end
 
+# All-bits-zero is the correct zero cotangent for a float, for `Complex` of floats and for
+# an isbits aggregate built only out of those, so those are zeroed with a memset. A type
+# with any other leaf - an index, a flag, an enum - is not, since only the differentiable
+# fields should be zeroed, so it takes the element-wise path below.
+@generated _memset_zeroable(::Type{T}) where {T} = _memset_zeroable_impl(T)
+
+function _memset_zeroable_impl(::Type{T}) where {T}
+    (T <: AbstractFloat || T <: Complex{<:AbstractFloat}) && return true
+    (isbitstype(T) && !isprimitivetype(T)) || return false
+    return all(_memset_zeroable_impl, fieldtypes(T))
+end
+
+# What `make_zero!` does, restricted to isbits data: zero the floating point leaves and
+# leave everything else as it is.
+@inline _shadow_zero(x::AbstractFloat) = zero(x)
+@inline _shadow_zero(x::Complex{<:AbstractFloat}) = zero(x)
+@inline _shadow_zero(x::Tuple) = map(_shadow_zero, x)
+@inline _shadow_zero(x::NamedTuple) = NamedTuple{keys(x)}(map(_shadow_zero, values(x)))
+@inline _shadow_zero(x) = _shadow_zero_fields(x)
+
+@generated function _shadow_zero_fields(x::T) where {T}
+    (isbitstype(T) && fieldcount(T) > 0) || return :x
+    return Expr(:new, T, (:(_shadow_zero(getfield(x, $i))) for i in 1:fieldcount(T))...)
+end
+
+@inline function _zero_elements!(arr)
+    arr .= _shadow_zero.(arr)
+    return nothing
+end
+
 function _zero!(ptr::Ptr{T}, off::Integer, n::Integer) where {T}
     _check_shadow_eltype(T)
-    Base.Libc.memset(ptr + off * sizeof(T), 0, n * sizeof(T))
+    if _memset_zeroable(T)
+        Base.Libc.memset(ptr + off * sizeof(T), 0, n * sizeof(T))
+    else
+        _zero_elements!(unsafe_wrap(Array, ptr + off * sizeof(T), n; own = false))
+    end
     return nothing
 end
 function _zero!(ptr::CuPtr{T}, off::Integer, n::Integer) where {T}
     _check_shadow_eltype(T)
-    bytes = reinterpret(CuPtr{UInt8}, ptr + off * sizeof(T))
-    CUDA.memset(bytes, UInt8(0), n * sizeof(T))
+    if _memset_zeroable(T)
+        bytes = reinterpret(CuPtr{UInt8}, ptr + off * sizeof(T))
+        CUDA.memset(bytes, UInt8(0), n * sizeof(T))
+    else
+        _zero_elements!(unsafe_wrap(CuArray, ptr + off * sizeof(T), n; own = false))
+    end
     return nothing
 end
 

--- a/ext/EnzymeCUDAExt.jl
+++ b/ext/EnzymeCUDAExt.jl
@@ -267,7 +267,7 @@ for (DstArr, SrcArr) in ARRAY_COPY_DIRECTIONS
                         _accumulate!(@view(dsrc[soffs.val:soffs.val+n.val-1]),
                                      @view(ddest[doffs.val:doffs.val+n.val-1]))
                     end
-                    _zero!(pointer(ddest, doffs.val), 0, n.val)
+                    GC.@preserve ddest _zero!(pointer(ddest, doffs.val), 0, n.val)
                 end
             end
             return (nothing, nothing, nothing, nothing, nothing)

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -732,7 +732,7 @@ code, as well as high-order differentiation.
         end
     else
         @assert A isa DataType
-        rt = A
+        rt = eltype(A)
         if rt == Union{}
 	    throw(ErrorException("Return type inferred to be Union{}. Giving up."))
         end

--- a/test/core/deferred.jl
+++ b/test/core/deferred.jl
@@ -66,6 +66,31 @@ using Enzyme, Test
 
     end
 
+    @testset "Explicit return activity" begin
+        f(x) = x[1] * x[2] + x[2]
+        x = [3.0, 5.0]
+
+        dx_bare, dx_explicit = zeros(2), zeros(2)
+        Enzyme.autodiff_deferred(Reverse, Const(f), Active, Duplicated(x, dx_bare))
+        Enzyme.autodiff_deferred(Reverse, Const(f), Active{Float64}, Duplicated(x, dx_explicit))
+        @test dx_bare == [5.0, 4.0]
+        @test dx_explicit == dx_bare
+
+        dx_bare, dx_explicit = zeros(2), zeros(2)
+        _, primal_bare = Enzyme.autodiff_deferred(
+            ReverseWithPrimal, Const(f), Active, Duplicated(x, dx_bare))
+        _, primal_explicit = Enzyme.autodiff_deferred(
+            ReverseWithPrimal, Const(f), Active{Float64}, Duplicated(x, dx_explicit))
+        @test primal_bare == 20.0
+        @test primal_explicit == primal_bare
+        @test dx_explicit == dx_bare
+
+        # A scalar argument, so the derivative comes back through the return value
+        g(y) = y * y
+        @test Enzyme.autodiff_deferred(Reverse, Const(g), Active{Float64}, Active(3.0))[1][1] ==
+              Enzyme.autodiff_deferred(Reverse, Const(g), Active, Active(3.0))[1][1] == 6.0
+    end
+
     @testset "Deferred upgrade" begin
         function gradsin(x)
             return gradient(Reverse, sin, x)[1]

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -3,6 +3,14 @@ using Enzyme
 using LinearAlgebra: mul!, dot, Symmetric
 using Test
 
+# A shadow element that mixes a cotangent with a field that is not one
+struct IndexedVal
+    idx::Int32
+    val::Float64
+end
+
+Base.:+(a::IndexedVal, b::IndexedVal) = IndexedVal(a.idx, a.val + b.val)
+
 @testset "CUDA memory copies" begin
     grad_roundtrip = function (to_gpu)
         x = Float32[1, 2, 3]
@@ -111,6 +119,29 @@ using Test
         end
 
         @test ptr_copy(C) == ptr_copy(R)
+    end
+    @testset "shadow with a non-differentiable field" begin
+        # Only the differentiable part of a shadow is zeroed once its cotangent has been
+        #   consumed: an index is not a cotangent, and `make_zero!` leaves it alone
+        n = 4
+        copy_kernel = (dst, src) -> (copyto!(dst, src); nothing)
+        src = CuArray([IndexedVal(Int32(i), Float64(i)) for i in 1:n])
+        dst = CuArray([IndexedVal(Int32(0), 0.0) for _ in 1:n])
+        dsrc = CuArray([IndexedVal(Int32(10 + i), 0.0) for i in 1:n])
+        ddst = CuArray([IndexedVal(Int32(20 + i), Float64(i)) for i in 1:n])
+
+        Enzyme.autodiff(
+            Reverse, Const(copy_kernel), Const,
+            Duplicated(dst, ddst), Duplicated(src, dsrc),
+        )
+        CUDA.synchronize()
+
+        hsrc, hdst = Array(dsrc), Array(ddst)
+        # The cotangent moved from the destination to the source
+        @test [x.val for x in hsrc] == Float64.(1:n)
+        # The destination cotangent was consumed, but the index was left as it was
+        @test all(iszero, [x.val for x in hdst])
+        @test [Int(x.idx) for x in hdst] == 20 .+ collect(1:n)
     end
     @testset "unified memory" begin
         @test grad_roundtrip(x -> cu(x; unified = true)) == Float32[2, 4, 6]


### PR DESCRIPTION
I am getting Molly's gradients working on GPU and had to change the following to get things to work:

1. `autodiff_deferred` mishandles an explicit `Active{T}` return type (`Enzyme/src/Enzyme.jl`). It has `rt = A` where the non-deferred `autodiff` has `eltype(A0)`. With `A = Active{Float64}`, `rt` becomes `Active{Float64}`, so `default_adjoint(rt)` falls into its "not a floating-like value" branch and the seed is never produced - which on a GPU surfaces as an `InvalidIRError` about a `string(...)` call rather than an error message. Fixed here with `rt = eltype(A)`.

2. Enzyme's CUDA copy rules are bounded to `T <: AbstractFloat` (`Enzyme/ext/EnzymeCUDAExt.jl`, the `reverse` halves and the `_zero!` helpers). The `augmented_primal` halves have no such bound, so a host↔device copy of anything else - a `Bool` array, or a `CuArray{SVector{3,Float64}}` of coordinates - gets through the forward pass and then has no `reverse` method. Relaxed here to any eltype; the bodies are a memset and `dst .+= src`, both already correct for those types, and they are skipped entirely when the argument is `Const`.

3. Checking `isa Const` is not enough. With `set_runtime_activity` Enzyme hands a rule a `Duplicated` whose `dval` is the `val`, for a value it could not prove inactive statically. `_accumulate!` then adds the cotangent into the primal, and `_zero!` zeroes a primal. Fixed with an `_active_shadow` helper that returns `nothing` when `dval === x.val`, and skipping both operations in that case.

Co-authored with Claude.