### PR TITLE
Cap docs Documenter compat at 1.17

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,7 +10,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ChainRulesCore = "1"
-Documenter = "1"
+# Documenter 1.18 regressed on large `@raw` blocks (see #3494), which the Pluto
+# notebook page generates.
+Documenter = "~1.17"
 EnzymeTestUtils = "0.2"
 Literate = "2"
 PlutoStaticHTML = "7, 8"


### PR DESCRIPTION
The `Documentation` job has been failing on `main` and every PR since 2026-08-31:

```
ERROR: LoadError: PCRE compilation error: regular expression is too large at offset 2009062
  [6] find_block_in_file(code::String, file::String) @ Documenter .../utilities/utilities.jl:67
  [7] runner(::Type{Documenter.Expanders.RawBlocks}, ...) @ Documenter .../expander_pipeline.jl:1107
```

Documenter 1.18.0 rewrote the `@raw` block runner to go through `parse_codeblock_args`, so it now unconditionally calls `find_block_in_file`, which builds a regex out of the entire block body. PlutoStaticHTML's `documenter_output` emits the whole rendered `ignore_derivatives` notebook as one ~2 MB ` ```@raw html ` block, and PCRE refuses to compile a pattern that size. The last green docs build resolved Documenter 1.17.0; `docs/Project.toml` said `Documenter = "1"`, so CI picked up 1.18.0 on its own.

Caps the docs environment at `~1.17` to unbreak CI. #3494 tracks the underlying (presumably upstream) bug and lifting the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ng2z5ftFXgpCdmmYwL18K4
