### PR TITLE
Define generator-backed entry points last (fix 1.12 precompile of interpreter code)

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -1596,6 +1596,7 @@ macro import_rrule(args...)
     return _import_rrule(args...)
 end
 
+include("late_generated.jl")
 include("precompile.jl")
 
 end # module

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7591,37 +7591,7 @@ function thunk_generator(world::UInt, source::Union{Method, LineNumberNode}, @no
     return ci
 end
 
-@eval @inline function thunk(
-    fakeworld::Val{0},
-    fa::Type{FA},
-    a::Type{A},
-    tt::Type{TT},
-    mode::Val{Mode},
-    width::Val{Width},
-    modifiedbetween::Val{ModifiedBetween},
-    returnprimal::Val{ReturnPrimal},
-    shadowinit::Val{ShadowInit},
-    abi::Type{ABI},
-    erriffuncwritten::Val{ErrIfFuncWritten},
-    runtimeactivity::Val{RuntimeActivity},
-    strongzero::Val{StrongZero}
-) where {
-    FA<:Annotation,
-    A<:Annotation,
-    TT,
-    Mode,
-    Width,
-    ModifiedBetween,
-    ReturnPrimal,
-    ShadowInit,
-    ABI,
-    ErrIfFuncWritten,
-    RuntimeActivity,
-    StrongZero
-}
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, thunk_generator))
-end
+# The generated wrapper `thunk` is defined in src/late_generated.jl; see the note there.
 
 import GPUCompiler: deferred_codegen_jobs
 
