### PR TITLE
Key the inference cache on what the interpreter reads

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -182,18 +182,23 @@ GPUCompiler.runtime_slug(job::CompilerJob{EnzymeTarget}) = "enzyme"
 
 # provide a specific interpreter to use.
 if VERSION >= v"1.11.0-DEV.1552"
+    # The owner of the CodeInstances produced by an `EnzymeInterpreter`, compared with
+    # `jl_egal`. It only carries the inputs that change what the interpreter infers: the
+    # method table, and the set of rules visible in the world for the mode in question.
+    # The compiler target and params types deliberately are not part of it: one `autodiff`
+    # call builds interpreters from several differently-typed jobs (the `EnzymeTarget`
+    # thunk job, the unwrapped primal job, `primal_interp_world`) that all infer the same
+    # way, and keying on those types made each of them re-infer the whole call graph.
     struct EnzymeCacheToken
-        target_type::Type
-        always_inline::Any
         method_table::Core.MethodTable
-        param_type::Type
         last_fwd_rule_world::Union{Nothing, Tuple}
         last_rev_rule_world::Union{Nothing, Tuple}
         last_ina_rule_world::Union{Nothing, Tuple}
     end
 
-    @inline EnzymeCacheToken(target_type::Type, always_inline::Any, method_table::Core.MethodTable, param_type::Type, world::UInt, is_forward::Bool, is_reverse::Bool, inactive_rule::Bool) =
-        EnzymeCacheToken(target_type, always_inline, method_table, param_type,
+    @inline EnzymeCacheToken(method_table::Core.MethodTable, world::UInt, is_forward::Bool, is_reverse::Bool, inactive_rule::Bool) =
+        EnzymeCacheToken(
+        method_table,
             is_forward ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.forward, Tuple{<:EnzymeCore.EnzymeRules.FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
             is_reverse ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:EnzymeCore.EnzymeRules.RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
             inactive_rule ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.inactive, Tuple{Vararg{Any}}, world)...,) : nothing
@@ -201,10 +206,7 @@ if VERSION >= v"1.11.0-DEV.1552"
 
     GPUCompiler.ci_cache_token(job::CompilerJob{<:Any,<:AbstractEnzymeCompilerParams}) =
         EnzymeCacheToken(
-            typeof(job.config.target),
-            job.config.always_inline,
-            GPUCompiler.method_table(job),
-            typeof(job.config.params),
+        GPUCompiler.method_table(job),
             job.world,
             job.config.params.mode == API.DEM_ForwardMode,
             job.config.params.mode != API.DEM_ForwardMode,

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -51,10 +51,7 @@ using InteractiveUtils
 function code_typed_helper(mi::Core.MethodInstance, world::UInt, mode::Enzyme.API.CDerivativeMode = Enzyme.API.DEM_ReverseModeCombined; interactive::Bool=false, kwargs...)
     CT = @static if VERSION >= v"1.11.0-DEV.1552"
         EnzymeCacheToken(
-            typeof(DefaultCompilerTarget()),
-            false,
-            GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
-            EnzymeCompilerParams,
+            GPUCompiler.GLOBAL_METHOD_TABLE,
             world,
             mode == API.DEM_ForwardMode,
             mode != API.DEM_ForwardMode,

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -21,10 +21,7 @@ function primal_interp_world(
 
     CT = @static if VERSION >= v"1.11.0-DEV.1552"
         EnzymeCacheToken(
-            typeof(DefaultCompilerTarget()),
-            false,
-            GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
-            EnzymeCompilerParams,
+            GPUCompiler.GLOBAL_METHOD_TABLE,
             world,
             false,
             true,
@@ -45,10 +42,7 @@ function primal_interp_world(
 
     CT = @static if VERSION >= v"1.11.0-DEV.1552"
         EnzymeCacheToken(
-            typeof(DefaultCompilerTarget()),
-            false,
-            GPUCompiler.GLOBAL_METHOD_TABLE, #=job.config.always_inline=#
-            EnzymeCompilerParams,
+            GPUCompiler.GLOBAL_METHOD_TABLE,
             world,
             true,
             false,

--- a/test/cache_token.jl
+++ b/test/cache_token.jl
@@ -1,0 +1,39 @@
+using Enzyme, Test
+using Enzyme.Compiler: EnzymeTarget, EnzymeCompilerParams, PrimalCompilerParams, UnknownTapeType
+using Enzyme: API, FFIABI
+const GPUCompiler = Enzyme.Compiler.GPUCompiler
+using .GPUCompiler: CompilerJob, CompilerConfig
+
+cache_token_fn(x::Float64) = sin(x) * x
+
+function token_jobs(mode, world)
+    mi = Enzyme.Compiler.my_methodinstance(Reverse, typeof(cache_token_fn), Tuple{Float64}, world)
+    params = EnzymeCompilerParams(
+        Tuple{Const{typeof(cache_token_fn)}, Active{Float64}}, mode, 1, Active{Float64},
+        true, true, (false, false), false, false, UnknownTapeType, FFIABI, false, false, false,
+    )
+    # The job `thunk` compiles, and the primal job `codegen` derives from it.
+    thunk_job = CompilerJob(mi, CompilerConfig(EnzymeTarget(), params; kernel = false), world)
+    primal_job = CompilerJob(mi, CompilerConfig(thunk_job.config.target.target, params.params; kernel = false), world)
+    return thunk_job, primal_job
+end
+
+@static if VERSION >= v"1.11.0-DEV.1552"
+    @testset "one cache owner per mode" begin
+        world = Base.get_world_counter()
+        for (mode, sugar) in ((API.DEM_ReverseModeCombined, Reverse), (API.DEM_ForwardMode, Forward))
+            thunk_job, primal_job = token_jobs(mode, world)
+            thunk_token = GPUCompiler.ci_cache_token(thunk_job)
+            primal_token = GPUCompiler.ci_cache_token(primal_job)
+            query_token = Enzyme.Compiler.primal_interp_world(sugar, world).token
+            # Owners are matched with jl_egal, so `===` is exactly the comparison that matters.
+            @test thunk_token === primal_token
+            @test thunk_token === query_token
+            @test Core.Compiler.cache_owner(GPUCompiler.get_interpreter(thunk_job)) === primal_token
+        end
+        # Forward and reverse mode still get separate owners: rule inlining differs between them.
+        rev_job, _ = token_jobs(API.DEM_ReverseModeCombined, world)
+        fwd_job, _ = token_jobs(API.DEM_ForwardMode, world)
+        @test GPUCompiler.ci_cache_token(rev_job) !== GPUCompiler.ci_cache_token(fwd_job)
+    end
+end


### PR DESCRIPTION
Stacked on #3498.

On Julia 1.11+ `EnzymeCacheToken` is the owner of every CodeInstance an `EnzymeInterpreter` produces; Julia matches owners with `jl_egal`. The token embedded `typeof(job.config.target)`, `typeof(job.config.params)` and `always_inline`. None of those change what the interpreter infers: it uses fixed `InferenceParams`/`OptimizationParams` and never reads `always_inline`. But one `autodiff` call builds interpreters from three differently-typed jobs, so the whole differentiated call graph was inferred three times per mode into three disjoint cache partitions:

| owner | who creates it | role |
|---|---|---|
| `NativeCompilerTarget`, `EnzymeCompilerParams` (UnionAll) | `primal_interp_world`, used by `primal_return_type` and `my_methodinstance` | return type only |
| `EnzymeTarget{Native}`, `EnzymeCompilerParams{PrimalCompilerParams}` | the `return_type` query in `thunkbase`, the `check_ir` interpreter | return type only |
| `NativeCompilerTarget`, `PrimalCompilerParams` | the primal job in `codegen`, every `nested_codegen!` | emits code |

Measured on Julia 1.12.7 (CodeInstances created per call, by owner, and inference frames from `@snoop_inference`):

| | main | this PR |
|---|---|---|
| reverse autodiff of `sum(exp.(x) ./ (1 .+ x.^2))`, new CodeInstances | 406 · 406 · 406 | 406 |
| same call, inference frames for 927 method instances | 1763 | 977 |
| wall time, small examples | | 6–18% lower |

The pre-1.11 path uses one global `CodeCache` per mode and was never affected; the comment next to it says "all caches can be re-used", which was the original intent.

Compared with GPUCompiler's default `GPUCompilerCacheToken(target_type, always_inline, method_table)` (which CUDA.jl uses unchanged): GPUCompiler keeps the target type because its interpreter takes `inference_params`/`optimization_params` from the job, which backends specialise per target. Enzyme's interpreter has no such dependence, so the token here reduces to the method table plus the per-mode rule-signature sets that were already there.

Test: the thunk job, the primal job derived from it, and `primal_interp_world` yield `===` tokens for each mode, and forward/reverse tokens still differ. The test fails on the base branch (6 of 7 assertions) and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SAFS97SoM9jA3R3zAgNqy

