### PR TITLE
Key the rule-lookup memos on a rule-set epoch instead of the world

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -208,9 +208,9 @@ if VERSION >= v"1.11.0-DEV.1552"
     @inline EnzymeCacheToken(method_table::Core.MethodTable, world::UInt, is_forward::Bool, is_reverse::Bool, inactive_rule::Bool) =
         EnzymeCacheToken(
         method_table,
-            is_forward ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.forward, Tuple{<:EnzymeCore.EnzymeRules.FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
-            is_reverse ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:EnzymeCore.EnzymeRules.RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)...,) : nothing,
-            inactive_rule ? (Enzyme.Compiler.Interpreter.get_rule_signatures(EnzymeRules.inactive, Tuple{Vararg{Any}}, world)...,) : nothing
+        is_forward ? (Interpreter.get_rule_signatures(EnzymeRules.forward, Interpreter.FWD_RULE_TT, world)...,) : nothing,
+        is_reverse ? (Interpreter.get_rule_signatures(EnzymeRules.augmented_primal, Interpreter.REV_RULE_TT, world)...,) : nothing,
+        inactive_rule ? (Interpreter.get_rule_signatures(EnzymeRules.inactive, Interpreter.ANY_RULE_TT, world)...,) : nothing
         )
 
     enzyme_cache_owner(job::CompilerJob{<:Any, <:AbstractEnzymeCompilerParams}) =
@@ -649,91 +649,107 @@ function prepare_llvm(interp, mod::LLVM.Module, job, meta)
     return rewrite_abi_converter_calls!(mod)
 end
 
-const FRULE_CACHE = Dict{Tuple{Type, UInt, Any}, Bool}()
-const RRULE_CACHE = Dict{Tuple{Type, UInt, Any}, Bool}()
-const INACTIVE_CACHE = Dict{Tuple{Type, UInt, Any}, Bool}()
-const EASY_RULE_CACHE = Dict{Tuple{Type, UInt}, Bool}()
-const NOALIAS_CACHE = Dict{Tuple{Type, UInt, Any}, Bool}()
+# Memoized rule queries. Each memo is keyed by the epoch of the rule family the query reads
+# (`Interpreter.rule_epoch`): the answer for a signature depends only on the rule methods
+# visible, so worlds that see the same methods share entries, and a new rule method (a new
+# epoch) retires the whole memo instead of leaving stale entries behind. The method table is
+# part of the key with its world stripped; as for the cache token, rule methods living in an
+# overlay table are not tracked.
+mutable struct RuleMemo
+    epoch::UInt
+    const entries::Dict{Tuple{Type, Any}, Bool}
+end
+RuleMemo() = RuleMemo(UInt(0), Dict{Tuple{Type, Any}, Bool}())
 