@@ -7701,36 +7671,7 @@ function deferred_id_generator(world::UInt, source::Union{Method, LineNumberNode
     return ci
 end
 
-@eval @inline function deferred_id_codegen(
-    fa::Type{FA},
-    a::Type{A},
-    tt::Type{TT},
-    mode::Val{Mode},
-    width::Val{Width},
-    modifiedbetween::Val{ModifiedBetween},
-    returnprimal::Val{ReturnPrimal},
-    shadowinit::Val{ShadowInit},
-    expectedtapetype::Type{ExpectedTapeType},
-    erriffuncwritten::Val{ErrIfFuncWritten},
-    runtimeactivity::Val{RuntimeActivity},
-    strongzero::Val{StrongZero}
-) where {
-    FA<:Annotation,
-    A<:Annotation,
-    TT,
-    Mode,
-    Width,
-    ModifiedBetween,
-    ReturnPrimal,
-    ShadowInit,
-    ExpectedTapeType,
-    ErrIfFuncWritten,
-    RuntimeActivity,
-    StrongZero
-}
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, deferred_id_generator))
-end
+# The generated wrapper `deferred_id_codegen` is defined in src/late_generated.jl; see the note there.
 
 @inline function deferred_codegen(
     @nospecialize(fa::Type),

--- a/src/late_generated.jl
+++ b/src/late_generated.jl
@@ -1,0 +1,91 @@
+# Generated-function entry points whose generators run the EnzymeInterpreter (or method
+# lookups through it). They are defined here, after every other method in Enzyme, on purpose:
+#
+# `jl_code_for_staged` runs a generator with `ct->world_age = def->primary_world`, i.e. the
+# world in which the generated *wrapper* method was defined. Everything the generator makes
+# the runtime compile on the fly -- in particular `Base.Compiler.typeinf_local(::EnzymeInterpreter, …)`
+# and friends -- is therefore inferred at that world. If the wrapper is defined early in the
+# module, those CodeInstances get a bounded `max_world` (later Enzyme definitions intersect
+# their edges) even though they are created during the precompile workload. Julia 1.12 drops
+# such external CodeInstances from the pkgimage (`queue_external_cis` requires
+# `max_world == typemax`; fixed on 1.13 by JuliaLang/julia#59436), which costs ~3.4 s of JIT
+# on the first `autodiff` of every session.
+#
+# Defining the wrappers last makes their `primary_world` postdate all other Enzyme methods, so
+# the code compiled from inside the generators is valid in all later worlds and precompiles.
+# Only the wrapper *methods* live here; the generators stay next to the code they belong to.
+#
+# Constraint: because these methods are the newest in the module, they must not be called at
+# *generation time* from a generated function defined earlier (its generator runs in that
+# earlier `primary_world`, where these methods do not exist yet, and would fail with a
+# "method too new" MethodError whenever Enzyme is loaded without a pkgimage). Calling them
+# from ordinary functions, or from the code a generator *returns*, is fine. `prevmethodinstance`
+# deliberately stays in utils.jl for this reason (`onehot_internal`'s generator uses it).
+
+@eval Base.@assume_effects :removable :foldable :nothrow @inline function Compiler.primal_return_type(mode::Mode, ft::Type, tt::Type)
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta, :generated, Compiler.primal_return_type_generator))
+end
+
+@eval @inline function Compiler.thunk(
+        fakeworld::Val{0},
+        fa::Type{FA},
+        a::Type{A},
+        tt::Type{TT},
+        mode::Val{Mode},
+        width::Val{Width},
+        modifiedbetween::Val{ModifiedBetween},
+        returnprimal::Val{ReturnPrimal},
+        shadowinit::Val{ShadowInit},
+        abi::Type{ABI},
+        erriffuncwritten::Val{ErrIfFuncWritten},
+        runtimeactivity::Val{RuntimeActivity},
+        strongzero::Val{StrongZero}
+    ) where {
+        FA <: Annotation,
+        A <: Annotation,
+        TT,
+        Mode,
+        Width,
+        ModifiedBetween,
+        ReturnPrimal,
+        ShadowInit,
+        ABI,
+        ErrIfFuncWritten,
+        RuntimeActivity,
+        StrongZero,
+    }
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta, :generated, Compiler.thunk_generator))
+end
+
+@eval @inline function Compiler.deferred_id_codegen(
+        fa::Type{FA},
+        a::Type{A},
+        tt::Type{TT},
+        mode::Val{Mode},
+        width::Val{Width},
+        modifiedbetween::Val{ModifiedBetween},
+        returnprimal::Val{ReturnPrimal},
+        shadowinit::Val{ShadowInit},
+        expectedtapetype::Type{ExpectedTapeType},
+        erriffuncwritten::Val{ErrIfFuncWritten},
+        runtimeactivity::Val{RuntimeActivity},
+        strongzero::Val{StrongZero}
+    ) where {
+        FA <: Annotation,
+        A <: Annotation,
+        TT,
+        Mode,
+        Width,
+        ModifiedBetween,
+        ReturnPrimal,
+        ShadowInit,
+        ExpectedTapeType,
+        ErrIfFuncWritten,
+        RuntimeActivity,
+        StrongZero,
+    }
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta, :generated, Compiler.deferred_id_generator))
+end

--- a/src/typeutils/inference.jl
+++ b/src/typeutils/inference.jl
@@ -133,8 +133,5 @@ function primal_return_type_generator(world::UInt, source, self, @nospecialize(m
     return ci
 end
 
-@eval Base.@assume_effects :removable :foldable :nothrow @inline function primal_return_type(mode::Mode, ft::Type, tt::Type)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, primal_return_type_generator))
-end
+# The generated wrapper `primal_return_type` is defined in src/late_generated.jl; see the note there.
 


### PR DESCRIPTION
Stacked on #3497.

## Problem

On Julia 1.12 the first `autodiff`/`gradient` of every session spends ~3.4 s LLVM-compiling `Base.Compiler.typeinf_local(::EnzymeInterpreter{Nothing}, ::InferenceState, ::CurrentState)` (3.1 s) and `abstract_call_gf_by_type(::EnzymeInterpreter, …)` (0.3 s). On 1.11 and 1.13 those specializations come out of Enzyme's own pkgimage; on 1.12 `mi.cache` is empty after `using Enzyme`.

## Root cause

`jl_code_for_staged` runs a generator with `ct->world_age = def->primary_world`, i.e. the world in which the generated *wrapper* method was defined. Enzyme's `primal_return_type`, `thunk` and `deferred_id_codegen` generators run the EnzymeInterpreter, so all the `Compiler.*(::EnzymeInterpreter, …)` code the runtime compiles on their behalf is inferred at that early world. Instrumenting Enzyme's own precompilation shows the CodeInstances being created *already stale*: `worlds = 0xa11e:0xa9f5` while the workload runs at `0xaa24` (the cap is the next Enzyme definition intersecting their edges, in `sugar.jl`).

- 1.12's `queue_external_cis` (`src/staticdata_utils.c`) keeps external CodeInstances only if `max_world == typemax`, so `typeinf_local` never reaches the image; its stale callees are written as garbage (`worlds=1:0`), which then makes the EnzymeInterpreter CIs that *were* written fail `verify_methods` at load (233 rejected EI CIs in the `Base.StaticData` load log on 1.12, 0 on 1.13).
- 1.13 dropped that check in JuliaLang/julia#59436 (`59a5fc8930d`, not backported to 1.12) and re-infers the CI at the latest world during native codegen.
- 1.11 never had the check.

A downstream package's `@compile_workload` doesn't hit this because there Enzyme is complete and the same CIs come out with `max_world = typemax`.

## Fix

Move the three `@eval … $(Expr(:meta, :generated, …))` wrapper methods into `src/late_generated.jl`, included right before `precompile.jl`, so their `primary_world` postdates every other Enzyme method. The generators themselves stay where they were. (Wrapping the generator body in `Base.invoke_in_world(world, …)` was tried first and has no effect; methods can't be redefined during precompile, hence the move.)

**Constraint**, documented in the file: these methods must not be called at *generation time* from a generated function defined earlier — that generator runs in the older world where they don't exist yet. `prevmethodinstance` therefore stays in `utils.jl` (`onehot_internal`'s generator calls it). An earlier revision of this PR moved it too and broke `gradient` under `--compiled-modules=no` with "method too new"; the pkgimage hides this class of mistake because it gives every method the same load-time `primary_world`, so `--compiled-modules=no` is the test to run for changes like this.

After `using Enzyme` on 1.12, `typeinf_local(::EnzymeInterpreter{Nothing}, …)` has a native CodeInstance and neither function appears in `--trace-compile` any more.

## Numbers

Wall time of a fresh process running

```julia
using Enzyme
@noinline store!(x, v) = (x .= v; nothing)
f(p, x) = (store!(x, p); sum(abs2, x))
Enzyme.gradient(Reverse, f, [3.0], Const(zeros(1)))
```

released `Enzyme_jll`, best of 3:

| Julia | main | #3497 | #3497 + this |
| --- | --- | --- | --- |
| 1.11.9 | 5.90 s | 4.55 s | 4.7 s |
| 1.12.7 | 9.30 s | 7.68 s | **4.5 s** |
| 1.13.0-rc4 | 5.32 s | 3.78 s | 4.0 s |

A same-window A/B against the parent commit shows no regression on 1.11/1.13 (1.11 5.93 vs 6.08 s, 1.13 5.06 vs 5.30 s, 1.12 5.83 vs 9.38 s; absolute values inflated by machine load during that run).

## Testing

- `basic`, `absint`, `optimize`, `sugar`, `errors`, `runtime_calls`, `passes`, `applyiter`, `mixedapplyiter`, `mixed`, `rules/*` on 1.12: 14831 pass, 46 broken (pre-existing), 0 fail.
- `--compiled-modules=no` on 1.12: `gradient` in Reverse and Forward mode, broadcast, loops and BLAS all run.
- Runic clean.
