### PR TITLE
Keep C callees symbolic instead of binding them to this session's addresses

### DIFF
--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -174,9 +174,34 @@ end
 #   :match    — the name resolves to `ptr`
 #   :mismatch — the name resolves to a different pointer, so it is the wrong name for `ptr`
 #   :unknown  — the name could not be resolved
-function resolve_symbol_name(fn::String, file::String, ptr::Ptr{Cvoid})::Symbol
+# `resolve_symbol` also returns the library the verdict was reached in, as a string that
+# `jl_load_and_lookup` accepts, or `nothing`: it names the library of a symbolic
+# `ejlstr\$fn\$lib` declaration (see `symbolize_call_target!`).
+resolve_symbol_name(fn::String, file::String, ptr::Ptr{Cvoid})::Symbol = resolve_symbol(fn, file, ptr)[1]
+
+# The library containing `ptr`, as a string `jl_load_and_lookup` accepts, or `nothing`.
+function library_of(ptr::Ptr{Cvoid})::Union{Nothing, String}
+    @static if Sys.iswindows()
+        return nothing
+    else
+        info = Ref(DlInfo(C_NULL, C_NULL, C_NULL, C_NULL))
+        if ccall(:dladdr, Cint, (Ptr{Cvoid}, Ref{DlInfo}), ptr, info) != 0 &&
+                info[].fname != C_NULL
+            fname = unsafe_string(info[].fname)
+            lib = Libdl.dlopen(fname, Libdl.RTLD_LAZY | Libdl.RTLD_NOLOAD; throw_error = false)
+            if lib !== nothing
+                Libdl.dlclose(lib)
+                return fname
+            end
+        end
+        return nothing
+    end
+end
+
+function resolve_symbol(fn::String, file::String, ptr::Ptr{Cvoid})::Tuple{Symbol, Union{Nothing, String}}
     hnd = C_NULL
     needsclose = false
+    libname = nothing
     @static if Sys.iswindows()
         # GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT
         href = Ref{Ptr{Cvoid}}(C_NULL)
@@ -195,14 +220,12 @@ function resolve_symbol_name(fn::String, file::String, ptr::Ptr{Cvoid})::Symbol
         info = Ref(DlInfo(C_NULL, C_NULL, C_NULL, C_NULL))
         if ccall(:dladdr, Cint, (Ptr{Cvoid}, Ref{DlInfo}), ptr, info) != 0 &&
                 info[].fname != C_NULL
-            lib = Libdl.dlopen(
-                unsafe_string(info[].fname),
-                Libdl.RTLD_LAZY | Libdl.RTLD_NOLOAD;
-                throw_error = false,
-            )
+            fname = unsafe_string(info[].fname)
+            lib = Libdl.dlopen(fname, Libdl.RTLD_LAZY | Libdl.RTLD_NOLOAD; throw_error = false)
             if lib !== nothing
                 hnd = lib
                 needsclose = true
+                libname = fname
             end
         end
     end
@@ -213,19 +236,47 @@ function resolve_symbol_name(fn::String, file::String, ptr::Ptr{Cvoid})::Symbol
         if lib !== nothing
             hnd = lib
             needsclose = true
+            libname = file
         end
     end
     if hnd == C_NULL
-        return :unknown
+        return (:unknown, nothing)
     end
     resolved = Libdl.dlsym(hnd, fn; throw_error = false)
     if needsclose
         Libdl.dlclose(hnd)
     end
     if resolved === nothing
-        return :unknown
+        return (:unknown, libname)
     end
-    return resolved == ptr ? (:match) : (:mismatch)
+    return (resolved == ptr ? (:match) : (:mismatch), libname)
+end
+
+# Whether the process resolves the symbol `fn` to `ptr`: the same search the JIT runs for
+# an undefined symbol (libjulia, libc and every library loaded globally). Such a
+# declaration keeps its plain name, which is also what Enzyme's rules match on, and is
+# never bound to an address.
+process_resolves(fn::String, ptr::Ptr{Cvoid})::Bool = LLVM.find_symbol(fn) == ptr
+
+# Declare a symbolic callee for a call through the literal pointer `ptr` that
+# `jl_lookup_code_address`/`resolve_symbol` identified as `fn` in `lib`: an
+# `ejlstr\$fn\$lib` declaration, resolved with `jl_load_and_lookup` when the module is
+# linked (`JIT.fix_ptr_lookup`), carrying `enzyme_math = fn` so that Enzyme's rules see the
+# real name. This is the same form the `jl_load_and_lookup` handling above produces, and
+# it is what keeps the module free of this session's addresses.
+function symbolize_call_target!(mod::LLVM.Module, inst::LLVM.CallInst, fn::String, lib::String)
+    FT = LLVM.FunctionType(LLVM.API.LLVMGetCalledFunctionType(inst))
+    fused_name = "ejlstr\$$fn\$$lib"
+    newf, _ = get_function!(mod, fused_name, FT)
+    decl = newf
+    while isa(decl, LLVM.ConstantExpr)
+        decl = operands(decl)[1]
+    end
+    if !has_fn_attr(decl, StringAttribute("enzyme_math", fn))
+        push!(function_attributes(decl), StringAttribute("enzyme_math", fn))
+    end
+    LLVM.API.LLVMSetOperand(inst, LLVM.API.LLVMGetNumOperands(inst) - 1, newf)
+    return nothing
 end
 
 """
@@ -258,6 +309,17 @@ function restore_native_invokes!(mod::LLVM.Module)::Nothing
     return nothing
 end
 
+# Marks a module in which `restore_lookups` bound a callee to an address of this session.
+const NONRELOCATABLE_FLAG = "enzyme.nonrelocatable"
+
+function mark_nonrelocatable!(mod::LLVM.Module)
+    fl = LLVM.flags(mod)
+    if !haskey(fl, NONRELOCATABLE_FLAG)
+        fl[NONRELOCATABLE_FLAG, LLVM.API.LLVMModuleFlagBehaviorWarning] = Metadata(ConstantInt(Int32(1)))
+    end
+    return nothing
+end
+
 function restore_lookups(mod::LLVM.Module; native_invokes::Bool = true)::Nothing
     T_size_t = convert(LLVM.LLVMType, Int)
     native_invoke = StringAttribute("enzymejl_native_invoke")
@@ -273,6 +335,10 @@ function restore_lookups(mod::LLVM.Module; native_invokes::Bool = true)::Nothing
             if isa(fattr, LLVM.StringAttribute)
                 if kind(fattr) == "enzymejl_needs_restoration"
                     v = parse(UInt, LLVM.value(fattr))
+                    if !has_fn_attr(f, native_invoke) && process_resolves(nm, Ptr{Cvoid}(v))
+                        # The JIT resolves the name itself; leave it symbolic.
+                        continue
+                    end
                     replace_uses!(
                         f,
                         LLVM.Value(
@@ -282,6 +348,7 @@ function restore_lookups(mod::LLVM.Module; native_invokes::Bool = true)::Nothing
                             ),
                         ),
                     )
+                    mark_nonrelocatable!(mod)
                 end
             end
         end
@@ -310,17 +377,32 @@ function restore_lookups(mod::LLVM.Module; native_invokes::Bool = true)::Nothing
                     repf,
                 )
                 eraseInst(mod, f)
+            elseif process_resolves(k, v)
+                # The JIT resolves the name itself; leave it symbolic.
+                continue
             else
-                replace_uses!(
-                    f,
-                    LLVM.Value(
-                        LLVM.API.LLVMConstIntToPtr(
-                            ConstantInt(T_size_t, convert(UInt, v)),
-                            value_type(f),
+                lib = library_of(v)
+                if lib !== nothing
+                    # Resolved when the module is linked, like the `jl_load_and_lookup`
+                    # targets above: `ejlstr\$k\$lib`, carrying the real name for Enzyme's
+                    # rules.
+                    attrs = LLVM.Attribute[StringAttribute("enzyme_math", k)]
+                    repf, _ = get_function!(mod, "ejlstr\$$k\$$lib", LLVM.function_type(f), attrs)
+                    replace_uses!(f, repf)
+                    eraseInst(mod, f)
+                else
+                    replace_uses!(
+                        f,
+                        LLVM.Value(
+                            LLVM.API.LLVMConstIntToPtr(
+                                ConstantInt(T_size_t, convert(UInt, v)),
+                                value_type(f),
+                            ),
                         ),
-                    ),
-                )
-                eraseInst(mod, f)
+                    )
+                    eraseInst(mod, f)
+                    mark_nonrelocatable!(mod)
+                end
             end
         end
     end
@@ -1576,12 +1658,30 @@ function check_ir!(interp, @nospecialize(job::CompilerJob), errors::Vector{IRErr
                         # Windows with `__gmpz_init2`/`__gmpz_set_si`). Drop names that
                         # provably belong to a different address. Curated `FFI.ptr_map`
                         # names are trusted as-is.
-                        if length(fn) > 0 && !haskey(FFI.ptr_map, ptr) &&
-                                resolve_symbol_name(fn, string(file), ptr) == :mismatch
+                        verdict, lib = if length(fn) > 0
+                            resolve_symbol(fn, string(file), ptr)
+                        else
+                            (:unknown, nothing)
+                        end
+                        if verdict == :mismatch && !haskey(FFI.ptr_map, ptr)
                             fn = ""
                         end
 
-                        if length(fn) > 0
+                        if length(fn) > 0 && process_resolves(fn, ptr)
+                            # Resolved by the JIT from the process: a plain declaration.
+                            mod = LLVM.parent(LLVM.parent(LLVM.parent(inst)))
+                            newf, _ = get_function!(mod, fn, LLVM.FunctionType(LLVM.API.LLVMGetCalledFunctionType(inst)))
+                            LLVM.API.LLVMSetOperand(inst, LLVM.API.LLVMGetNumOperands(inst) - 1, newf)
+                            fn = ""
+                            lfn = nothing
+                        elseif length(fn) > 0 && lib !== nothing &&
+                                (verdict == :match || haskey(FFI.ptr_map, ptr))
+                            # The library is known and the name verified (or curated):
+                            # keep the reference symbolic instead of binding the address.
+                            symbolize_call_target!(LLVM.parent(LLVM.parent(LLVM.parent(inst))), inst, fn, lib)
+                            fn = ""
+                            lfn = nothing
+                        elseif length(fn) > 0
                             mod = LLVM.parent(LLVM.parent(LLVM.parent(inst)))
                             lfn = LLVM.API.LLVMGetNamedFunction(mod, fn)
                             if lfn != C_NULL

--- a/test/symbolic_lookups.jl
+++ b/test/symbolic_lookups.jl
@@ -1,0 +1,80 @@
+using Enzyme, LinearAlgebra, Test
+
+# The module Enzyme hands to its JIT must not bind C callees to addresses of this session:
+# a call through a literal pointer that `check_ir` could attribute to a symbol in a
+# library becomes an `ejlstr$name$library` declaration, resolved when the module is
+# linked, and calls into Julia's runtime or the C library keep their plain names for the
+# JIT to resolve from the process.
+
+const THUNK_CACHE = Enzyme.Compiler.THUNK_CACHE
+
+# The IR of the last thunk compiled, as kept for nested differentiation.
+function last_thunk_ir(f, args...)
+    empty!(THUNK_CACHE.by_ptr)
+    autodiff(Reverse, f, args...)
+    return first(values(THUNK_CACHE.by_ptr))[2]
+end
+
+# A call whose callee is a literal address (opaque or typed pointers).
+const LITERAL_CALLEE = r"call[^\n]*inttoptr \(i64 \d{9,} to (ptr|[^\n]*\*)\)\("
+
+literal_callees(ir) = [m.match for m in eachmatch(LITERAL_CALLEE, ir)]
+symbolic_decls(ir) = [m.captures[1] for m in eachmatch(r"declare[^\n]*@\"?(ejlstr\$[^\"( ]+)", ir)]
+plain_decls(ir) = [m.captures[1] for m in eachmatch(r"declare[^\n]*@(i?jl_[A-Za-z0-9_]+|malloc|free|memcpy|memmove|memset|memcmp)\b", ir)]
+
+sl_memcmp(x) = (a = [x[1], x[2]]; b = [x[2], x[1]]; ccall(:memcmp, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), a, b, 16) == 0 ? x[1] : x[2])
+sl_blas(x) = dot(x, x)
+sl_alloc(x) = sum(exp.(x) ./ (1 .+ x .^ 2))
+function sl_malloc(x)
+    p = Libc.malloc(8)
+    Base.unsafe_store!(Ptr{Float64}(p), x[1] * 2)
+    v = Base.unsafe_load(Ptr{Float64}(p))
+    Libc.free(p)
+    return v
+end
+
+x = [1.0, 2.0]
+
+@testset "C symbols are declared, not bound" begin
+    # libc is loaded globally, so the JIT resolves `memcmp` by its plain name.
+    ir = last_thunk_ir(sl_memcmp, Duplicated(x, zero(x)))
+    @test isempty(literal_callees(ir))
+    @test "memcmp" in plain_decls(ir)
+    @test !occursin(Enzyme.Compiler.NONRELOCATABLE_FLAG, ir)
+
+    # libblastrampoline is not, so its symbols are declared with their library.
+    ir = last_thunk_ir(sl_blas, Duplicated(x, zero(x)))
+    @test isempty(literal_callees(ir))
+    @test any(d -> occursin("blastrampoline", d), symbolic_decls(ir))
+    @test occursin(r"\"enzyme_math\"=\"[a-z_0-9]*(dot|copy|axpy)", ir)
+    @test !occursin(Enzyme.Compiler.NONRELOCATABLE_FLAG, ir)
+    @test autodiff(Reverse, sl_blas, Duplicated(x, zero(x))) isa Tuple
+end
+
+@testset "runtime and libc symbols keep their names" begin
+    ir = last_thunk_ir(sl_alloc, Duplicated(x, zero(x)))
+    @test isempty(literal_callees(ir))
+    @test !isempty(plain_decls(ir))
+
+    # Type analysis of the malloc'd store/load pair is not supported on 1.10.
+    @static if VERSION >= v"1.11"
+        ir = last_thunk_ir(sl_malloc, Duplicated(x, zero(x)))
+        @test isempty(literal_callees(ir))
+        @test any(d -> d in ("malloc", "free"), plain_decls(ir))
+        @test !occursin(Enzyme.Compiler.NONRELOCATABLE_FLAG, ir)
+    end
+end
+
+@testset "results are unchanged" begin
+    dx = zero(x)
+    autodiff(Reverse, sl_alloc, Duplicated(x, dx))
+    @test dx ≈ [(exp(1.0) * (1 + 1) - exp(1.0) * 2) / 4, (exp(2.0) * 5 - exp(2.0) * 4) / 25]
+    dx = zero(x)
+    autodiff(Reverse, sl_blas, Duplicated(x, dx))
+    @test dx ≈ 2 .* x
+    @static if VERSION >= v"1.11"
+        dx = zero(x)
+        autodiff(Reverse, sl_malloc, Duplicated(x, dx))
+        @test dx ≈ [2.0, 0.0]
+    end
+end


### PR DESCRIPTION
Stacked on #3512. Part of the cache redesign towards session-local state and relocatable, cross-session cacheable compilation.

Keep C callees symbolic instead of binding them to this session's addresses

`check_ir` turns a call through a literal pointer into a declaration named
after the symbol `jl_lookup_code_address` (or the curated `FFI.ptr_map`)
reports, tagged with the pointer, and `restore_lookups` then replaces the
declaration with that pointer again, for every such callee and for every
`FFI.ptr_map` name enzyme-core's rules emit (the BLAS helpers of a reverse
pass, for instance). The module Enzyme's JIT receives therefore embeds
addresses of this session, and can never be reused by another one.

Two kinds of callee need no address at all. A symbol the process resolves
(`LLVM.find_symbol`, the same search the ORC JIT runs for an undefined symbol:
libjulia, libc, anything loaded globally) keeps its plain declaration, which
is also the name Enzyme's rules match on. A symbol in a library that is not
global (libblastrampoline, typically) becomes an `ejlstr$name$library`
declaration carrying `enzyme_math = name`, exactly the form the
`jl_load_and_lookup` handling already produces, which `JIT.fix_ptr_lookup`
resolves through `jl_load_and_lookup` when the module is linked. The library
is the one `dladdr` reports for the pointer (`library_of`), and for a name
that came from the lookup it must also verify to the pointer there
(`resolve_symbol`). Only a pointer neither of these covers is still bound,
and doing so now sets the module flag `enzyme.nonrelocatable`, so a later
change can tell which modules are safe to persist.

Test: `test/symbolic_lookups.jl` checks that the differentiated modules for a
`ccall(:memcmp, …)`, a BLAS `dot` and an allocating broadcast contain no
literal call target, that `memcmp` and the runtime calls stay plain
declarations, that the BLAS calls are `ejlstr$…$libblastrampoline`
declarations with `enzyme_math`, that the modules are not flagged, and that
the derivatives are unchanged. Passes with `blas`, `basic`, `tests`,
`core/deferred`, `relocation`, `rules/rules`, `session_cache`,
`ext/specialfunctions`, `ext/jlarrays`, `DiffTests`, `advanced` on Julia 1.12
with GPUCompiler 2.5 and 1.23, and on Julia 1.10.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT