### PR TITLE
Return the singleton member of a union tape as its instance

### DIFF
--- a/src/rules/customrules.jl
+++ b/src/rules/customrules.jl
@@ -1610,6 +1610,44 @@ function sret_union_tape_type(@nospecialize(aug_RT))
     return Union{InnerTypes...}
 end
 
+"""
+    box_inline_union!(B, alloctx, val, offset, UT) -> LLVM.Value
+
+`val` is an aggregate that holds an isbits `Union` field of type `UT`
+inline at byte `offset`: the payload, then a selector byte with the 0-based
+index of the member in `Base.uniontypes` order. Return the selected member
+boxed, as a tracked pointer; a singleton member is its instance. The tape
+slot of a `Union` tape holds the union boxed, as `jl_type_to_llvm` declares
+it, and the reverse rule takes such a tape boxed too.
+"""
+function box_inline_union!(B::LLVM.IRBuilder, alloctx::LLVM.IRBuilder, val::LLVM.Value, offset::Int, @nospecialize(UT::Type))::LLVM.Value
+    T_int8 = LLVM.Int8Type()
+    T_int64 = LLVM.Int64Type()
+    slot = alloca!(alloctx, value_type(val), "union.tape")
+    store!(B, val, slot)
+    base = bitcast!(B, slot, LLVM.PointerType(T_int8))
+    payload = gep!(B, T_int8, base, LLVM.Value[LLVM.ConstantInt(T_int64, offset)])
+    selp = gep!(B, T_int8, base, LLVM.Value[LLVM.ConstantInt(T_int64, offset + union_alloca_type(UT))])
+    sel = load!(B, T_int8, selp, "union.tape.selector")
+    members = Base.uniontypes(UT)
+    boxed = LLVM.Value[]
+    for T in members
+        if Base.issingletontype(T)
+            push!(boxed, unsafe_to_llvm(B, T.instance))
+        else
+            box = emit_allocobj!(B, T, "union.tape.$T")
+            memcpy!(B, box, 0, payload, 0, LLVM.ConstantInt(T_int64, sizeof(T)))
+            push!(boxed, box)
+        end
+    end
+    result = boxed[end]
+    for k in (length(members) - 1):-1:1
+        is_k = icmp!(B, LLVM.API.LLVMIntEQ, sel, LLVM.ConstantInt(T_int8, k - 1))
+        result = select!(B, is_k, boxed[k], result)
+    end
+    return result
+end
+
 function nthfield_if_byref!(B, isboxed, sret_union_type, res) 
     mod = LLVM.parent(LLVM.parent(position(B)))
     
@@ -2250,6 +2288,12 @@ function enzyme_custom_common_rev(
         cur = nothing
         cur_size = nothing
         cur_offset = nothing
+        # A singleton tape, such as `nothing`, is its instance and must not
+        # be allocated: `tape === nothing` compares identities.
+        T_int1 = LLVM.Int1Type()
+        cur_singleton = nothing
+        cur_singleton_val = nothing
+        any_singleton = false
 
         counter = 1
 
@@ -2262,16 +2306,23 @@ function enzyme_custom_common_rev(
             elseif cur_size != sizeof(jlrettype)
                 same_size = false
             end
+            singleton = Base.issingletontype(jlrettype)
+            any_singleton |= singleton
+            singleton_val = unsafe_to_llvm(B, singleton ? jlrettype.instance : nothing)
 
             if cur === nothing
                 cur = unsafe_to_llvm(B, jlrettype)
                 cur_size = LLVM.ConstantInt(sizeof(jlrettype))
                 cur_offset = LLVM.ConstantInt(fieldoffset(aug_RT, 3))
+                cur_singleton = LLVM.ConstantInt(T_int1, singleton)
+                cur_singleton_val = singleton_val
             else
                 cmpv = icmp!(B, LLVM.API.LLVMIntEQ, idxv, LLVM.ConstantInt(value_type(idxv), counter))
                 cur = select!(B, cmpv, unsafe_to_llvm(B, jlrettype), cur)
                 cur_size = select!(B, cmpv, LLVM.ConstantInt(sizeof(jlrettype)), cur_size)
                 cur_offset = select!(B, cmpv, LLVM.ConstantInt(fieldoffset(aug_RT, 3)), cur_offset)
+                cur_singleton = select!(B, cmpv, LLVM.ConstantInt(T_int1, singleton), cur_singleton)
+                cur_singleton_val = select!(B, cmpv, singleton_val, cur_singleton_val)
             end
 
             counter += 1
@@ -2288,6 +2339,10 @@ function enzyme_custom_common_rev(
         memcpy!(B, bitcast!(B, sret_union_tape, LLVM.PointerType(T_int8, Tracked)), 0, gep!(B, T_int8, bitcast!(B, sret, LLVM.PointerType(T_int8)), LLVM.Value[cur_offset]), 0, cur_size)
 
         sret_union_tape = nthfield_if_byref!(B, isboxed, sret_union_tape, res)
+        if any_singleton
+            use_singleton = and!(B, cur_singleton, not!(B, isboxed))
+            sret_union_tape = select!(B, use_singleton, cur_singleton_val, sret_union_tape)
+        end
         
         res = sret
 
@@ -2496,6 +2551,9 @@ function enzyme_custom_common_rev(
                 sret_union_tape
             elseif abstract
                 emit_nthfield!(B, res, LLVM.ConstantInt(2))
+            elseif TapeT isa Union && Base.isbitsunion(TapeT)
+                # The struct holds the tape inline as payload and selector.
+                box_inline_union!(B, alloctx, res, Int(fieldoffset(aug_RT, 3)), TapeT)
             else
                 extract_value!(B, res, idx)
             end

--- a/test/rules/rule_inlining.jl
+++ b/test/rules/rule_inlining.jl
@@ -271,6 +271,8 @@ end
 boxed_tape_vector(x) = x^3
 boxed_tape_any(x) = x^3
 boxed_tape_union(x) = x^3
+boxed_tape_union2(x) = x^3
+boxed_tape_union3(x) = x^3
 boxed_nospec_fwd(x) = x^3
 boxed_nospec_rev(v) = v[1]^3
 boxed_mutable_payload(p::MParam, x) = p.c * x^3
@@ -329,6 +331,43 @@ for inl in (:inline, :noinline)
             end
         )
     )
+    # A `Union` tape with two members that carry data. The reverse rule
+    # tells them apart, so the selector must survive.
+    push!(
+        defs, :(
+            function EnzymeRules.augmented_primal(config::EnzymeRules.RevConfig, func::Const{typeof(boxed_tape_union2)}, ::Type{<:Active}, x::Active)
+                primal = EnzymeRules.needs_primal(config) ? func.val(x.val) : nothing
+                return EnzymeRules.AugmentedReturn(primal, nothing, x.val > 0 ? x.val : Float32(x.val))
+            end
+        )
+    )
+    push!(
+        defs, :(
+            function EnzymeRules.reverse(config::EnzymeRules.RevConfig, func::Const{typeof(boxed_tape_union2)}, dret::Active, tape, x::Active)
+                scale = tape isa Float32 ? 1 : 10
+                return (scale * 3 * Float64(tape)^2 * dret.val,)
+            end
+        )
+    )
+    # The same tape, with the augmented return typed explicitly, so the union
+    # is one field laid out inline: payload, then selector.
+    push!(
+        defs, :(
+            function EnzymeRules.augmented_primal(config::EnzymeRules.RevConfig, func::Const{typeof(boxed_tape_union3)}, ::Type{<:Active}, x::Active)
+                primal = EnzymeRules.needs_primal(config) ? func.val(x.val) : nothing
+                tape = x.val > 0 ? x.val : nothing
+                return EnzymeRules.AugmentedReturn{typeof(primal), Nothing, Union{Nothing, Float64}}(primal, nothing, tape)
+            end
+        )
+    )
+    push!(
+        defs, :(
+            function EnzymeRules.reverse(config::EnzymeRules.RevConfig, func::Const{typeof(boxed_tape_union3)}, dret::Active, tape, x::Active)
+                xv = tape === nothing ? 0.0 : tape
+                return (10 * 3 * xv^2 * dret.val,)
+            end
+        )
+    )
     # A `@nospecialize` annotation is boxed.
     push!(
         defs, :(
@@ -373,11 +412,11 @@ for inl in (:inline, :noinline)
         @test autodiff(Reverse, boxed_tape_vector, Active(2.0))[1][1] == 120.0
         @test autodiff(Reverse, boxed_tape_any, Active(2.0))[1][1] == 120.0
         @test autodiff(Reverse, boxed_tape_union, Active(2.0))[1][1] == 120.0
-        # The `nothing` member of the union tape reads back as garbage,
-        # whichever way the rule is emitted: the augmented primal boxes the
-        # singleton instead of handing back its instance. Exercise the path
-        # but do not assert the value, which the next PR fixes.
-        autodiff(Reverse, boxed_tape_union, Active(-2.0))
+        @test autodiff(Reverse, boxed_tape_union, Active(-2.0))[1][1] == 0.0
+        @test autodiff(Reverse, boxed_tape_union2, Active(2.0))[1][1] == 120.0
+        @test autodiff(Reverse, boxed_tape_union2, Active(-2.0))[1][1] == 12.0
+        @test autodiff(Reverse, boxed_tape_union3, Active(2.0))[1][1] == 120.0
+        @test autodiff(Reverse, boxed_tape_union3, Active(-2.0))[1][1] == 0.0
         @test autodiff(ForwardWithPrimal, boxed_nospec_fwd, Duplicated(2.0, 1.0)) == (120.0, 8.0)
         v = [2.0]
         dv = [0.0]


### PR DESCRIPTION
Stacked on #3479. Fixes the union tape bug that 212326e1 marked broken on 32-bit Julia there.

### The bug

A rule whose augmented primal returns `AugmentedReturn(primal, shadow, tape)` with a tape of type `Union{Nothing, Float64}` infers to a union of two `AugmentedReturn` types, one per tape member. The handler for such a return (`sret_union` in `enzyme_custom_common_rev`) boxed every member with a fresh `jl_gc_alloc` of the member's type and size, the singleton members included. A freshly allocated `Nothing` is not the `nothing` singleton, so `tape === nothing` in the reverse rule was false and the payload bytes, zero-sized for `Nothing`, were read as a `Float64`: garbage. The 64-bit CI jobs passed by the content of those bytes; the 32-bit job read `Inf`. Reproduced deterministically on 64-bit with a reverse rule that returns `tape === nothing ? -1.0 : Float64(tape)`.

### The fix

- For the union-of-`AugmentedReturn` form, the handler now selects the member's instance for a singleton member instead of the allocated box.
- For an augmented return typed explicitly as `AugmentedReturn{..., Union{...}}`, the union is one field laid out inline as payload bytes and a selector byte. The handler extracted only the payload and passed a pointer to it where the reverse rule expects the union boxed (`jl_type_to_llvm` declares the tape slot boxed, and a `Union` argument is boxed). `box_inline_union!` now boxes the selected member from payload and selector, or hands back the singleton instance.

### Tests

`test/rules/rule_inlining.jl` restores the `nothing`-member assertion on every platform, and adds a union of two data-carrying members (`Union{Float32, Float64}`) whose selector the reverse rule relies on, and the explicitly typed inline form. Each runs as an `@inline` and as a `@noinline` rule. Rule tests pass on 1.10, 1.11, 1.12 and 1.13; the `rules` and `mixedrrule` suites pass on 1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
