### PR TITLE
Make deferred codegen GPU-only with ids derived from the job specification

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -694,8 +694,10 @@ end
 """
     autodiff_deferred(::ReverseMode, f, Activity, args::Annotation...)
 
-Same as [`autodiff`](@ref) but uses deferred compilation to support usage in GPU
-code, as well as high-order differentiation.
+Same as [`autodiff`](@ref) but uses deferred compilation, for use inside GPU kernels.
+Calling it on the host throws `Enzyme.Compiler.DeferredOnHostError`; use `autodiff` there,
+including for higher-order differentiation, where Enzyme differentiates through nested
+`autodiff` calls directly.
 """
 @inline function autodiff_deferred(
     mode::ReverseMode{ReturnPrimal,RuntimeActivity,StrongZero,RABI,Holomorphic,ErrIfFuncWritten},
@@ -830,8 +832,9 @@ end
 """
     autodiff_deferred(::ForwardMode, f, Activity, args::Annotation...)
 
-Same as `autodiff(::ForwardMode, f, Activity, args...)` but uses deferred compilation to support usage in GPU
-code, as well as high-order differentiation.
+Same as `autodiff(::ForwardMode, f, Activity, args...)` but uses deferred compilation, for
+use inside GPU kernels. Calling it on the host throws `Enzyme.Compiler.DeferredOnHostError`;
+use `autodiff` there, including for higher-order differentiation.
 """
 @inline function autodiff_deferred(
     mode::ForwardMode{ReturnPrimal,RABI,ErrIfFuncWritten,RuntimeActivity,StrongZero},
@@ -1382,13 +1385,12 @@ The reverse function will return the derivative of `Active` arguments, updating 
 arguments in place. The same arguments to the forward pass should be provided, followed by
 the adjoint of the return (if the return is active), and finally the tape from the forward pass.
 
-Example:
+Like [`autodiff_deferred`](@ref), this is for use inside GPU kernels; on the host it throws
+`Enzyme.Compiler.DeferredOnHostError`, and [`autodiff_thunk`](@ref) is the entry point.
 
-```jldoctest
+Example (inside a kernel):
 
-A = [2.2]; ∂A = zero(A)
-v = 3.3
-
+```julia
 function f(A, v)
     res = A[1] * v
     A[1] = 0
@@ -1400,12 +1402,6 @@ forward, reverse = autodiff_deferred_thunk(ReverseSplitWithPrimal, TapeType, Con
 
 tape, result, shadow_result  = forward(Const(f), Duplicated(A, ∂A), Active(v))
 _, ∂v = reverse(Const(f), Duplicated(A, ∂A), Active(v), 1.0, tape)[1]
-
-result, ∂v, ∂A
-
-# output
-
-(7.26, 2.2, [3.3])
 ```
 """
 @inline function autodiff_deferred_thunk(

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7799,6 +7799,8 @@ import GPUCompiler: deferred_codegen_jobs
 
 function deferred_id_codegen end
 
+include("compiler/deferred.jl")
+
 function deferred_id_generator(world::UInt, source::Union{Method, LineNumberNode}, @nospecialize(FA::Type), @nospecialize(A::Type), @nospecialize(TT::Type), Mode::Enzyme.API.CDerivativeMode, Width::Int, @nospecialize(ModifiedBetween::(NTuple{N, Bool} where N)), ReturnPrimal::Bool, ShadowInit::Bool, @nospecialize(ExpectedTapeType::Type), ErrIfFuncWritten::Bool, RuntimeActivity::Bool, StrongZero::Bool, @nospecialize(self), @nospecialize(fa::Type), @nospecialize(a::Type), @nospecialize(tt::Type), @nospecialize(mode::Type), @nospecialize(width::Type), @nospecialize(modifiedbetween::Type), @nospecialize(returnprimal::Type), @nospecialize(shadowinit::Type), @nospecialize(expectedtapetype::Type), @nospecialize(erriffuncwritten::Type), @nospecialize(runtimeactivity::Type), @nospecialize(strongzero::Type))
     @nospecialize
     
@@ -7809,66 +7811,27 @@ function deferred_id_generator(world::UInt, source::Union{Method, LineNumberNode
 
     stub = Core.GeneratedFunctionStub(identity, slotnames, Core.svec())
 
-    ft = eltype(FA)
-    primal_tt = Tuple{map(eltype, TT.parameters)...}
-    # look up the method match
-    
-    min_world = Ref{UInt}(typemin(UInt))
-    max_world = Ref{UInt}(typemax(UInt))
- 
-    mi = my_methodinstance(Mode == API.DEM_ForwardMode ? Forward : Reverse, ft, primal_tt, world, min_world, max_world)
-    
-    mi === nothing && return stub(world, source, :(throw(MethodError($ft, $primal_tt, $world))))
-    
-    target = EnzymeTarget()
-    rt2 = if A isa UnionAll
-        rrt = primal_return_type_world(Mode == API.DEM_ForwardMode ? Forward : Reverse, world, mi)
-
-        # Don't error here but default to nothing return since in cuda context we don't use the device overrides
-        if rrt == Union{}
-            rrt = Nothing
+    spec = DeferredSpec(
+        FA, A, TT, Mode, Width, ModifiedBetween, ReturnPrimal, ShadowInit, ExpectedTapeType,
+        ErrIfFuncWritten, RuntimeActivity, StrongZero
+    )
+    job = deferred_job(spec, world)
+    if job === nothing
+        ft = eltype(FA)
+        primal_tt = Tuple{map(eltype, TT.parameters)...}
+        return stub(world, source, :(throw(MethodError($ft, $primal_tt, $world))))
+    elseif job isa String
+        return quote
+            error($job)
         end
-
-        if !(A <: Const) && guaranteed_const_nongen(rrt, world)
-            estr = "Return type `$rrt` not marked Const, but type is guaranteed to be constant"
-            return quote
-                error($estr)
-            end
-        end
-        instantiate_annotation(A, rrt, Width)
-    else
-        @assert A isa DataType
-        A
     end
 
-    params = EnzymeCompilerParams(
-        PrimalCompilerParams(Mode),
-        Tuple{FA,TT.parameters...},
-        Mode,
-        Width,
-        rt2,
-        true,
-        true,
-        ModifiedBetween,
-        ReturnPrimal,
-        ShadowInit,
-        ExpectedTapeType,
-        FFIABI,
-        ErrIfFuncWritten,
-        RuntimeActivity,
-        StrongZero
-    ) #=abiwrap=#
-    job =
-        Compiler.CompilerJob(mi, CompilerConfig(target, params; kernel = false), world)
-
-    addr = get_trampoline(job)
-    id = Base.reinterpret(Int, pointer(addr))
-    deferred_codegen_jobs[id] = job
+    id = register_deferred!(spec, job)
 
     code = Any[Core.Compiler.ReturnNode(reinterpret(UInt, id))]
     ci = create_fresh_codeinfo(deferred_id_codegen, source, world, slotnames, code)
 
-    ci.edges = Any[mi]
+    ci.edges = Any[job.source]
 
     return ci
 end
@@ -7890,7 +7853,17 @@ end
     @nospecialize(strongzero::Val)
 )
     id = deferred_id_codegen(fa, a, tt, mode, width, modifiedbetween, returnprimal, shadowinit, expectedtapetype, erriffuncwritten, runtimeactivity, strongzero)
-    return _deferred_codegen_call(Val(id))
+    ptr = _deferred_codegen_call(Val(id))
+    # The job is registered under a twin id as well. In device code GPUCompiler's pass
+    # resolves both markers to the same function, so this comparison folds away before any
+    # later pass sees the function's address (GPUCompiler rewrites the signatures of
+    # functions using the kernel state and refuses uses other than calls and stores). On
+    # the host both markers reach GPUCompiler's identity stub and return their ids, which
+    # differ: the call runs natively, which is not supported.
+    if ptr != _deferred_codegen_call(Val(deferred_twin_id(id)))
+        throw(DeferredOnHostError())
+    end
+    return ptr
 end
 
 # `@generated` shell so the `ccall("extern deferred_codegen", …)` body

--- a/src/compiler/deferred.jl
+++ b/src/compiler/deferred.jl
@@ -1,0 +1,180 @@
+# Deferred compilation is Enzyme's device-side entry point: a kernel calls `autodiff_deferred`,
+# and GPUCompiler's `deferred_codegen` pass resolves the marker call emitted by
+# `_deferred_codegen_call` to the differentiated function, compiled from the job registered
+# under the marker's id and linked into the kernel module. There is no host runtime path (and
+# none is needed: higher-order differentiation goes through plain `autodiff`, whose nested
+# calls Enzyme recognizes by itself). Outside of a GPUCompiler compilation the marker resolves
+# to GPUCompiler's host stub, which hands the id back unchanged as a "pointer";
+# `deferred_codegen` detects that by emitting the marker twice, under the id and its twin
+# (`deferred_twin_id`), and raising `DeferredOnHostError` when the two results differ.
+#
+# The id is derived from the job's specification, which is entirely type-level, so it is the
+# same in every session. `deferred_codegen_jobs` is process-local; `rebuild_deferred_registry!`
+# recreates its entries from the specializations of `deferred_id_codegen`.
+
+struct DeferredSpec
+    FA::Type
+    A::Type
+    TT::Type
+    mode::API.CDerivativeMode
+    width::Int
+    modified_between::Tuple{Vararg{Bool}}
+    return_primal::Bool
+    shadow_init::Bool
+    expected_tape_type::Type
+    err_if_func_written::Bool
+    runtime_activity::Bool
+    strong_zero::Bool
+end
+
+function Base.hash(spec::DeferredSpec, h::UInt)
+    h = hash(spec.FA, h)
+    h = hash(spec.A, h)
+    h = hash(spec.TT, h)
+    h = hash(Int(spec.mode), h)
+    h = hash(spec.width, h)
+    h = hash(spec.modified_between, h)
+    h = hash(spec.return_primal, h)
+    h = hash(spec.shadow_init, h)
+    h = hash(spec.expected_tape_type, h)
+    h = hash(spec.err_if_func_written, h)
+    h = hash(spec.runtime_activity, h)
+    return hash(spec.strong_zero, h)
+end
+
+# Set in every Enzyme deferred id, so ids never collide with the small counters GPUCompiler
+# hands out for its own deferred jobs.
+const DEFERRED_ID_BIT = UInt(1) << (8 * sizeof(UInt) - 2)
+
+# Non-negative, so it round-trips through the `Int`-keyed `deferred_codegen_jobs`.
+deferred_id(spec::DeferredSpec) = Int((hash(spec) | DEFERRED_ID_BIT) & ~(UInt(1) << (8 * sizeof(UInt) - 1)))
+
+# The second id every job is registered under; see `deferred_codegen`.
+deferred_twin_id(id::Int) = id ⊻ 1
+deferred_twin_id(id::UInt) = id ⊻ UInt(1)
+
+const DEFERRED_LOCK = ReentrantLock()
+const DEFERRED_SPECS = Dict{Int, DeferredSpec}()
+
+struct DeferredOnHostError <: EnzymeError end
+
+function Base.showerror(io::IO, ::DeferredOnHostError)
+    return print(
+        io,
+        "autodiff_deferred (and autodiff_deferred_thunk) can only be used inside GPU kernels. ",
+        "Use autodiff on the host, also for higher-order differentiation.",
+    )
+end
+
+# The compiler job for `spec` at `world`; `nothing` if the primal has no method for the
+# signature, or a `String` describing why the request is invalid.
+function deferred_job(spec::DeferredSpec, world::UInt)
+    ft = eltype(spec.FA)
+    primal_tt = Tuple{map(eltype, spec.TT.parameters)...}
+    sugar = spec.mode == API.DEM_ForwardMode ? Forward : Reverse
+
+    min_world = Ref{UInt}(typemin(UInt))
+    max_world = Ref{UInt}(typemax(UInt))
+    mi = my_methodinstance(sugar, ft, primal_tt, world, min_world, max_world)
+    mi === nothing && return nothing
+
+    A = spec.A
+    rt2 = if A isa UnionAll
+        rrt = primal_return_type_world(sugar, world, mi)
+
+        # Don't error here but default to nothing return since in cuda context we don't use the device overrides
+        if rrt == Union{}
+            rrt = Nothing
+        end
+
+        if !(A <: Const) && guaranteed_const_nongen(rrt, world)
+            return "Return type `$rrt` not marked Const, but type is guaranteed to be constant"
+        end
+        instantiate_annotation(A, rrt, spec.width)
+    else
+        @assert A isa DataType
+        A
+    end
+
+    params = EnzymeCompilerParams(
+        PrimalCompilerParams(spec.mode),
+        Tuple{spec.FA, spec.TT.parameters...},
+        spec.mode,
+        spec.width,
+        rt2,
+        true,
+        true,
+        spec.modified_between,
+        spec.return_primal,
+        spec.shadow_init,
+        spec.expected_tape_type,
+        FFIABI,
+        spec.err_if_func_written,
+        spec.runtime_activity,
+        spec.strong_zero
+    ) #=abiwrap=#
+    return CompilerJob(mi, CompilerConfig(EnzymeTarget(), params; kernel = false), world)
+end
+
+# Register `job` for the marker id of `spec` and return the id.
+function register_deferred!(spec::DeferredSpec, job::CompilerJob)
+    id = deferred_id(spec)
+    lock(DEFERRED_LOCK)
+    try
+        prev = get(DEFERRED_SPECS, id, nothing)
+        if prev !== nothing && prev != spec
+            error("deferred codegen id $id is claimed by two specifications: $prev and $spec")
+        end
+        DEFERRED_SPECS[id] = spec
+        # The same job object under both ids, so the deferred codegen pass compiles it once
+        # and resolves both markers to one function.
+        deferred_codegen_jobs[id] = job
+        deferred_codegen_jobs[deferred_twin_id(id)] = job
+    finally
+        unlock(DEFERRED_LOCK)
+    end
+    return id
+end
+
+# The specification a `deferred_id_codegen` specialization was created for, or `nothing` when
+# the specialization is not fully concrete.
+function deferred_spec(@nospecialize(specTypes::Type))
+    ps = specTypes.parameters
+    length(ps) == 13 || return nothing
+    vals = Vector{Any}(undef, 12)
+    for i in 2:13
+        p = ps[i]
+        p isa DataType || return nothing
+        if i in (2, 3, 4, 10)
+            p <: Type || return nothing
+            isempty(p.parameters) && return nothing
+            vals[i - 1] = p.parameters[1]
+        else
+            p <: Val || return nothing
+            isempty(p.parameters) && return nothing
+            vals[i - 1] = p.parameters[1]
+        end
+    end
+    return DeferredSpec(vals...)
+end
+
+"""
+    rebuild_deferred_registry!(world = Base.get_world_counter()) -> Int
+
+Register a compiler job for every `deferred_id_codegen` specialization that exists in this
+process, e.g. after the registry was cleared, and return how many were registered. A kernel
+whose code was loaded from a package image refers to its deferred ids without having run the
+generator that registers them in this session.
+"""
+function rebuild_deferred_registry!(world::UInt = Base.get_world_counter())
+    n = 0
+    for mi in Base.specializations(only(methods(deferred_id_codegen)))
+        spec = deferred_spec(mi.specTypes)
+        spec === nothing && continue
+        job = deferred_job(spec, world)
+        job isa CompilerJob || continue
+        register_deferred!(spec, job)
+        n += 1
+    end
+    return n
+end

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -9,21 +9,11 @@ import GPUCompiler
 import ..Compiler
 import ..Compiler: API, cpu_name, cpu_features
 
-export get_trampoline
-
 struct CompilerInstance
     jit::LLVM.JuliaOJIT
-    lctm::Union{LLVM.LazyCallThroughManager,Nothing}
-    ism::Union{LLVM.IndirectStubsManager,Nothing}
 end
 
 function LLVM.dispose(ci::CompilerInstance)
-    if ci.ism !== nothing
-        dispose(ci.ism)
-    end
-    if ci.lctm !== nothing
-        dispose(ci.lctm)
-    end
     dispose(ci.jit)
     return nothing
 end
@@ -99,15 +89,7 @@ function setup_globals()
     dg = LLVM.CreateDynamicLibrarySearchGeneratorForProcess(prefix)
     LLVM.add!(jd_main, dg)
 
-    es = ExecutionSession(lljit)
-    try
-        lctm = LLVM.LocalLazyCallThroughManager(triple(lljit), es)
-        ism = LLVM.LocalIndirectStubsManager(triple(lljit))
-        jit[] = CompilerInstance(lljit, lctm, ism)
-    catch err
-        @warn "OrcV2 initialization failed with" err
-        jit[] = CompilerInstance(lljit, nothing, nothing)
-    end
+    jit[] = CompilerInstance(lljit)
 
     jd_main, lljit
 end
@@ -153,24 +135,6 @@ function move_to_threadsafe(ir)
         mod = parse(LLVM.Module, buf)
         ThreadSafeModule(mod)
     end
-end
-
-function add_trampoline!(jd, (lljit, lctm, ism), entry, target)
-    flags = LLVM.API.LLVMJITSymbolFlags(
-        LLVM.API.LLVMJITSymbolGenericFlagsCallable |
-        LLVM.API.LLVMJITSymbolGenericFlagsExported,
-        0,
-    )
-
-    alias = LLVM.API.LLVMOrcCSymbolAliasMapPair(
-        mangle(lljit, entry),
-        LLVM.API.LLVMOrcCSymbolAliasMapEntry(mangle(lljit, target), flags),
-    )
-
-    mu = LLVM.reexports(lctm, ism, jd, [alias])
-    LLVM.define(jd, mu)
-
-    LLVM.lookup(lljit, jd, entry)
 end
 
 function prepare!(mod)
@@ -226,74 +190,6 @@ function prepare!(mod)
         replace_uses!(g, ptr)
         Compiler.eraseInst(mod, g)
     end
-end
-
-function get_trampoline(job)
-    compiler = jit[]
-    lljit = compiler.jit
-    lctm = compiler.lctm
-    ism = compiler.ism
-
-    if lctm === nothing || ism === nothing
-        error("Delayed compilation not available.")
-    end
-
-    mode = job.config.params.mode
-    use_primal = mode == API.DEM_ReverseModePrimal
-
-    # We could also use one dylib per job
-    jd = JITDylib(lljit)
-
-    sym = String(gensym(:func))
-    _sym = String(gensym(:func))
-    addr = add_trampoline!(jd, (lljit, lctm, ism), _sym, sym)
-
-    # 3. add MU that will call back into the compiler
-    function materialize(mr)
-        # Rename adjointf to match target_sym
-        # Really we should do:
-        # Create a re-export for a unique name, and a custom materialization unit that makes the deferred decision. E.g. add "foo" -> "my_deferred_decision_sym.1". Then define a CustomMU whose materialization method looks like:
-        # 1. Make the runtime decision about what symbol should implement "foo". Let's call this "foo.rt.impl".
-        # 2 Add a module defining "foo.rt.impl" to the JITDylib.
-        # 2. Call MR.replace(symbolAliases({"my_deferred_decision_sym.1" -> "foo.rt.impl"})).
-        GPUCompiler.JuliaContext() do ctx
-            mod, edges, adjoint_name, primal_name = Compiler._thunk(job)
-            func_name = use_primal ? primal_name : adjoint_name
-            other_name = !use_primal ? primal_name : adjoint_name
-
-            func = functions(mod)[func_name]
-            LLVM.name!(func, sym)
-
-            if other_name !== nothing
-                # Otherwise MR will complain -- we could claim responsibilty,
-                # but it would be nicer if _thunk just codegen'd the half
-                # we need.
-                other_func = functions(mod)[other_name]
-                Compiler.eraseInst(mod, other_func)
-            end
-
-	    prepare!(mod)
-            tsm = move_to_threadsafe(mod)
-
-            il = LLVM.IRCompileLayer(lljit)
-            LLVM.emit(il, mr, tsm)
-        end
-        return nothing
-    end
-
-    function discard(jd, sym) end
-
-    flags = LLVM.API.LLVMJITSymbolFlags(
-        LLVM.API.LLVMJITSymbolGenericFlagsCallable |
-        LLVM.API.LLVMJITSymbolGenericFlagsExported,
-        0,
-    )
-
-    symbols = [LLVM.API.LLVMOrcCSymbolFlagsMapPair(mangle(lljit, sym), flags)]
-
-    mu = LLVM.CustomMaterializationUnit(sym, symbols, materialize, discard)
-    LLVM.define(jd, mu)
-    return addr
 end
 
 function add!(mod)

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -1550,7 +1550,7 @@ end
 
     function f_gradient_deferred!(dx, x, tmp)
         dtmp = make_zero(tmp)
-        autodiff_deferred(Reverse, Const(f_ip), Active, Duplicated(x, dx), Duplicated(tmp, dtmp))
+        autodiff(Reverse, Const(f_ip), Active, Duplicated(x, dx), Duplicated(tmp, dtmp))
         return nothing
     end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -664,7 +664,7 @@ end
 
     function nested_df!(dx, x)
         make_zero!(dx)
-        autodiff_deferred(Reverse, Const(nested_f), Active, Duplicated(x, dx))
+        autodiff(Reverse, Const(nested_f), Active, Duplicated(x, dx))
         return nothing
     end
 

--- a/test/core/abi.jl
+++ b/test/core/abi.jl
@@ -29,13 +29,13 @@ end
     
     @test () === autodiff(Forward, f, Const(nothing))
 
-    res = autodiff_deferred(Reverse, Const(f), Const, Const(nothing))
+    res = autodiff(Reverse, Const(f), Const, Const(nothing))
     @test res === ((nothing,),)
-    res = autodiff_deferred(Enzyme.set_abi(Reverse, NonGenABI), Const(f), Const, Const(nothing))
+    res = autodiff(Enzyme.set_abi(Reverse, NonGenABI), Const(f), Const, Const(nothing))
     @test res === ((nothing,),)
     
-    @test () === autodiff_deferred(Forward, Const(f), Const, Const(nothing))
-    @test () === autodiff_deferred(Enzyme.set_abi(Forward, NonGenABI), Const(f), Const, Const(nothing))
+    @test () === autodiff(Forward, Const(f), Const, Const(nothing))
+    @test () === autodiff(Enzyme.set_abi(Forward, NonGenABI), Const(f), Const, Const(nothing))
 
     # ConstType -> Type{Int}
     res = autodiff(Reverse, f, Const, Const(Int))
@@ -46,9 +46,9 @@ end
     @test res === ((nothing,),)
     @test () === autodiff(Forward, f, Const(Int))
 
-    res = autodiff_deferred(Reverse, Const(f), Const, Const(Int))
+    res = autodiff(Reverse, Const(f), Const, Const(Int))
     @test res === ((nothing,),)
-    @test () === autodiff_deferred(Forward, Const(f), Const, Const(Int))
+    @test () === autodiff(Forward, Const(f), Const, Const(Int))
 
     # Complex numbers
     @test_throws ErrorException autodiff(Reverse, f, Active, Active(1.5 + 0.7im))
@@ -66,7 +66,7 @@ end
     @test_throws ErrorException autodiff_deferred(Reverse, Const(f), Active, Active(1.5 + 0.7im))
     @test_throws ErrorException autodiff_deferred(ReverseHolomorphic, Const(f), Active, Active(1.5 + 0.7im))
 
-    cres,  = autodiff_deferred(Forward, Const(f), Duplicated, Duplicated(1.5 + 0.7im, 1.0+0im))
+    cres, = autodiff(Forward, Const(f), Duplicated, Duplicated(1.5 + 0.7im, 1.0 + 0im))
     @test cres ≈ 1.0 + 0.0im
 
     # Unused singleton argument
@@ -106,7 +106,7 @@ end
 
     x = [0.0]
     dx = [1.2]
-    autodiff_deferred(Reverse, Const(squareRetArray), Const, Duplicated(x, dx))
+    autodiff(Reverse, Const(squareRetArray), Const, Duplicated(x, dx))
 
     dx = [1.2]
     @test () === autodiff(Forward, squareRetArray, Const, Duplicated(x, dx))
@@ -122,7 +122,7 @@ end
     @test pair[1] ≈ 3.0
     @test pair[2] ≈ 2.0
 
-    pair = autodiff_deferred(Reverse, Const(mul), Active, Active(2.0), Active(3.0))[1]
+    pair = autodiff(Reverse, Const(mul), Active, Active(2.0), Active(3.0))[1]
     @test pair[1] ≈ 3.0
     @test pair[2] ≈ 2.0
     
@@ -131,7 +131,7 @@ end
     @test pair[2] ≈ 2.0
     @test orig ≈ 6.0
     
-    pair, orig = autodiff_deferred(ReverseWithPrimal, Const(mul), Active, Active(2.0), Active(3.0))
+    pair, orig = autodiff(ReverseWithPrimal, Const(mul), Active, Active(2.0), Active(3.0))
     @test pair[1] ≈ 3.0
     @test pair[2] ≈ 2.0
     @test orig ≈ 6.0
@@ -151,7 +151,7 @@ end
     
     res = Ref(3.0)
     dres = Ref(1.0)
-    pair, orig = autodiff_deferred(ReverseWithPrimal, Const(inplace), Const, Duplicated(res, dres))
+    pair, orig = autodiff(ReverseWithPrimal, Const(inplace), Const, Duplicated(res, dres))
     @test pair == (nothing,)
     @test res[] ≈ 6.0
     @test dres[] ≈ 2.0
@@ -172,7 +172,7 @@ end
 
     res = Ref(3.0)
     dres = Ref(1.0)
-    pair, orig = autodiff_deferred(ReverseWithPrimal, Const(inplace2), Const, Duplicated(res, dres))
+    pair, orig = autodiff(ReverseWithPrimal, Const(inplace2), Const, Duplicated(res, dres))
     @test pair == (nothing,)
     @test res[] ≈ 6.0
     @test dres[] ≈ 2.0
@@ -187,7 +187,7 @@ end
     # pair = first(autodiff(Forward, tup, Duplicated(3.14, 1.0)))
     # @test pair[1] ≈ 1.0
     # @test pair[2] ≈ 2.0
-    # pair = first(autodiff_deferred(Forward, tup, Duplicated(3.14, 1.0)))
+    # pair = first(autodiff(Forward, tup, Duplicated(3.14, 1.0)))
     # @test pair[1] ≈ 1.0
     # @test pair[2] ≈ 2.0
 
@@ -319,7 +319,7 @@ unstable_load(x) = Base.inferencebarrier(x)[1]
 
     x = [2.7]
     dx = [0.0]
-    Enzyme.autodiff_deferred(Reverse, Const(unstable_load), Active, Duplicated(x, dx))
+    Enzyme.autodiff(Reverse, Const(unstable_load), Active, Duplicated(x, dx))
     @test dx ≈ [1.0] 
 end
 
@@ -473,7 +473,7 @@ end
     @test r[2] ≈ 100.0
     @test r[1][1] ≈ -400.0
     @test r[1][2] ≈ 200.0
-    r = autodiff_deferred(ForwardWithPrimal, Const(rosenbrock_inp), Duplicated, BatchDuplicated(x, (dx_1, dx_2)))
+    r = autodiff(ForwardWithPrimal, Const(rosenbrock_inp), Duplicated, BatchDuplicated(x, (dx_1, dx_2)))
     @test r[2] ≈ 100.0
     @test r[1][1] ≈ -400.0
     @test r[1][2] ≈ 200.0

--- a/test/core/deferred.jl
+++ b/test/core/deferred.jl
@@ -1,69 +1,72 @@
 using Enzyme, Test
+using Enzyme: API
+using Enzyme.Compiler: DeferredSpec, deferred_id, DeferredOnHostError, DEFERRED_SPECS,
+    rebuild_deferred_registry!, UnknownTapeType
+const GPUCompiler = Enzyme.Compiler.GPUCompiler
 
 @testset "deferred" begin
 
-    @testset "Deferred and deferred thunk" begin
-        function dot(A)
+    @testset "Host calls are an error" begin
+        function dot2(A)
             return A[1] * A[1] + A[2] * A[2]
         end
-        dA = zeros(2)
         A = [3.0, 5.0]
-        thunk_dA, def_dA = copy(dA), copy(dA)
-        def_A, thunk_A = copy(A), copy(A)
-        primal = Enzyme.autodiff(ReverseWithPrimal, dot, Active, Duplicated(A, dA))[2]
-        @test primal == 34.0
-        primal = Enzyme.autodiff_deferred(ReverseWithPrimal, Const(dot), Active, Duplicated(def_A, def_dA))[2]
-        @test primal == 34.0
-
-        dup = Duplicated(thunk_A, thunk_dA)
-        TapeType = Enzyme.EnzymeCore.tape_type(
-            ReverseSplitWithPrimal,
-            Const{typeof(dot)}, Active, Duplicated{typeof(thunk_A)}
+        dA = zeros(2)
+        @test_throws DeferredOnHostError autodiff_deferred(ReverseWithPrimal, Const(dot2), Active, Duplicated(A, dA))
+        @test_throws DeferredOnHostError autodiff_deferred(Forward, Const(dot2), Duplicated, Duplicated(A, dA))
+        TapeType = Enzyme.EnzymeCore.tape_type(ReverseSplitWithPrimal, Const{typeof(dot2)}, Active, Duplicated{typeof(A)})
+        @test_throws DeferredOnHostError autodiff_deferred_thunk(
+            ReverseSplitWithPrimal, TapeType, Const{typeof(dot2)}, Active, Duplicated{typeof(A)}
         )
-        @static if VERSION < v"1.11-"
-            @test Tuple{Float64, Float64} === TapeType
-        else
-            @test NamedTuple{(Symbol("1"), Symbol("2"), Symbol("3")), Tuple{Any, Float64, Float64}} === TapeType
-        end
-        Ret = Active
-        fwd, rev = Enzyme.autodiff_deferred_thunk(
-            ReverseSplitWithPrimal,
-            TapeType,
-            Const{typeof(dot)},
-            Ret,
-            Duplicated{typeof(thunk_A)}
+
+        # The host entry points do the job.
+        @test autodiff(ReverseWithPrimal, dot2, Active, Duplicated(A, dA))[2] == 34.0
+        @test dA == [6.0, 10.0]
+    end
+
+    @testset "Ids derive from the specification" begin
+        make_spec(width) = DeferredSpec(
+            Const{typeof(sin)}, Active, Tuple{Active{Float64}}, API.DEM_ReverseModeCombined,
+            width, (false, false), false, false, UnknownTapeType, false, false, false,
         )
-        tape, primal, _ = fwd(Const(dot), dup)
-        @test isa(tape, TapeType)
-        rev(Const(dot), dup, 1.0, tape)
-        @test all(primal == 34)
-        @test all(dA .== [6.0, 10.0])
-        @test all(dA .== def_dA)
-        @test all(dA .== thunk_dA)
+        id = deferred_id(make_spec(1))
+        @test id > 0
+        @test deferred_id(make_spec(1)) == id
+        @test deferred_id(make_spec(2)) != id
+        # Never one of GPUCompiler's own ids; the twin id is distinct and keeps that bit.
+        @test reinterpret(UInt, id) & Enzyme.Compiler.DEFERRED_ID_BIT != 0
+        twin = Enzyme.Compiler.deferred_twin_id(id)
+        @test twin != id
+        @test reinterpret(UInt, twin) & Enzyme.Compiler.DEFERRED_ID_BIT != 0
+        @test Enzyme.Compiler.deferred_twin_id(twin) == id
 
-        function kernel(len, A)
-            for i in 1:len
-                A[i] *= A[i]
-            end
+        # Another session derives the same id.
+        code = """
+        using Enzyme
+        using Enzyme: API
+        using Enzyme.Compiler: DeferredSpec, deferred_id, UnknownTapeType
+        print(deferred_id(DeferredSpec(
+            Const{typeof(sin)}, Active, Tuple{Active{Float64}}, API.DEM_ReverseModeCombined,
+            1, (false, false), false, false, UnknownTapeType, false, false, false,
+        )))
+        """
+        cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $code`
+        @test parse(Int, read(cmd, String)) == id
+    end
+
+    @testset "Registry rebuild" begin
+        ids = collect(keys(DEFERRED_SPECS))
+        @test !isempty(ids)
+        for id in ids
+            delete!(GPUCompiler.deferred_codegen_jobs, id)
         end
-
-        A = Array{Float64}(undef, 64)
-        dA = Array{Float64}(undef, 64)
-
-        A .= (1:1:64)
-        dA .= 1
-
-        function aug_fwd(ctx, f::FT, ::Val{ModifiedBetween}, args...) where {ModifiedBetween, FT}
-            TapeType = Enzyme.tape_type(ReverseSplitModified(ReverseSplitWithPrimal, Val(ModifiedBetween)), Const{Core.Typeof(f)}, Const, Const{Core.Typeof(ctx)}, map(Core.Typeof, args)...)
-            forward, reverse = Enzyme.autodiff_deferred_thunk(ReverseSplitModified(ReverseSplitWithPrimal, Val(ModifiedBetween)), TapeType, Const{Core.Typeof(f)}, Const, Const{Core.Typeof(ctx)}, map(Core.Typeof, args)...)
-            forward(Const(f), Const(ctx), args...)[1]
-            return nothing
+        @test rebuild_deferred_registry!() >= length(ids)
+        for id in ids
+            @test GPUCompiler.deferred_codegen_jobs[id] isa GPUCompiler.CompilerJob
+            # Both markers of a call site resolve to one job.
+            @test GPUCompiler.deferred_codegen_jobs[Enzyme.Compiler.deferred_twin_id(id)] ===
+                GPUCompiler.deferred_codegen_jobs[id]
         end
-
-        ModifiedBetween = Val((false, false, true))
-
-        aug_fwd(64, kernel, ModifiedBetween, Duplicated(A, dA))
-
     end
 
     @testset "Deferred upgrade" begin

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -16,7 +16,7 @@ function fun_gpu!(A, B, a)
 end
 
 function ∇_fun_cpu!(A, Ā, B, B̄, a)
-    Enzyme.autodiff_deferred(Reverse, Const(fun_cpu!), Const, DuplicatedNoNeed(A, Ā), DuplicatedNoNeed(B, B̄), Const(a))
+    Enzyme.autodiff(Reverse, Const(fun_cpu!), Const, DuplicatedNoNeed(A, Ā), DuplicatedNoNeed(B, B̄), Const(a))
     nothing
 end
 

--- a/test/rules/rule_inlining.jl
+++ b/test/rules/rule_inlining.jl
@@ -246,7 +246,7 @@ end
 end
 
 fwd_over(x) = autodiff(ForwardWithPrimal, Const(cube_nested), Duplicated(x, 1.0))[1]
-rev_over(x) = autodiff_deferred(Reverse, Const(cube_nested), Active, Active(x))[1][1]
+rev_over(x) = autodiff(Reverse, Const(cube_nested), Active, Active(x))[1][1]
 
 @testset "nested differentiation through natively called rules" begin
     @test fwd_over(2.0) == 120.0


### PR DESCRIPTION
Stacked on #3510. Part of the cache redesign towards session-local state and relocatable, cross-session cacheable compilation.

`deferred_id_codegen` embedded a host JIT trampoline address as the id of a
deferred job: GPUCompiler's host stub returns the id unchanged, so on the host
the id doubled as the function pointer. That address is only valid in the
session that created it, and a `deferred_id_codegen` CodeInstance loaded from
a package image returns a dead pointer.

Deferred codegen is only needed inside GPU kernels: on the host, and for
higher-order differentiation, `autodiff` is the entry point (Enzyme recognizes
nested `autodiff` calls itself). So:

- The id is now derived from the job's specification (`DeferredSpec`, entirely
  type-level), so it is the same in every session, and `deferred_codegen_jobs`
  can be repopulated from the specializations of `deferred_id_codegen`
  (`rebuild_deferred_registry!`). A high bit keeps the ids disjoint from
  GPUCompiler's counters.
- `deferred_codegen` emits the marker twice, under the id and a twin id that
  is registered to the same job. GPUCompiler's pass resolves both to one
  function, so the comparison folds away in device code before any later pass
  sees the function's address (GPUCompiler rewrites the signatures of
  functions using the kernel state and only accepts call and store uses). On
  the host both markers reach GPUCompiler's identity stub and differ, and the
  call throws `DeferredOnHostError`.
- The host trampoline machinery is gone: `get_trampoline`, `add_trampoline!`,
  and the lazy call-through and indirect-stubs managers in `JIT`.

Known gap: a kernel CodeInstance loaded from a package image whose device
object is not cached still misses in `deferred_codegen_jobs` inside
GPUCompiler's pass, which has no lookup fallback; that needs an upstream hook.

Tests that called `autodiff_deferred` natively on the host now use `autodiff`
(`core/abi`, the nested helpers in `basic`, `advanced` and
`rules/rule_inlining`, the CPU reference in `metal`), except the two `abi`
checks of errors that deferred codegen raises before the host check; the
`autodiff_deferred_thunk` docstring example is no longer a host doctest.
`core/deferred` covers the host error, id stability within and across
sessions, the twin ids and the registry rebuild. CUDA's test suite passes with
GPUCompiler 1.23/CUDA 6.2.2 and, apart from a pre-existing reverse-mode
limitation on `trylock` that CUDA 6.3's per-allocation locks expose, with
GPUCompiler 2.5/CUDA 6.3.1.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT