### PR TITLE
Forward method_table through EnzymeTarget jobs

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -2569,6 +2569,16 @@ function GPUCompiler.nest_params(params::AbstractEnzymeCompilerParams, parent::A
     )
 end
 
+# Backends define `method_table` for their own `CompilerJob{Target, Params}` (e.g. CUDA.jl
+# for `CompilerJob{PTXCompilerTarget, CUDACompilerParams}`). An Enzyme job wraps both the
+# target and the params, so that definition would not apply and the job would silently fall
+# back to the global method table, while the primal code emitted for it (see `codegen`)
+# is compiled under the backend's overlay table. Unwrap the job so both agree.
+function GPUCompiler.method_table(@nospecialize(job::CompilerJob{<:EnzymeTarget, <:EnzymeCompilerParams}))
+    primal_config = CompilerConfig(job.config; target = job.config.target.target, params = job.config.params.params)
+    return GPUCompiler.method_table(CompilerJob(job.source, primal_config, job.world))
+end
+
 struct UnknownTapeType end
 
 

--- a/test/method_table.jl
+++ b/test/method_table.jl
@@ -1,0 +1,49 @@
+using Enzyme, Test
+using Enzyme.Compiler: EnzymeTarget, EnzymeCompilerParams, PrimalCompilerParams, UnknownTapeType
+using Enzyme: API, FFIABI
+const GPUCompiler = Enzyme.Compiler.GPUCompiler
+using .GPUCompiler: CompilerJob, CompilerConfig
+
+# A pretend backend that, like CUDA.jl, defines its method table only for its own job type.
+struct MTTestTarget <: GPUCompiler.AbstractCompilerTarget end
+struct MTTestParams <: GPUCompiler.AbstractCompilerParams end
+Base.Experimental.@MethodTable(mt_test_table)
+GPUCompiler.method_table(@nospecialize(job::CompilerJob{MTTestTarget, MTTestParams})) = mt_test_table
+
+mt_test_fn(x::Float64) = x
+Base.Experimental.@overlay mt_test_table mt_test_fn(x::Float64) = "overlaid"
+# The overlay is picked up at call sites, so infer a caller.
+mt_test_caller(x::Float64) = mt_test_fn(x)
+
+function enzyme_job(inner_target, inner_params, mode, world)
+    mi = Enzyme.Compiler.my_methodinstance(Reverse, typeof(mt_test_caller), Tuple{Float64}, world)
+    params = EnzymeCompilerParams(
+        Tuple{Const{typeof(mt_test_caller)}, Active{Float64}}, mode, 1, Active{Float64},
+        true, true, (false, false), false, false, UnknownTapeType, FFIABI, false, false, false,
+    )
+    target = GPUCompiler.nest_target(EnzymeTarget(), inner_target)
+    params = GPUCompiler.nest_params(params, inner_params)
+    return mi, CompilerJob(mi, CompilerConfig(target, params; kernel = false), world)
+end
+
+@testset "method_table forwards through EnzymeTarget" begin
+    world = Base.get_world_counter()
+    mode = API.DEM_ReverseModeCombined
+
+    mi, native_job = enzyme_job(GPUCompiler.NativeCompilerTarget(), PrimalCompilerParams(mode), mode, world)
+    @test GPUCompiler.method_table(native_job) === GPUCompiler.GLOBAL_METHOD_TABLE
+    @test Enzyme.Compiler.return_type(GPUCompiler.get_interpreter(native_job), mi) === Float64
+
+    mi, backend_job = enzyme_job(MTTestTarget(), MTTestParams(), mode, world)
+    @test backend_job.config.target isa EnzymeTarget{MTTestTarget}
+    @test backend_job.config.params isa EnzymeCompilerParams{MTTestParams}
+    @test GPUCompiler.method_table(backend_job) === mt_test_table
+
+    interp = GPUCompiler.get_interpreter(backend_job)
+    @test Core.Compiler.method_table(interp).mt === mt_test_table
+    # Inference under the Enzyme job now sees the backend's overlay, as the primal job does.
+    @test Enzyme.Compiler.return_type(interp, mi) === String
+    @static if VERSION >= v"1.11.0-DEV.1552"
+        @test GPUCompiler.ci_cache_token(backend_job).method_table === mt_test_table
+    end
+end

--- a/test/method_table.jl
+++ b/test/method_table.jl
@@ -12,13 +12,17 @@ GPUCompiler.method_table(@nospecialize(job::CompilerJob{MTTestTarget, MTTestPara
 
 mt_test_fn(x::Float64) = x
 Base.Experimental.@overlay mt_test_table mt_test_fn(x::Float64) = "overlaid"
-# The overlay is picked up at call sites, so infer a caller.
-mt_test_caller(x::Float64) = mt_test_fn(x)
+# The overlay is picked up at call sites, so infer a caller. Use a separate caller per
+# job: before Julia 1.11 Enzyme keeps one global code cache per mode, shared across method
+# tables, so inferring the same method instance under both tables would reuse the first
+# result.
+mt_test_native_caller(x::Float64) = mt_test_fn(x)
+mt_test_overlay_caller(x::Float64) = mt_test_fn(x)
 
-function enzyme_job(inner_target, inner_params, mode, world)
-    mi = Enzyme.Compiler.my_methodinstance(Reverse, typeof(mt_test_caller), Tuple{Float64}, world)
+function enzyme_job(caller, inner_target, inner_params, mode, world)
+    mi = Enzyme.Compiler.my_methodinstance(Reverse, typeof(caller), Tuple{Float64}, world)
     params = EnzymeCompilerParams(
-        Tuple{Const{typeof(mt_test_caller)}, Active{Float64}}, mode, 1, Active{Float64},
+        Tuple{Const{typeof(caller)}, Active{Float64}}, mode, 1, Active{Float64},
         true, true, (false, false), false, false, UnknownTapeType, FFIABI, false, false, false,
     )
     target = GPUCompiler.nest_target(EnzymeTarget(), inner_target)
@@ -30,11 +34,11 @@ end
     world = Base.get_world_counter()
     mode = API.DEM_ReverseModeCombined
 
-    mi, native_job = enzyme_job(GPUCompiler.NativeCompilerTarget(), PrimalCompilerParams(mode), mode, world)
+    mi, native_job = enzyme_job(mt_test_native_caller, GPUCompiler.NativeCompilerTarget(), PrimalCompilerParams(mode), mode, world)
     @test GPUCompiler.method_table(native_job) === GPUCompiler.GLOBAL_METHOD_TABLE
     @test Enzyme.Compiler.return_type(GPUCompiler.get_interpreter(native_job), mi) === Float64
 
-    mi, backend_job = enzyme_job(MTTestTarget(), MTTestParams(), mode, world)
+    mi, backend_job = enzyme_job(mt_test_overlay_caller, MTTestTarget(), MTTestParams(), mode, world)
     @test backend_job.config.target isa EnzymeTarget{MTTestTarget}
     @test backend_job.config.params isa EnzymeCompilerParams{MTTestParams}
     @test GPUCompiler.method_table(backend_job) === mt_test_table


### PR DESCRIPTION
Backends such as CUDA.jl define `GPUCompiler.method_table` for their own `CompilerJob{Target, Params}`. Enzyme wraps both the target and the params (`EnzymeTarget{Target}`, `EnzymeCompilerParams{Params}`), so that definition never applied to the Enzyme job, which silently fell back to `GLOBAL_METHOD_TABLE`. The primal job that `codegen` derives from it unwraps both and does see the backend's overlay table. As a result the return-type query in `thunkbase`, the interpreter handed to `check_ir`, and the cache token were all computed under a different method table than the code being emitted.

This adds a `method_table` overload for `CompilerJob{<:EnzymeTarget, <:EnzymeCompilerParams}` that unwraps the job and forwards the lookup, so all of them agree.

Test: a pretend backend that defines `method_table` only for its own job type and overlays a function. The Enzyme job's interpreter now infers the overlaid return type, and the cache token carries the backend's table.

Found while looking at why Enzyme infers the same call graph several times; the follow-up that simplifies the cache token is stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SAFS97SoM9jA3R3zAgNqy
