### PR TITLE
Add lock/unlock/trylock rules that mirror the lock in the reverse pass

### DIFF
--- a/src/internal_rules/core.jl
+++ b/src/internal_rules/core.jl
@@ -662,3 +662,112 @@ function EnzymeRules.reverse(
 ) where {RT,T}
     return (nothing,)
 end
+
+# Locks
+#
+# Taking or releasing a lock carries no derivative information, but the
+# region it protects is replayed in the reverse sweep, so the reverse pass must
+# hold the same lock over the same region.  The adjoint of `lock` is therefore
+# `unlock` and the adjoint of `unlock` is `lock`; `trylock` releases in the
+# reverse pass exactly when it acquired in the forward pass.  The shadow lock
+# is never touched.
+#
+# The closure-taking `lock(f, l)` / `trylock(f, l)` methods are deliberately
+# not matched, since `f` may be active; they reach these rules through the
+# inner single-argument calls.
+
+function EnzymeRules.forward(
+        config::EnzymeRules.FwdConfig,
+        func::Const{typeof(Base.lock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    func.val(l.val)
+    return nothing
+end
+
+function EnzymeRules.forward(
+        config::EnzymeRules.FwdConfig,
+        func::Const{typeof(Base.unlock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    func.val(l.val)
+    return nothing
+end
+
+function EnzymeRules.forward(
+        config::EnzymeRules.FwdConfig,
+        func::Const{typeof(Base.trylock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    acquired = func.val(l.val)
+    return EnzymeRules.needs_primal(config) ? acquired : nothing
+end
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{typeof(Base.lock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    func.val(l.val)
+    return EnzymeRules.AugmentedReturn(nothing, nothing, nothing)
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        ::Const{typeof(Base.lock)},
+        ::Type{<:Const},
+        ::Nothing,
+        l::Annotation{<:Base.AbstractLock},
+    )
+    Base.unlock(l.val)
+    return (nothing,)
+end
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{typeof(Base.unlock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    func.val(l.val)
+    return EnzymeRules.AugmentedReturn(nothing, nothing, nothing)
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        ::Const{typeof(Base.unlock)},
+        ::Type{<:Const},
+        ::Nothing,
+        l::Annotation{<:Base.AbstractLock},
+    )
+    Base.lock(l.val)
+    return (nothing,)
+end
+
+function EnzymeRules.augmented_primal(
+        config::EnzymeRules.RevConfig,
+        func::Const{typeof(Base.trylock)},
+        ::Type{<:Const},
+        l::Annotation{<:Base.AbstractLock},
+    )
+    acquired = func.val(l.val)
+    primal = EnzymeRules.needs_primal(config) ? acquired : nothing
+    return EnzymeRules.AugmentedReturn(primal, nothing, acquired)
+end
+
+function EnzymeRules.reverse(
+        config::EnzymeRules.RevConfig,
+        ::Const{typeof(Base.trylock)},
+        ::Type{<:Const},
+        tape::Bool,
+        l::Annotation{<:Base.AbstractLock},
+    )
+    if tape
+        Base.unlock(l.val)
+    end
+    return (nothing,)
+end

--- a/src/internal_rules/inactive.jl
+++ b/src/internal_rules/inactive.jl
@@ -145,6 +145,14 @@ function EnzymeRules.inactive_noinl(::typeof(Base.fieldnames), args...)
     return nothing
 end
 
+# Querying a lock never mutates it and never carries derivative information.
+# `lock`, `unlock` and `trylock` are not inactive: the reverse sweep of a
+# locked region must itself hold the lock, so they get proper rules in
+# core.jl that run `unlock` as the adjoint of `lock` and vice versa.
+function EnzymeRules.inactive_noinl(::typeof(Base.islocked), ::Base.AbstractLock)
+    return nothing
+end
+
 @inline EnzymeRules.inactive_type(v::Type{Nothing}) = true
 @inline EnzymeRules.inactive_type(v::Type{Union{}}) = true
 @inline EnzymeRules.inactive_type(v::Type{Char}) = true

--- a/test/locks.jl
+++ b/test/locks.jl
@@ -11,5 +11,148 @@ end
 
 @testset "Lock forward" begin
     Enzyme.autodiff(Forward, my_lock, Const)
+    @test !islocked(my_cache_lock)
 end
 
+@testset "Lock reverse" begin
+    Enzyme.autodiff(Reverse, my_lock, Const)
+    @test !islocked(my_cache_lock)
+end
+
+# A lock that records every acquire/release into a shared log, so the tests
+# can check that the reverse sweep holds the lock over the same region as the
+# forward sweep: the adjoint of `lock` is `unlock` and vice versa.
+mutable struct RecordingLock <: Base.AbstractLock
+    inner::ReentrantLock
+    name::Symbol
+    log::Vector{Tuple{Symbol, Symbol}}
+end
+RecordingLock(name, log) = RecordingLock(ReentrantLock(), name, log)
+function Base.lock(l::RecordingLock)
+    push!(l.log, (l.name, :lock))
+    return lock(l.inner)
+end
+function Base.unlock(l::RecordingLock)
+    push!(l.log, (l.name, :unlock))
+    return unlock(l.inner)
+end
+function Base.trylock(l::RecordingLock)
+    push!(l.log, (l.name, :trylock))
+    return trylock(l.inner)
+end
+Base.islocked(l::RecordingLock) = islocked(l.inner)
+
+mutable struct LockedBuf{L <: Base.AbstractLock}
+    lock::L
+    data::Vector{Float64}
+end
+
+function copy_locked!(d::LockedBuf, s::LockedBuf, n)
+    lock(d.lock)
+    try
+        lock(s.lock)
+        try
+            @inbounds for i in 1:n
+                d.data[i] = s.data[i]
+            end
+        finally
+            unlock(s.lock)
+        end
+    finally
+        unlock(d.lock)
+    end
+    return nothing
+end
+
+function trylock_copy!(d::LockedBuf, s::LockedBuf, n)
+    if trylock(d.lock)
+        @inbounds for i in 1:n
+            d.data[i] = s.data[i]
+        end
+        unlock(d.lock)
+    end
+    return nothing
+end
+
+@testset "Lock inside Duplicated forward" begin
+    for f in (copy_locked!, trylock_copy!)
+        log = Tuple{Symbol, Symbol}[]
+        d = LockedBuf(RecordingLock(:d, log), zeros(3))
+        s = LockedBuf(RecordingLock(:s, log), [1.0, 2.0, 3.0])
+        dd = LockedBuf(RecordingLock(:dd, log), zeros(3))
+        ds = LockedBuf(RecordingLock(:ds, log), [1.0, 1.0, 1.0])
+        Enzyme.autodiff(Forward, f, Const, Duplicated(d, dd), Duplicated(s, ds), Const(3))
+        @test d.data == [1.0, 2.0, 3.0]
+        @test dd.data == [1.0, 1.0, 1.0]
+        @test !islocked(d.lock)
+        @test !islocked(s.lock)
+        @test !islocked(dd.lock)
+        @test !islocked(ds.lock)
+        # Only the primal locks are touched, and only once each.
+        if f === copy_locked!
+            @test log == [(:d, :lock), (:s, :lock), (:s, :unlock), (:d, :unlock)]
+        else
+            @test log == [(:d, :trylock), (:d, :unlock)]
+        end
+    end
+end
+
+@testset "Lock inside Duplicated reverse" begin
+    for f in (copy_locked!, trylock_copy!)
+        log = Tuple{Symbol, Symbol}[]
+        d = LockedBuf(RecordingLock(:d, log), zeros(3))
+        s = LockedBuf(RecordingLock(:s, log), [1.0, 2.0, 3.0])
+        dd = LockedBuf(RecordingLock(:dd, log), ones(3))
+        ds = LockedBuf(RecordingLock(:ds, log), zeros(3))
+        Enzyme.autodiff(Reverse, f, Const, Duplicated(d, dd), Duplicated(s, ds), Const(3))
+        @test d.data == [1.0, 2.0, 3.0]
+        @test ds.data == [1.0, 1.0, 1.0]
+        @test dd.data == [0.0, 0.0, 0.0]
+        @test !islocked(d.lock)
+        @test !islocked(s.lock)
+        @test !islocked(dd.lock)
+        @test !islocked(ds.lock)
+        # The reverse sweep re-acquires the primal locks over the mirrored
+        # region: the adjoint of `unlock` is `lock` and the adjoint of `lock`
+        # (or a successful `trylock`) is `unlock`.  Shadow locks are untouched.
+        if f === copy_locked!
+            @test log == [
+                (:d, :lock), (:s, :lock), (:s, :unlock), (:d, :unlock),   # forward
+                (:d, :lock), (:s, :lock), (:s, :unlock), (:d, :unlock),   # reverse
+            ]
+        else
+            @test log == [
+                (:d, :trylock), (:d, :unlock),   # forward
+                (:d, :lock), (:d, :unlock),      # reverse
+            ]
+        end
+    end
+end
+
+# The reverse of a failed `trylock` must not release a lock it never held.
+@testset "trylock failure reverse" begin
+    log = Tuple{Symbol, Symbol}[]
+    d = LockedBuf(RecordingLock(:d, log), zeros(3))
+    s = LockedBuf(RecordingLock(:s, log), [1.0, 2.0, 3.0])
+    dd = LockedBuf(RecordingLock(:dd, log), ones(3))
+    ds = LockedBuf(RecordingLock(:ds, log), zeros(3))
+    # Hold the lock from another task so the primal trylock fails (a
+    # ReentrantLock held by this task would be re-acquired successfully).
+    started = Base.Event()
+    release = Base.Event()
+    holder = Threads.@spawn begin
+        lock(d.lock.inner)
+        notify(started)
+        wait(release)
+        unlock(d.lock.inner)
+    end
+    wait(started)
+    Enzyme.autodiff(Reverse, trylock_copy!, Const, Duplicated(d, dd), Duplicated(s, ds), Const(3))
+    notify(release)
+    wait(holder)
+    @test d.data == [0.0, 0.0, 0.0]
+    @test ds.data == [0.0, 0.0, 0.0]
+    @test dd.data == [1.0, 1.0, 1.0]
+    @test log == [(:d, :trylock)]
+    @test !islocked(d.lock)
+end


### PR DESCRIPTION
Reverse-mode differentiation through a `ReentrantLock` that lives inside a `Duplicated` object failed inside `Base._trylock` with "cannot handle unknown instruction: cmpxchg" on the `havelock` field. The same code worked with a global lock, and it surfaced in practice because CUDA.jl 6.3 takes per-allocation locks in `unsafe_copyto!`, so a reverse-mode copy between `Duplicated` CuArrays now hit it.

Enzyme.jl never declared any rule for the lock primitives. Activity analysis saw the lock pointer loaded from a shadowed object, treated the call as a potential active store through it, and enzyme-core recursed into `_trylock` and `_unlock`, where the cmpxchg has no derivative.

Marking the primitives inactive (the first version of this PR) would silently drop the lock from the reverse sweep: the region a lock protects is replayed backwards, so the reverse pass must hold the same lock over the same region. This adds forward and reverse rules for the single-argument `lock`, `unlock` and `trylock` methods on `AbstractLock` instead:

- Forward mode runs the primal only.
- Reverse mode: the augmented primal runs the primal and stores the lock on the tape. The adjoint of `lock` is `unlock`, the adjoint of `unlock` is `lock`, and the adjoint of `trylock` is `unlock` exactly when the forward `trylock` acquired.
- Shadow locks are never touched. `islocked` is a pure query and stays inactive.
- The closure-taking `lock(f, l)` / `trylock(f, l)` methods are deliberately not matched because `f` may be active; they reach the rules through their inner single-argument calls.

Tests: `test/locks.jl` gains a `RecordingLock` that logs every acquire and release into a shared vector, and checks the exact event order for lock/unlock and trylock on locks inside `Duplicated` structs in both modes, e.g. for a nested `lock(d); lock(s); ...; unlock(s); unlock(d)` region the log is

```
(:d, :lock), (:s, :lock), (:s, :unlock), (:d, :unlock),   # forward
(:d, :lock), (:s, :lock), (:s, :unlock), (:d, :unlock),   # reverse
```

It also checks that a failed `trylock` is not unlocked in the reverse pass, and that all locks are released afterwards. Ran `test/locks.jl` on Julia 1.12 and 1.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMa2ZdykwFNF7pAYjwFNc1
