### PR TITLE
Make setup_global a top-level @nospecialize function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -97,6 +97,58 @@ function unsafe_to_ptr(@nospecialize(val))
 end
 export unsafe_to_ptr
 
+# Create (or fetch) the `ejl_<k>` global that stands for the Julia object `val` in the module
+# `B` is positioned in. Top-level and `@nospecialize`d on purpose: as a closure inside
+# `unsafe_to_llvm` this captured `val`, so the closure type embedded `typeof(val)` and a fresh
+# specialization (~20 ms of compile) was needed for every distinct global object ever emitted.
+function setup_global(
+        B::LLVM.IRBuilder,
+        T_jlvalue::LLVM.StructType,
+        world::Union{UInt, Nothing},
+        insert_name_if_not_exists::Union{String, Nothing},
+        k::String,
+        @nospecialize(val),
+    )::LLVM.Value
+    mod = LLVM.parent(LLVM.parent(LLVM.position(B)))
+    globs = LLVM.globals(mod)
+    if Base.haskey(globs, "ejl_" * k)
+        return globs["ejl_" * k]
+    end
+
+    force_inactive = false
+    if insert_name_if_not_exists isa String
+        k = "inserted\$" * insert_name_if_not_exists
+        if !haskey(Compiler.JuliaEnzymeNameMap, k)
+            Compiler.JuliaEnzymeNameMap[k] = val
+        end
+        # Since the legacy behavior was to force inactive for global constants, we retain that here (for now)
+        force_inactive = true
+    end
+
+    if Base.haskey(globs, "ejl_" * k)
+        return globs["ejl_" * k]
+    end
+
+    gv = LLVM.GlobalVariable(mod, T_jlvalue, "ejl_" * k, Tracked)
+
+    API.SetMD(gv, "enzyme_ta_norecur", LLVM.MDNode(LLVM.Metadata[]))
+    inactive = force_inactive || Enzyme.Compiler.is_memory_instance(val)
+    if !inactive && val isa Core.SimpleVector && length(val) == 0
+        inactive = true
+    end
+    if !inactive && world isa UInt
+        legal, jTy, byref = Compiler.abs_typeof(gv, true)
+        if legal
+            state = Enzyme.Compiler.active_reg(jTy, world)
+            inactive = state == Enzyme.Compiler.AnyState || state == Enzyme.Compiler.ActiveState
+        end
+    end
+    if inactive
+        API.SetMD(gv, "enzyme_inactive", LLVM.MDNode(LLVM.Metadata[]))
+    end
+    return gv
+end
+
 # This mimicks literal_pointer_val / literal_pointer_val_slot
 function unsafe_to_llvm(B::LLVM.IRBuilder, @nospecialize(val); insert_name_if_not_exists::Union{String, Nothing}=nothing)::LLVM.Value
     T_jlvalue = LLVM.StructType(LLVM.LLVMType[])
@@ -113,64 +165,21 @@ function unsafe_to_llvm(B::LLVM.IRBuilder, @nospecialize(val); insert_name_if_no
         end
     end
     
-    function setup_global(k, v)
-	    k0 = k
-            mod = LLVM.parent(LLVM.parent(LLVM.position(B)))
-            globs = LLVM.globals(mod)
-            if Base.haskey(globs, "ejl_" * k)
-                return globs["ejl_"*k]
-            end
-        
-	force_inactive = false
-	if insert_name_if_not_exists isa String
-	    k = "inserted\$"*insert_name_if_not_exists
-            if !haskey(Compiler.JuliaEnzymeNameMap, k)
-		 Compiler.JuliaEnzymeNameMap[k] = val
-	    end
-	    # Since the legacy behavior was to force inactive for global constants, we retain that here (for now)
-	    force_inactive = true
-	end
-
-            if Base.haskey(globs, "ejl_" * k)
-                return globs["ejl_"*k]
-            end
-
-            gv = LLVM.GlobalVariable(mod, T_jlvalue, "ejl_" * k, Tracked)
-
-            API.SetMD(gv, "enzyme_ta_norecur", LLVM.MDNode(LLVM.Metadata[]))
-            inactive = force_inactive || Enzyme.Compiler.is_memory_instance(v)
-	    if !inactive && v isa Core.SimpleVector && length(v) == 0
-		inactive = true
-	    end
-	    if !inactive && world isa UInt
-                legal, jTy, byref = Compiler.abs_typeof(gv, true)
-                if legal
-                    curent_bb = position(B)
-                    fn = LLVM.parent(curent_bb)
-		    state = Enzyme.Compiler.active_reg(jTy, world)
-		    inactive = state == Enzyme.Compiler.AnyState ||state == Enzyme.Compiler.ActiveState
-                end
-            end
-	    if inactive
-		API.SetMD(gv, "enzyme_inactive", LLVM.MDNode(LLVM.Metadata[]))
-	    end
-            return gv
-    end
 
     for (k, v) in Compiler.JuliaGlobalNameMap
         if v === val
-	    return setup_global(k, v)
+            return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, k, val)
         end
     end
 
     for (k, v) in Compiler.JuliaEnzymeNameMap
         if v === val
-	    return setup_global(k, v)
+            return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, k, val)
         end
     end
 
     if insert_name_if_not_exists !== nothing
-	return setup_global(insert_name_if_not_exists, val)
+        return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, insert_name_if_not_exists, val)
     end
 
     # XXX: This prevents code from being runtime relocatable


### PR DESCRIPTION
Follow-up to #3497 in the same spirit (independent of #3504).

`unsafe_to_llvm` builds the `ejl_<name>` global for a Julia object through a local closure `setup_global(k, v)`. The closure captures `val`, so the closure *type* embeds `typeof(val)`, and its untyped `(k, v)` arguments specialize once more per call. Every distinct global object Enzyme emits therefore compiles a fresh copy (~22 ms each). On the first `Enzyme.gradient` of a session, `--trace-compile-timing` on Julia 1.12 shows 12 of them for **263 ms**:

```
#=   22.6 ms =# precompile(Tuple{Enzyme.var"#setup_global#8"{String, LLVM.IRBuilder, Type{BoundsError}, LLVM.StructType}, String, Type})
#=   22.5 ms =# precompile(Tuple{Enzyme.var"#setup_global#8"{String, LLVM.IRBuilder, typeof(Core.throw_inexacterror), LLVM.StructType}, String, Function})
#=   22.2 ms =# precompile(Tuple{Enzyme.var"#setup_global#8"{String, LLVM.IRBuilder, Type{Tuple{Base.UnitRange{Int64}}}, LLVM.StructType}, String, Type})
... 9 more
```

None of these can be covered by the precompile workload since the set of globals is program-dependent.

This lifts it to a top-level function with `@nospecialize(val)`, passing the previously captured state (`B`, `T_jlvalue`, `world`, `insert_name_if_not_exists`) explicitly — the pattern CLAUDE.md asks for in compiler helpers. The `v` argument was `=== val` at all three call sites and is folded into `val`; the unused locals `k0` and `curent_bb`/`fn` are dropped. No behavior change otherwise.

After: `setup_global` does not appear in `--trace-compile` at all (0 compilations).

Tested: `basic`, `absint`, `optimize`, `sugar`, `errors`, `runtime_calls`, `mixed` on 1.12 — 632 pass, 44 broken (pre-existing), 0 fail. The new function is Runic-clean (the rest of `utils.jl` predates Runic and is left untouched).
