### PR TITLE
Don't dev EnzymeTestUtils in the Downgrade job

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -44,11 +44,19 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
-      - name: add EnzymeCore EnzymeTestUtils
+      # Julia 1.10's Pkg ignores `[sources]`, so the local EnzymeCore has to be
+      # dev'd explicitly. EnzymeTestUtils is deliberately not dev'd here: doing
+      # so adds it to Enzyme's `[deps]`, which pulls the *registered* Enzyme
+      # into the downgrade resolution as a dependency of EnzymeTestUtils. That
+      # is unsatisfiable whenever our Enzyme_jll floor is ahead of every
+      # registered Enzyme release (i.e. right after a jll bump). The test
+      # sandbox picks up EnzymeTestUtils from the registry instead; local
+      # changes to it are covered by the dedicated EnzymeTestUtils CI job.
+      - name: add EnzymeCore
         shell: julia --color=yes --project=. {0}
         run: |
           using Pkg
-          Pkg.develop([PackageSpec(; path) for path in ("lib/EnzymeCore", "lib/EnzymeTestUtils")])
+          Pkg.develop(PackageSpec(; path = "lib/EnzymeCore"))
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - uses: julia-actions/julia-downgrade-compat@v2


### PR DESCRIPTION
Downgrade CI has been red on every PR since d48efdcd ("Bump jll and increase", #3493) raised the `Enzyme_jll` compat floor to `0.0.291`. It is not a per-PR failure — the last green run is 33423447705, right before that bump.

## Root cause

The job's setup step devs both `lib/EnzymeCore` and `lib/EnzymeTestUtils`. Julia 1.10's Pkg has no `[sources]` support, so `Pkg.develop` records the path only in the manifest while writing `EnzymeTestUtils` into Enzyme's `[deps]`.

`julia-downgrade-compat@v2` builds its merged resolver project from `[deps]` plus `[sources]`, so it sees `EnzymeTestUtils` as a plain registry requirement and pulls the *registered* Enzyme in as its dependency. No registered Enzyme allows `Enzyme_jll >= 0.0.291`, so the resolve is unsatisfiable:

```
Conflict 1: EnzymeTestUtils cannot be satisfied.
  • you require EnzymeTestUtils
  • EnzymeTestUtils ≥ 0.2.0 requires Enzyme at ≥ 0.13.1
  • Enzyme 0.13.199 requires Enzyme_jll at 0.0.290+0
  ...
  • your compat leaves Enzyme_jll at ≥ 0.0.291+0
  Fix it by any one of:
    1. relax your compat on Enzyme_jll
    2. drop requirement EnzymeTestUtils
```

This will break again after every jll bump that lands ahead of a release, so the workaround of waiting for registration isn't enough.

## Fix

Dev only `lib/EnzymeCore`, which is the one that actually needs it on 1.10 (its `[sources]` entry is ignored there). `EnzymeTestUtils` stays out of the root project, so the downgrade resolution no longer drags in registered Enzyme.

## Verification

Reproduced and fixed locally with Julia 1.10.12 against the pinned action SHA (`30b83cf`):

- With the old step: the exact conflict above.
- With the fix: resolution succeeds and floors the graph — `Enzyme_jll 0.0.291+0`, `CEnum 0.4.0`, `GPUCompiler 1.6.2`, `LLVM 9.10.0`, `ADTypes 1.0.0`, `StaticArrays 1.0.0`, ...
- `Pkg.test(; test_args=["blas"])` in that downgraded environment passes 6000/6000. `test/blas.jl` is the only test file that uses `EnzymeTestUtils`; the sandbox resolved local Enzyme + local EnzymeCore + registry `EnzymeTestUtils 0.2.8`.

Trade-off: the Downgrade job now tests against registry `EnzymeTestUtils` instead of the working tree copy. Local changes to it are still covered by the dedicated EnzymeTestUtils CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)