### PR TITLE
Add @nospecialize to try_replace_constant_load!

### DIFF
--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -345,7 +345,7 @@ function check_ir!(interp, @nospecialize(job::CompilerJob), errors::Vector{IRErr
     return errors
 end
 
-function try_replace_constant_load!(inst::LLVM.Instruction; check_mutability::Bool=true, do_replace::Bool=true)::LLVM.Value
+function try_replace_constant_load!(@nospecialize(inst::LLVM.Instruction); check_mutability::Bool = true, do_replace::Bool = true)::LLVM.Value
     if !(isa(value_type(inst), LLVM.PointerType) && addrspace(value_type(inst)) == Tracked)
         return inst
     end


### PR DESCRIPTION
`check_ir!` materializes every instruction with `LLVM.Instruction(iter)`, which returns the concrete subtype, so `try_replace_constant_load!` gets specialized once per `LLVM.Instruction` subtype it ever sees. On a trivial first `Enzyme.gradient` that is 22 specializations and ~1.26 s of codegen, none of which the precompile workload can cover:

```
$ julia --trace-compile=stderr --trace-compile-timing ...
#=   67.5 ms =# precompile(Tuple{typeof(Core.kwcall), ..., typeof(Enzyme.Compiler.try_replace_constant_load!), LLVM.MulInst})
#=   59.9 ms =# precompile(Tuple{typeof(Core.kwcall), ..., typeof(Enzyme.Compiler.try_replace_constant_load!), LLVM.AddrSpaceCastInst})
#=   58.4 ms =# precompile(Tuple{typeof(Core.kwcall), ..., typeof(Enzyme.Compiler.try_replace_constant_load!), LLVM.XorInst})
... 19 more ...
```

The body only does `isa` tests and LLVM C-API calls, so the specializations buy nothing. `get_base_and_offset`, which it calls on the same value, is already `@nospecialize`d.

After this change a single `LLVM.Instruction` specialization is precompiled and the function no longer shows up in `--trace-compile` at all.

## Numbers

Wall time of a fresh process running

```julia
using Enzyme
@noinline store!(x, v) = (x .= v; nothing)
f(p, x) = (store!(x, p); sum(abs2, x))
Enzyme.gradient(Reverse, f, [3.0], Const(zeros(1)))
```

against the released `Enzyme_jll`, best of two runs each:

| Julia | before | after |
| --- | --- | --- |
| 1.11.9 | 5.90 s | 4.55 s |
| 1.12.7 | 9.30 s | 7.68 s |
| 1.13.0-rc4 | 5.32 s | 3.78 s |

(Note `@time` around the call reports ~0 s — the generated function runs during inference of the enclosing top-level statement, so the compile time lands before the timer starts. These are wall-clock numbers for the whole script.)

The 1.12 column is offset by an unrelated Julia 1.12 regression: `Base.Compiler.typeinf_local(::EnzymeInterpreter{Nothing}, ...)` does not survive into Enzyme's own pkgimage there (it does on 1.11 and on 1.13), costing a further ~3.1 s of runtime codegen. That is being tracked separately.

## Testing

`absint`, `optimize`, `blas`, `sugar`, `basic`, `errors`, `runtime_calls` and `passes` pass on 1.12 (`blas` and `basic` cover the `jl_load_and_lookup` call sites that pass non-`Instruction`-rooted values into this function). Runic clean.