-function cached_has_easy_rule(specTypes::Type, world::UInt)
-    key = (specTypes, world)
-    val = get(EASY_RULE_CACHE, key, nothing)
+const RULE_MEMO_LOCK = ReentrantLock()
+const FRULE_MEMO = RuleMemo()
+const RRULE_MEMO = RuleMemo()
+const INACTIVE_MEMO = RuleMemo()
+const EASY_RULE_MEMO = RuleMemo()
+const NOALIAS_MEMO = RuleMemo()
+
+# When set, every memo hit is re-derived and compared against the stored answer.
+const CHECK_RULE_MEMO = Ref(false)
+
+memo_method_table(@nospecialize(mt)) = mt
+memo_method_table(mt::Core.Compiler.OverlayMethodTable) = mt.mt
+memo_method_table(::Core.Compiler.InternalMethodTable) = nothing
+memo_method_table(mt::Core.Compiler.CachedMethodTable) = memo_method_table(mt.table)
+
+function memo_get(memo::RuleMemo, epoch::UInt, key::Tuple{Type, Any})
+    lock(RULE_MEMO_LOCK)
+    try
+        if memo.epoch != epoch
+            empty!(memo.entries)
+            memo.epoch = epoch
+        end
+        return get(memo.entries, key, nothing)
+    finally
+        unlock(RULE_MEMO_LOCK)
+    end
+end
+
+function memo_set!(memo::RuleMemo, epoch::UInt, key::Tuple{Type, Any}, val::Bool)
+    lock(RULE_MEMO_LOCK)
+    try
+        # An epoch that moved on while the answer was computed already dropped the memo.
+        if memo.epoch == epoch
+            memo.entries[key] = val
+        end
+    finally
+        unlock(RULE_MEMO_LOCK)
+    end
+    return val
+end
+
+query_has_frule(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    EnzymeRules.has_frule_from_sig(specTypes; world, method_table)
+query_has_rrule(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    EnzymeRules.has_rrule_from_sig(specTypes; world, method_table)
+query_is_inactive(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    EnzymeRules.is_inactive_from_sig(specTypes; world, method_table)
+query_noalias(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    EnzymeRules.noalias_from_sig(specTypes; world, method_table)
+query_has_easy_rule(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    EnzymeRules.has_easy_rule_from_sig(specTypes; world)
+
+function cached_rule_query(
+        memo::RuleMemo, @nospecialize(rule), rule_tt::Type, @nospecialize(query),
+        specTypes::Type, world::UInt, @nospecialize(method_table)
+    )::Bool
+    epoch = Interpreter.rule_epoch(rule, rule_tt, world)
+    key = (specTypes, memo_method_table(method_table))
+    val = memo_get(memo, epoch, key)
     if val !== nothing
+        if CHECK_RULE_MEMO[]
+            fresh = query(specTypes, world, method_table)::Bool
+            fresh == val || error("stale rule memo for $specTypes: cached $val, recomputed $fresh")
+        end
         return val::Bool
     end
     func = specTypes.parameters[1]
-    if func isa Core.Builtin
-        EASY_RULE_CACHE[key] = false
-        return false
+    val = if func isa Core.Builtin
+        false
+    else
+        query(specTypes, world, method_table)::Bool
     end
-    res = EnzymeRules.has_easy_rule_from_sig(specTypes; world)
-    EASY_RULE_CACHE[key] = res
-    return res
+    return memo_set!(memo, epoch, key, val)
 end
 
-function cached_has_frule(specTypes::Type, world::UInt, method_table)
-    key = (specTypes, world, method_table)
-    val = get(FRULE_CACHE, key, nothing)
-    if val !== nothing
-        return val::Bool
-    end
-    func = specTypes.parameters[1]
-    if func isa Core.Builtin
-        FRULE_CACHE[key] = false
-        return false
-    end
-    res = EnzymeRules.has_frule_from_sig(specTypes; world, method_table)
-    FRULE_CACHE[key] = res
-    return res
-end
+cached_has_easy_rule(specTypes::Type, world::UInt) =
+    cached_rule_query(EASY_RULE_MEMO, EnzymeRules.has_easy_rule, Interpreter.ANY_RULE_TT, query_has_easy_rule, specTypes, world, nothing)
 
-function cached_has_rrule(specTypes::Type, world::UInt, method_table)
-    key = (specTypes, world, method_table)
-    val = get(RRULE_CACHE, key, nothing)
-    if val !== nothing
-        return val::Bool
-    end
-    func = specTypes.parameters[1]
-    if func isa Core.Builtin
-        RRULE_CACHE[key] = false
-        return false
-    end
-    res = EnzymeRules.has_rrule_from_sig(specTypes; world, method_table)
-    RRULE_CACHE[key] = res
-    return res
-end
+cached_has_frule(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    cached_rule_query(FRULE_MEMO, EnzymeRules.forward, Interpreter.FWD_RULE_TT, query_has_frule, specTypes, world, method_table)
 
-function cached_is_inactive(specTypes::Type, world::UInt, method_table)
-    key = (specTypes, world, method_table)
-    val = get(INACTIVE_CACHE, key, nothing)
-    if val !== nothing
-        return val::Bool
-    end
-    func = specTypes.parameters[1]
-    if func isa Core.Builtin
-        INACTIVE_CACHE[key] = false
-        return false
-    end
-    res = EnzymeRules.is_inactive_from_sig(specTypes; world, method_table)
-    INACTIVE_CACHE[key] = res
-    return res
-end
+cached_has_rrule(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    cached_rule_query(RRULE_MEMO, EnzymeRules.augmented_primal, Interpreter.REV_RULE_TT, query_has_rrule, specTypes, world, method_table)
 
-function cached_noalias(specTypes::Type, world::UInt, method_table)
-    key = (specTypes, world, method_table)
-    val = get(NOALIAS_CACHE, key, nothing)
-    if val !== nothing
-        return val::Bool
-    end
-    func = specTypes.parameters[1]
-    if func isa Core.Builtin
-        NOALIAS_CACHE[key] = false
-        return false
-    end
-    res = EnzymeRules.noalias_from_sig(specTypes; world, method_table)
-    NOALIAS_CACHE[key] = res
-    return res
-end
+cached_is_inactive(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    cached_rule_query(INACTIVE_MEMO, EnzymeRules.inactive, Interpreter.ANY_RULE_TT, query_is_inactive, specTypes, world, method_table)
+
+cached_noalias(specTypes::Type, world::UInt, @nospecialize(method_table)) =
+    cached_rule_query(NOALIAS_MEMO, EnzymeRules.noalias, Interpreter.ANY_RULE_TT, query_noalias, specTypes, world, method_table)
 
 include("compiler/optimize.jl")
 include("compiler/interpreter.jl")
@@ -7409,16 +7425,26 @@ function clear_caches!()
     reset_session!()
     empty!(Enzyme.captured_constants)
 
-    # Which rules apply, memoized against the world the methods were read in.
-    empty!(FRULE_CACHE)
-    empty!(RRULE_CACHE)
-    empty!(INACTIVE_CACHE)
-    empty!(EASY_RULE_CACHE)
-    empty!(NOALIAS_CACHE)
-    empty!(Interpreter.SigCache)
-    Interpreter.LastFwdWorld[] = Base.IdSet{Type}()
-    Interpreter.LastRevWorld[] = Base.IdSet{Type}()
-    Interpreter.LastInaWorld[] = Base.IdSet{Type}()
+    # Which rules apply, memoized against the rule-set epoch they were read in, and the rule
+    # families those epochs were derived from.
+    lock(RULE_MEMO_LOCK)
+    try
+        for memo in (FRULE_MEMO, RRULE_MEMO, INACTIVE_MEMO, EASY_RULE_MEMO, NOALIAS_MEMO)
+            empty!(memo.entries)
+            memo.epoch = UInt(0)
+        end
+    finally
+        unlock(RULE_MEMO_LOCK)
+    end
+    lock(Interpreter.RuleFamilyLock)
+    try
+        empty!(Interpreter.RULE_FAMILIES)
+    finally
+        unlock(Interpreter.RuleFamilyLock)
+    end
+    Interpreter.LastFwdEpoch[] = 0
+    Interpreter.LastRevEpoch[] = 0
+    Interpreter.LastInaEpoch[] = 0
 
     # Activity, and the world its `inactive_type` methods were last checked in. Left set, it
     # tells a later session its own worlds need no check.

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -17,6 +17,7 @@ const HAS_INTEGRATED_CACHE = VERSION >= v"1.11.0-DEV.1552"
 
 import ..Enzyme
 import ..EnzymeRules
+import ..EnzymeRules: FwdConfig, RevConfig, Annotation
 import ..cached_has_frule, ..cached_has_rrule, ..cached_is_inactive
 
 @static if VERSION ≥ v"1.11.0-DEV.1498"
@@ -87,35 +88,35 @@ struct EnzymeInterpreter{T} <: AbstractInterpreter
     handler::T
 end
 
-const SigCacheLock = ReentrantLock()
+# Argument tuples selecting the methods of each rule family.
+const FWD_RULE_TT = Tuple{<:FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}
+const REV_RULE_TT = Tuple{<:RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}
+const ANY_RULE_TT = Tuple{Vararg{Any}}
+
+# The methods of one rule family (`EnzymeRules.forward`, `augmented_primal`, `inactive`, ...)
+# visible in the world last asked about, and an epoch that advances whenever that set differs
+# between two worlds. Memoized rule queries and the pre-1.11 code cache key on the epoch: two
+# worlds that see the same rule methods answer every rule query the same way, so nothing has to
+# be recomputed per world, and a new rule method retires every answer at once. Only the global
+# method table is consulted, as for the cache token; rules living in an overlay method table are
+# not tracked.
+mutable struct RuleFamily
+    world::UInt
+    sigs::Base.IdSet{Type}
+    epoch::UInt
+end
+
+const RuleFamilyLock = ReentrantLock()
+const RULE_FAMILIES = Dict{Tuple{Any, Type}, RuleFamily}()
 const InterpreterLock = ReentrantLock()
-const SigCache = Dict{Tuple, Dict{UInt, Base.IdSet{Type}}}()
-function get_rule_signatures(f, TT, world)
-    subdict = lock(SigCacheLock) do
-        if haskey(SigCache, (f, TT))
-           SigCache[(f, TT)]
-        else
-           tmp = Dict{UInt, Base.IdSet{Type}}()
-           SigCache[(f, TT)] = tmp
-           tmp
-        end
+
+function rule_signatures_at(@nospecialize(f), @nospecialize(TT), world::UInt)
+    meths = Base._methods(f, TT, -1, world)::Vector
+    sigs = Type[]
+    for rule in meths
+        push!(sigs, (rule::Core.MethodMatch).method.sig)
     end
-    
-    return lock(SigCacheLock) do
-        if haskey(subdict, world)
-           return subdict[world]
-        end
-        
-        fwdrules_meths = Base._methods(f, TT, -1, world)::Vector
-        sigs = Type[]
-        for rule in fwdrules_meths
-            push!(sigs, (rule::Core.MethodMatch).method.sig)
-        end
-        result = Base.IdSet{Type}(sigs)
-        
-        subdict[world] = result
-        return result
-    end
+    return Base.IdSet{Type}(sigs)
 end
 
 function rule_sigs_equal(a, b)
@@ -131,9 +132,47 @@ function rule_sigs_equal(a, b)
     return true
 end
 
-const LastFwdWorld = Ref(Base.IdSet{Type}())
-const LastRevWorld = Ref(Base.IdSet{Type}())
-const LastInaWorld = Ref(Base.IdSet{Type}())
+# `(sigs, epoch)` of the family at `world`. The method lookup runs outside the lock.
+function rule_family(@nospecialize(f), @nospecialize(TT), world::UInt)
+    key = (f, TT)
+    lock(RuleFamilyLock)
+    try
+        fam = get(RULE_FAMILIES, key, nothing)
+        if fam !== nothing && fam.world == world
+            return (fam.sigs, fam.epoch)
+        end
+    finally
+        unlock(RuleFamilyLock)
+    end
+
+    sigs = rule_signatures_at(f, TT, world)
+
+    lock(RuleFamilyLock)
+    try
+        fam = get(RULE_FAMILIES, key, nothing)
+        if fam === nothing
+            fam = RuleFamily(world, sigs, UInt(1))
+            RULE_FAMILIES[key] = fam
+        elseif fam.world != world
+            if !rule_sigs_equal(sigs, fam.sigs)
+                fam.sigs = sigs
+                fam.epoch += 1
+            end
+            fam.world = world
+        end
+        return (fam.sigs, fam.epoch)
+    finally
+        unlock(RuleFamilyLock)
+    end
+end
+
+get_rule_signatures(@nospecialize(f), @nospecialize(TT), world::UInt) = rule_family(f, TT, world)[1]
+rule_epoch(@nospecialize(f), @nospecialize(TT), world::UInt) = rule_family(f, TT, world)[2]
+
+# Pre-1.11: the epochs the global code caches were last validated against.
+const LastFwdEpoch = Ref{UInt}(0)
+const LastRevEpoch = Ref{UInt}(0)
+const LastInaEpoch = Ref{UInt}(0)
 
 function EnzymeInterpreter(
     cache_or_token,
@@ -157,50 +196,33 @@ function EnzymeInterpreter(
     @static if HAS_INTEGRATED_CACHE
 
     else
-        fwdrules = if forward_rules
-            get_rule_signatures(EnzymeRules.forward, Tuple{<:FwdConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)
-        else
-            nothing
-        end
-
-        revrules = if reverse_rules
-            get_rule_signatures(EnzymeRules.augmented_primal, Tuple{<:RevConfig, <:Annotation, Type{<:Annotation}, Vararg{Annotation}}, world)
-        else
-            nothing
-        end
-
-        inarules = if inactive_rules
-            get_rule_signatures(EnzymeRules.inactive, Tuple{Vararg{Any}}, world)
-        else
-            nothing
-        end
+        # The global code cache holds inference results that depend on which rules were
+        # visible; drop it when a rule family changed since the last interpreter was built.
+        fwd_epoch = forward_rules ? rule_epoch(EnzymeRules.forward, FWD_RULE_TT, world) : UInt(0)
+        rev_epoch = reverse_rules ? rule_epoch(EnzymeRules.augmented_primal, REV_RULE_TT, world) : UInt(0)
+        ina_epoch = inactive_rules ? rule_epoch(EnzymeRules.inactive, ANY_RULE_TT, world) : UInt(0)
 
         cache_or_token = cache_or_token::CodeCache
-        invalid = false
-        lock(InterpreterLock) do
-            if forward_rules
-                if !rule_sigs_equal(fwdrules, LastFwdWorld[])
-                    LastFwdWorld[] = fwdrules
-                    invalid = true
-                end
+        lock(InterpreterLock)
+        try
+            invalid = false
+            if forward_rules && fwd_epoch != LastFwdEpoch[]
+                LastFwdEpoch[] = fwd_epoch
+                invalid = true
             end
-            if reverse_rules
-                if !rule_sigs_equal(revrules, LastRevWorld[])
-                    LastRevWorld[] = revrules
-                    invalid = true
-                end
+            if reverse_rules && rev_epoch != LastRevEpoch[]
+                LastRevEpoch[] = rev_epoch
+                invalid = true
             end
-    
-            if inactive_rules
-                if !rule_sigs_equal(inarules, LastInaWorld[])
-                    LastInaWorld[] = inarules
-                    invalid = true
-                end
+            if inactive_rules && ina_epoch != LastInaEpoch[]
+                LastInaEpoch[] = ina_epoch
+                invalid = true
             end
-            
             if invalid
                 Base.empty!(cache_or_token)
             end
+        finally
+            unlock(InterpreterLock)
         end
     end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -174,9 +174,10 @@ end
         using Enzyme
         C = Enzyme.Compiler
         sizes = (length(C.THUNK_CACHE.thunks), length(C.THUNK_CACHE.by_ptr), length(C.THUNK_CACHE.tapes),
-                 length(C.FRULE_CACHE), length(C.RRULE_CACHE), length(C.INACTIVE_CACHE),
-                 length(C.EASY_RULE_CACHE), length(C.NOALIAS_CACHE),
-                 length(C.Interpreter.SigCache), length(C.ActivityCache),
+                 length(C.FRULE_MEMO.entries), length(C.RRULE_MEMO.entries),
+                 length(C.INACTIVE_MEMO.entries), length(C.EASY_RULE_MEMO.entries),
+                 length(C.NOALIAS_MEMO.entries), length(C.Interpreter.RULE_FAMILIES),
+                 length(C.ActivityCache),
                  length(C.ActivityMethodCache), Int(C.ActivityWorldCache[]),
                  length(C.JIT.hnd_string_map), length(C.JIT.hnd_int_map))
         print(sum(sizes), " ", Enzyme.autodiff(Reverse, x -> x * x, Active(4.0))[1][1])

--- a/test/rule_cache.jl
+++ b/test/rule_cache.jl
@@ -1,0 +1,83 @@
+using Enzyme
+using Enzyme.EnzymeRules
+using Test
+
+const C = Enzyme.Compiler
+const I = Enzyme.Compiler.Interpreter
+
+rc_plain(x) = 2x
+rc_ruled(x) = 3x
+
+fwd_epoch(world) = I.rule_epoch(EnzymeRules.forward, I.FWD_RULE_TT, world)
+
+@testset "memo entries are shared across worlds" begin
+    world = Base.get_world_counter()
+    st = Tuple{typeof(rc_plain), Float64}
+    @test !C.cached_has_frule(st, world, nothing)
+    e0 = fwd_epoch(world)
+    n0 = length(C.FRULE_MEMO.entries)
+    @test n0 >= 1
+    @test C.FRULE_MEMO.epoch == e0
+    for i in 1:5
+        # A new method bumps the world without touching any rule family.
+        @eval $(Symbol(:rc_unrelated_, i))(x) = x + $i
+        world = Base.get_world_counter()
+        @test !C.cached_has_frule(st, world, nothing)
+        @test fwd_epoch(world) == e0
+        @test length(C.FRULE_MEMO.entries) == n0
+    end
+    # Signatures are also equal across worlds, so the token inputs do not churn.
+    @test I.get_rule_signatures(EnzymeRules.forward, I.FWD_RULE_TT, world) ===
+        I.get_rule_signatures(EnzymeRules.forward, I.FWD_RULE_TT, world - 1)
+end
+
+world_before_rule = Base.get_world_counter()
+@test !C.cached_has_frule(Tuple{typeof(rc_ruled), Float64}, world_before_rule, nothing)
+epoch_before_rule = fwd_epoch(world_before_rule)
+rev_epoch_before_rule = I.rule_epoch(EnzymeRules.augmented_primal, I.REV_RULE_TT, world_before_rule)
+
+function EnzymeRules.forward(config, ::Const{typeof(rc_ruled)}, ::Type{<:Duplicated}, x::Duplicated)
+    return Duplicated(rc_ruled(x.val), 3 * x.dval)
+end
+function EnzymeRules.forward(config, ::Const{typeof(rc_ruled)}, ::Type{<:DuplicatedNoNeed}, x::Duplicated)
+    return 3 * x.dval
+end
+
+@testset "a new rule retires the memo" begin
+    world = Base.get_world_counter()
+    st = Tuple{typeof(rc_ruled), Float64}
+    @test fwd_epoch(world) == epoch_before_rule + 1
+    @test C.cached_has_frule(st, world, nothing)
+    # The memo was dropped as a whole: only the query just made is in it.
+    @test C.FRULE_MEMO.epoch == epoch_before_rule + 1
+    @test length(C.FRULE_MEMO.entries) == 1
+    # Other families are untouched.
+    @test I.rule_epoch(EnzymeRules.augmented_primal, I.REV_RULE_TT, world) == rev_epoch_before_rule
+    # The old world still answers as it did, at its own epoch.
+    @test !C.cached_has_frule(st, world_before_rule, nothing)
+    @test autodiff(Forward, rc_ruled, Duplicated(1.0, 1.0))[1] == 3.0
+end
+
+@testset "check mode re-derives hits" begin
+    C.CHECK_RULE_MEMO[] = true
+    try
+        world = Base.get_world_counter()
+        st = Tuple{typeof(rc_ruled), Float64}
+        @test C.cached_has_frule(st, world, nothing)
+        @test C.cached_has_frule(st, world, nothing)
+        @test !C.cached_is_inactive(st, world, nothing)
+        @test !C.cached_is_inactive(st, world, nothing)
+    finally
+        C.CHECK_RULE_MEMO[] = false
+    end
+end
+
+@testset "method table key strips the world" begin
+    world = Base.get_world_counter()
+    mt = Core.Compiler.InternalMethodTable(world)
+    @test C.memo_method_table(mt) === nothing
+    @test C.memo_method_table(nothing) === nothing
+    omt = Core.Compiler.OverlayMethodTable(world, C.GPUCompiler.GLOBAL_METHOD_TABLE)
+    @test C.memo_method_table(omt) === C.GPUCompiler.GLOBAL_METHOD_TABLE
+    @test C.memo_method_table(Core.Compiler.OverlayMethodTable(world - 1, C.GPUCompiler.GLOBAL_METHOD_TABLE)) === C.memo_method_table(omt)
+end


### PR DESCRIPTION
Stacked on #3509. Part of the cache redesign towards session-local state and relocatable, cross-session cacheable compilation.

The memoized rule queries (`cached_has_frule`, `cached_has_rrule`,
`cached_is_inactive`, `cached_noalias`, `cached_has_easy_rule`) were keyed by
`(specTypes, world, method_table)`, so every world age that Enzyme compiled in
added a full set of entries that was never dropped, and the dicts were mutated
from inference without a lock. `SigCache` likewise kept the rule signatures of
every world ever asked about.

Each rule family (`EnzymeRules.forward`, `augmented_primal`, `inactive`,
`noalias`, `has_easy_rule`) now keeps only the signatures of the last world it
was asked about and an epoch that advances when that set differs between two
worlds (`Interpreter.rule_family`). The answer of a rule query depends only on
the rule methods visible, so a memo is keyed by `(specTypes, method table)`
with the world stripped and belongs to one epoch; a new epoch empties it. The
memos share one lock, and predicates are evaluated outside it. The pre-1.11
constructor uses the same epochs to decide when to drop the global CodeCache,
replacing the per-family signature-set comparison. `CHECK_RULE_MEMO[]`
re-derives every hit for bisection.

As before, only the global method table contributes to the signatures; rule
methods in an overlay table are not tracked (the cache token has the same
limitation). The cache token itself is unchanged.

Test: `test/rule_cache.jl` checks that world bumps without rule changes reuse
entries and keep the epoch, that a new rule advances the epoch and drops the
memo while other families keep theirs, that older worlds still answer as
before, that check mode passes, and that the method-table key ignores the
world. Passes with `cache_token`, `session_cache` and `rules/ruleinvalidation`
on Julia 1.10 and 1.12.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT