### PR TITLE
Fix batched setfield shadow return dominance

### DIFF
--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1839,21 +1839,26 @@ end
     common_jl_getfield_rev(1, B, orig, gutils, tape)
 end
 
-function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
+function store_setfield_shadow_return!(B, orig, gutils, normalR, shadowR)
     normal =
         (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
     if shadowR != C_NULL && normal !== nothing
         width = get_width(gutils)
-        shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
-            if width == 1
-                shadowres = normal
-            else
+        shadowres = normal
+        if width != 1
+            position!(B, LLVM.Instruction(LLVM.API.LLVMGetNextInstruction(normal)))
+            shadowres =
+                UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
+            for idx in 1:width
                 shadowres = insert_value!(B, shadowres, normal, idx - 1)
             end
         end
         unsafe_store!(shadowR, shadowres.ref)
     end
+    return nothing
+end
+
+function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
 
     origops = @view operands(orig)[offset:end]
     if !is_constant_value(gutils, origops[4])
@@ -1896,6 +1901,7 @@ function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
             need_result = false
         ) #=lookup=#
     end
+    store_setfield_shadow_return!(B, orig, gutils, normalR, shadowR)
     return false
 end
 
@@ -1926,21 +1932,6 @@ function rt_jl_setfield_rev(dptr::T, idx, ::Val{isconst}, val, dval) where {T,is
 end
 
 function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR)
-
-    normal =
-        (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
-    if shadowR != C_NULL && normal !== nothing
-        width = get_width(gutils)
-        shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
-            if width == 1
-                shadowres = normal
-            else
-                shadowres = insert_value!(B, shadowres, normal, idx - 1)
-            end
-        end
-        unsafe_store!(shadowR, shadowres.ref)
-    end
 
     origops = @view operands(orig)[offset:end]
     if !is_constant_value(gutils, origops[2])
@@ -1974,6 +1965,7 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
             debug_from_orig!(gutils, cal, orig)
         end
     end
+    store_setfield_shadow_return!(B, orig, gutils, normalR, shadowR)
 
     return false
 end

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -309,6 +309,13 @@ end
         Enzyme.Const(loss_setproperty_mwe),
         Enzyme.Duplicated([0.5], [1.0]),
     ) == (1.0,)
+
+    result = Enzyme.autodiff(
+        Enzyme.set_runtime_activity(Enzyme.Forward),
+        Enzyme.Const(loss_setproperty_mwe),
+        Enzyme.BatchDuplicated([0.5], ([1.0], [2.0])),
+    )
+    @test Tuple(result[1]) == (1.0, 2.0)
 end
 
 # Issue 3425: an `Active` return whose inferred type is abstract routes combined


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The forward and augmented-forward rules for type-unstable `setfield!` built a width-wide shadow return from the primal return before the primal instruction had been placed in the generated function. With batch width greater than one, the resulting `insertvalue` instructions used a value that did not dominate them and LLVM aborted verification.

This change materializes the shadow-return aggregate after the derivative mutation logic and positions its builder immediately after the primal return instruction. The shared helper keeps the forward and augmented-forward rules consistent.

## Failing before

I ran the new width-2 regression against unmodified `a865b354` on Julia 1.12.7:

```julia
mutable struct SetpropertyBox
    x::Vector{Float64}
end
function loss_setproperty_mwe(x)
    box = SetpropertyBox(zeros(length(x)))
    setproperty!(Base.inferencebarrier(box), Base.inferencebarrier(:x), x)
    return sum(abs2, box.x)
end
Enzyme.autodiff(
    Enzyme.set_runtime_activity(Enzyme.Forward),
    Enzyme.Const(loss_setproperty_mwe),
    Enzyme.BatchDuplicated([0.5], ([1.0], [2.0])),
)
```

The process aborted with exit code 134:

```text
Instruction does not dominate all uses!
  %jl_f_setfield_ret = call ... @jl_f_setfield ...
  %1 = insertvalue [2 x ptr addrspace(10)] undef, ptr addrspace(10) %jl_f_setfield_ret, 0
Instruction does not dominate all uses!
  %2 = insertvalue [2 x ptr addrspace(10)] %1, ptr addrspace(10) %jl_f_setfield_ret, 1
LLVM ERROR: function failed verification (4)
signal 6 (-6): Aborted
```

## Passing after

I reran the standalone MWE after the fix and observed:

```text
result = ((var"1" = 1.0, var"2" = 2.0),)
```

The same case is included in the existing runtime-activity `setproperty!` testset. I ran:

```bash
TMPDIR="$PWD/../.tmp" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --startup-file=no --project=test test/runtests.jl typeunstable
```

```text
Test Summary: | Pass  Total     Time
  Overall     |   35     35  5m03.0s
    SUCCESS
```

Additional local checks:

```text
../git-runic --julia ~/.juliaup/bin/julia --project ../.runic-env -f upstream/main
runic did not modify any files

git diff --unified=0 upstream/main -- | typos -
# no findings

git diff --check upstream/main
# no findings
```

## Not verified

I did not run the full Enzyme test suite, GPU tests, integration tests, or documentation build. This changes no public API or documentation.

## Reviewer attention

The builder is repositioned immediately after the primal return instruction only for batched shadow-return construction. Width-one behavior continues to reuse the primal value directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03f84-af17-7a90-955c-10b5d980e4da