### PR TITLE
Refer to Julia values from generated code through named globals

### DIFF
--- a/src/absint.jl
+++ b/src/absint.jl
@@ -123,7 +123,10 @@ function absint(@nospecialize(arg::LLVM.Value), partial::Bool = false, istracked
                     return (true, v)
                 end
             end
-	    @assert !startswith(gname, "ejl_inserted") "Could not find ejl_inserted variable in map $gname"
+            found, v = relocation_value(gname)
+            if found
+                return (true, v)
+            end
         end
         if isa(ce, LLVM.LoadInst)
             gv = operands(ce)[1]
@@ -276,6 +279,10 @@ function absint(@nospecialize(arg::LLVM.Value), partial::Bool = false, istracked
             if gname == k || gname == "ejl_" * k
                 return (true, v)
             end
+        end
+        found, v = relocation_value(gname)
+        if found
+            return (true, v)
         end
     end
 
@@ -507,6 +514,10 @@ function abs_typeof(
                 if gname == "ejl_" * k
 		    return (true, Core.Typeof(unbind(v)), GPUCompiler.BITS_REF)
                 end
+            end
+            found, v = relocation_value(gname)
+            if found
+                return (true, Core.Typeof(v), GPUCompiler.BITS_REF)
             end
         end
         if isa(ce, LLVM.LoadInst)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -550,6 +550,7 @@ const JuliaEnzymeNameMap = Dict{String,Any}(
     "enz_non_scalar_return_exc" => EnzymeNonScalarReturnException,
 )
 
+include("compiler/relocation.jl")
 include("absint.jl")
 include("llvm/transforms.jl")
 include("llvm/passes.jl")
@@ -7405,25 +7406,22 @@ Empty every cache Enzyme keeps in a global, dropping what this session compiled,
 and rooted along with them.
 
 Nearly all of it means something only to the session that filled it. A `CompileResult` holds
-the address the JIT gave a thunk, `captured_constants` roots objects because their addresses
-were written into that code, the rule and activity memos are keyed on world ages, and the
+the address the JIT gave a thunk, the rule and activity memos are keyed on rule-set epochs
+and world ages, and the
 `jl_load_and_lookup` handles are ones this process opened. Anything outliving the session
 must not carry them, which is why Enzyme's precompile workload ends with this call: what it
 left behind would otherwise be serialized into Enzyme's package image and inherited, dead,
 by every session that loads it.
 
-This is meant for the end of precompilation and not for a live session. It hands back the
-thunks the JIT compiled and unroots the objects their code refers to by address, so a thunk
-still held anywhere is left pointing at objects that may now be collected.
+This is meant for the end of precompilation and not for a live session: it starts a new
+session epoch, so every thunk held anywhere is linked again on its next use.
 
 Caches filled by `__init__` rather than by compiling are left alone: they are rebuilt per
 session and so never reach an image.
 """
 function clear_caches!()
-    # Thunks, held as the addresses the JIT gave them, and the objects rooted because those
-    # addresses were written into their code.
+    # Thunks, held as the links the JIT made for them in this session.
     reset_session!()
-    empty!(Enzyme.captured_constants)
 
     # Which rules apply, memoized against the rule-set epoch they were read in, and the rule
     # families those epochs were derived from.

--- a/src/compiler/orcv2.jl
+++ b/src/compiler/orcv2.jl
@@ -163,25 +163,11 @@ function prepare!(mod)
         replace_uses!(f, ptr)
         Compiler.eraseInst(mod, f)
     end
+    # Bind the symbolic Julia value references (`compiler/relocation.jl`) to the objects'
+    # addresses in this process.
     for g in collect(globals(mod))
-        if !startswith(LLVM.name(g), "ejl_inserted\$")
-           continue
-        end
-        _, ogname, load1, initaddr = split(LLVM.name(g), "\$")
-
-        load1 = load1 == "true"
-            initaddr = parse(UInt, initaddr)
-        ptr = Base.reinterpret(Ptr{Ptr{Cvoid}}, initaddr)
-        if load1
-           ptr = Base.unsafe_load(ptr, :unordered)
-        end
-                
-        obj = Base.unsafe_pointer_to_objref(ptr)
-	
-        # Let's try a de-bind for 1.10 lux
-        if isa(obj, Core.Binding)
-           ptr = Compiler.unsafe_to_ptr(obj.value)
-        end
+        Compiler.is_relocation_name(LLVM.name(g)) || continue
+        ptr = Compiler.relocation_pointer(LLVM.name(g))
 
         ptr = reinterpret(UInt, ptr)
         ptr = LLVM.ConstantInt(ptr)

--- a/src/compiler/relocation.jl
+++ b/src/compiler/relocation.jl
@@ -1,0 +1,106 @@
+# Symbolic references to Julia values from generated code.
+#
+# Generated code refers to a Julia object through a named global `ejl_v_<id>` whose address
+# is the object: the form Enzyme already uses for the values of `JuliaGlobalNameMap` and
+# `JuliaEnzymeNameMap`. `RELOC_TARGETS` maps the name to the object, and the JIT binds the
+# name to the object's address only when the module is linked (`JIT.prepare!`), so the module
+# Enzyme emits carries no address of this session. Targets are rooted for the lifetime of the
+# process by `jl_as_global_root`, which also canonicalizes egal immutables, so equal values
+# share one name. A `Core.Binding` target stands for the value of the binding.
+
+const RELOC_LOCK = ReentrantLock()
+const RELOC_TARGETS = Dict{String, Any}()
+const RELOC_PREFIX = "ejl_v_"
+
+# Root `val` for the lifetime of the process and return its canonical rooted instance, as
+# Julia's own codegen does for values referenced from native code.
+function root_value(@nospecialize(val))
+    @static if VERSION >= v"1.11-"
+        return ccall(:jl_as_global_root, Any, (Any, Cint), val, 1)
+    else
+        return ccall(:jl_as_global_root, Any, (Any,), val)
+    end
+end
+
+value_pointer(@nospecialize(val)) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), val)
+
+# The global name standing for `val`, registering it on first use.
+function relocation_name(@nospecialize(val))::String
+    val = root_value(val)
+    base = RELOC_PREFIX * string(objectid(val); base = 16)
+    lock(RELOC_LOCK)
+    return try
+        name = base
+        i = 0
+        while true
+            prev = get(RELOC_TARGETS, name, nothing)
+            if prev === nothing && !haskey(RELOC_TARGETS, name)
+                RELOC_TARGETS[name] = val
+                return name
+            elseif prev === val
+                return name
+            end
+            i += 1
+            name = base * "_" * string(i)
+        end
+    finally
+        unlock(RELOC_LOCK)
+    end
+end
+
+is_relocation_name(gname::AbstractString) = startswith(gname, RELOC_PREFIX)
+
+# `(true, target)` for a registered global name, `(false, nothing)` otherwise.
+function relocation_target(gname::AbstractString)::Tuple{Bool, Any}
+    is_relocation_name(gname) || return (false, nothing)
+    lock(RELOC_LOCK)
+    try
+        if haskey(RELOC_TARGETS, gname)
+            return (true, RELOC_TARGETS[gname])
+        end
+    finally
+        unlock(RELOC_LOCK)
+    end
+    return (false, nothing)
+end
+
+# The value a registered global denotes: a binding's target is the binding's value.
+function relocation_value(gname::AbstractString)::Tuple{Bool, Any}
+    found, target = relocation_target(gname)
+    found || return (false, nothing)
+    return (true, unbind(target))
+end
+
+# The address the global `gname` must be bound to in this process.
+function relocation_pointer(gname::AbstractString)::Ptr{Cvoid}
+    found, target = relocation_target(gname)
+    found || error("$gname is not a registered Julia value reference")
+    return value_pointer(root_value(unbind(target)))
+end
+
+"""
+    manifest(mod::LLVM.Module) -> Vector{Pair{String, Any}}
+
+The Julia values `mod` refers to symbolically, by global name.
+"""
+function manifest(mod::LLVM.Module)
+    m = Pair{String, Any}[]
+    for g in globals(mod)
+        gname = LLVM.name(g)
+        found, target = relocation_target(gname)
+        found && push!(m, gname => target)
+    end
+    return m
+end
+
+# Whether every target can be reconstructed in another process from its serialized form.
+function persistable(m::AbstractVector{<:Pair{String}})::Bool
+    for (_, target) in m
+        v = unbind(target)
+        (
+            v isa Type || v isa Symbol || v isa String || v isa Module || v isa Core.MethodInstance ||
+                v isa Method || (isbits(v) && !(v isa Ptr))
+        ) || return false
+    end
+    return true
+end

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -550,7 +550,8 @@ function try_replace_constant_load!(@nospecialize(inst::LLVM.Instruction); check
 
         b = IRBuilder()
         position!(b, inst)
-        newf = unsafe_to_llvm(b, obj0; insert_name_if_not_exists = gname)
+        # A folded global constant was always marked inactive; keep that.
+        newf = unsafe_to_llvm(b, obj0; force_inactive = gname isa String)
         if do_replace
             replace_uses!(inst, newf)
             LLVM.API.LLVMInstructionEraseFromParent(inst)
@@ -1261,7 +1262,7 @@ function check_ir!(interp, @nospecialize(job::CompilerJob), errors::Vector{IRErr
                 fname = String(map(Base.Fix1(convert, UInt8), collect(fname)[1:(end - 1)]))
             end
 
-            # Julia 1.13+: fname is an ejl_inserted GlobalVariable holding a Julia Symbol.
+            # Julia 1.13+: fname is a named global standing for a Julia Symbol.
             if !isa(fname, String)
                 legal2, sym = absint(fname_llvm)
                 if legal2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,8 +60,6 @@ const Tracked = 10
 const Derived = 11
 export Tracked, Derived
 
-const captured_constants = Base.IdSet{Any}()
-
 function arg_operands_view(inst::LLVM.CallInst)
     N_args = LLVM.API.LLVMGetNumArgOperands(inst)
     return @view LLVM.operands(inst)[1:N_args]
@@ -82,18 +80,10 @@ function unsafe_nothing_to_llvm(mod::LLVM.Module)
     return gv
 end
 
+# The address of `val` as native code refers to it: the canonical instance rooted for the
+# lifetime of the process (a stable box for an immutable value).
 function unsafe_to_ptr(@nospecialize(val))
-    if !Base.ismutable(val)
-        val = Core.Box(val) # FIXME many objects could be leaked here
-        @assert Base.ismutable(val)
-        push!(captured_constants, val) # Globally root
-        ptr = unsafe_load(Base.reinterpret(Ptr{Ptr{Cvoid}}, Base.pointer_from_objref(val)))
-    else
-        @assert Base.ismutable(val)
-        push!(captured_constants, val) # Globally root
-        ptr = Base.pointer_from_objref(val)
-    end
-    return ptr
+    return Compiler.value_pointer(Compiler.root_value(val))
 end
 export unsafe_to_ptr
 
@@ -105,31 +95,17 @@ function setup_global(
         B::LLVM.IRBuilder,
         T_jlvalue::LLVM.StructType,
         world::Union{UInt, Nothing},
-        insert_name_if_not_exists::Union{String, Nothing},
-        k::String,
+        force_inactive::Bool,
+        gname::String,
         @nospecialize(val),
     )::LLVM.Value
     mod = LLVM.parent(LLVM.parent(LLVM.position(B)))
     globs = LLVM.globals(mod)
-    if Base.haskey(globs, "ejl_" * k)
-        return globs["ejl_" * k]
+    if Base.haskey(globs, gname)
+        return globs[gname]
     end
 
-    force_inactive = false
-    if insert_name_if_not_exists isa String
-        k = "inserted\$" * insert_name_if_not_exists
-        if !haskey(Compiler.JuliaEnzymeNameMap, k)
-            Compiler.JuliaEnzymeNameMap[k] = val
-        end
-        # Since the legacy behavior was to force inactive for global constants, we retain that here (for now)
-        force_inactive = true
-    end
-
-    if Base.haskey(globs, "ejl_" * k)
-        return globs["ejl_" * k]
-    end
-
-    gv = LLVM.GlobalVariable(mod, T_jlvalue, "ejl_" * k, Tracked)
+    gv = LLVM.GlobalVariable(mod, T_jlvalue, gname, Tracked)
 
     API.SetMD(gv, "enzyme_ta_norecur", LLVM.MDNode(LLVM.Metadata[]))
     inactive = force_inactive || Enzyme.Compiler.is_memory_instance(val)
@@ -149,11 +125,12 @@ function setup_global(
     return gv
 end
 
-# This mimicks literal_pointer_val / literal_pointer_val_slot
-function unsafe_to_llvm(B::LLVM.IRBuilder, @nospecialize(val); insert_name_if_not_exists::Union{String, Nothing}=nothing)::LLVM.Value
+# This mimicks literal_pointer_val / literal_pointer_val_slot: the Julia object `val` as a
+# tracked pointer constant, always through a named global (see `compiler/relocation.jl`) so
+# that the module carries no address of this session. `force_inactive` marks the reference
+# inactive regardless of its type, the behavior kept for folded global constants.
+function unsafe_to_llvm(B::LLVM.IRBuilder, @nospecialize(val); force_inactive::Bool = false)::LLVM.Value
     T_jlvalue = LLVM.StructType(LLVM.LLVMType[])
-    T_prjlvalue = LLVM.PointerType(T_jlvalue, Tracked)
-    T_prjlvalue_UT = LLVM.PointerType(T_jlvalue)
 
     world = nothing
     for fattr in collect(LLVM.function_attributes(LLVM.parent(LLVM.position(B))))
@@ -168,29 +145,17 @@ function unsafe_to_llvm(B::LLVM.IRBuilder, @nospecialize(val); insert_name_if_no
 
     for (k, v) in Compiler.JuliaGlobalNameMap
         if v === val
-            return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, k, val)
+            return setup_global(B, T_jlvalue, world, force_inactive, "ejl_" * k, val)
         end
     end
 
     for (k, v) in Compiler.JuliaEnzymeNameMap
         if v === val
-            return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, k, val)
+            return setup_global(B, T_jlvalue, world, force_inactive, "ejl_" * k, val)
         end
     end
 
-    if insert_name_if_not_exists !== nothing
-        return setup_global(B, T_jlvalue, world, insert_name_if_not_exists, insert_name_if_not_exists, val)
-    end
-
-    # XXX: This prevents code from being runtime relocatable
-    #      We likely should emit global variables and use something
-    #      like `absolute_symbol_materialization` and write out cache-files
-    #      that have relocation tables.
-    ptr = unsafe_to_ptr(val)
-
-    fill_val = LLVM.ConstantInt(convert(UInt, ptr))
-    fill_val = LLVM.const_inttoptr(fill_val, T_prjlvalue_UT)
-    LLVM.const_addrspacecast(fill_val, T_prjlvalue)
+    return setup_global(B, T_jlvalue, world, force_inactive, Compiler.relocation_name(val), val)
 end
 export unsafe_to_llvm, unsafe_nothing_to_llvm
 

--- a/test/julia_value_refs.jl
+++ b/test/julia_value_refs.jl
@@ -1,0 +1,106 @@
+using Enzyme, LLVM, Test
+
+# Julia objects that Enzyme's generated code refers to (rule configurations, types, error
+# payloads, folded global constants) are named globals `ejl_v_*` bound to the objects'
+# addresses only when the module is linked, so the module itself carries no address of this
+# session. `Enzyme.Compiler.manifest` lists them.
+
+const C = Enzyme.Compiler
+const THUNK_CACHE = C.THUNK_CACHE
+
+# The IR of every thunk compiled by differentiating `f` (the runtime rules compile thunks
+# for dynamic callees as the derivative runs, so there can be several), as kept for nested
+# differentiation. Only a first differentiation compiles anything.
+function thunk_irs(f, args...)
+    empty!(THUNK_CACHE.by_ptr)
+    autodiff(Reverse, f, args...)
+    return unique(map(last, values(THUNK_CACHE.by_ptr)))
+end
+
+value_globals(ir) = unique([m.captures[1] for m in eachmatch(r"@\"?(ejl_v_[0-9a-f_]+)", ir)])
+
+# A dynamic call goes through the runtime rules, whose emitted code refers to the
+# activity configuration, types and the called functions.
+vr_dynamic(x) = (
+    v = Any[x[1]]; s = 0.0; for e in v
+        s += e * 2
+    end; s
+)
+
+const VR_KEEP = Any[[1.0, 2.0]]
+vr_global(x) = VR_KEEP[1][1] * x[1] + x[2]
+
+x = [1.0, 2.0]
+
+@testset "references are named and resolvable" begin
+    irs = thunk_irs(vr_dynamic, Active, Duplicated(x, zero(x)))
+    @test !isempty(irs)
+    @test !any(Base.Fix1(occursin, "ejl_inserted"), irs)
+    # The module with the most references is the one differentiating the dynamic call.
+    ir = argmax(ir -> length(value_globals(ir)), irs)
+    names = value_globals(ir)
+    @test !isempty(names)
+    LLVM.Context() do ctx
+        mod = parse(LLVM.Module, ir)
+        man = C.manifest(mod)
+        @test Set(first.(man)) == Set(names)
+        @test C.persistable(man)
+        for (name, target) in man
+            gv = LLVM.globals(mod)[name]
+            val = C.unbind(target)
+            legal, v = C.absint(gv)
+            @test legal && v === val
+            legal, T, _ = C.abs_typeof(gv)
+            @test legal && T == Core.Typeof(val)
+            @test C.relocation_pointer(name) == C.unsafe_to_ptr(val)
+        end
+    end
+end
+
+@testset "equal values share a name, distinct objects do not" begin
+    n1 = C.relocation_name(Val(3))
+    @test C.relocation_name(Val(3)) == n1
+    @test C.relocation_name((1, 2.0)) == C.relocation_name((1, 2.0))
+    @test C.relocation_name(Val(3)) != C.relocation_name(Val(4))
+    a = [1.0]
+    b = [1.0]
+    @test C.relocation_name(a) != C.relocation_name(b)
+    @test C.relocation_name(a) == C.relocation_name(a)
+    @test C.relocation_value(n1) == (true, Val(3))
+    @test C.relocation_value("ejl_v_nonexistent") == (false, nothing)
+    @test !C.persistable(["ejl_v_x" => a])
+    @test C.persistable(["ejl_v_x" => Val(3), "ejl_v_y" => :sym, "ejl_v_z" => Int])
+end
+
+@testset "emitting a reference" begin
+    LLVM.Context() do ctx
+        mod = LLVM.Module("refs")
+        ft = LLVM.FunctionType(LLVM.VoidType())
+        fn = LLVM.Function(mod, "f", ft)
+        bb = LLVM.BasicBlock(fn, "entry")
+        LLVM.@dispose builder = LLVM.IRBuilder() begin
+            LLVM.position!(builder, bb)
+            g1 = C.unsafe_to_llvm(builder, Val(7))
+            g2 = C.unsafe_to_llvm(builder, Val(7))
+            g3 = C.unsafe_to_llvm(builder, nothing)
+            LLVM.ret!(builder)
+            @test g1 === g2
+            @test g1 isa LLVM.GlobalVariable
+            @test startswith(LLVM.name(g1), C.RELOC_PREFIX)
+            @test LLVM.name(g3) == "ejl_jl_nothing"
+            @test C.absint(g1) == (true, Val(7))
+        end
+        @test !occursin("inttoptr", string(mod))
+    end
+end
+
+@testset "derivatives are unchanged" begin
+    irs = thunk_irs(vr_global, Active, Duplicated(x, zero(x)))
+    @test !any(Base.Fix1(occursin, "ejl_inserted"), irs)
+    dx = zero(x)
+    autodiff(Reverse, vr_global, Active, Duplicated(x, dx))
+    @test dx == [1.0, 1.0]
+    dx = zero(x)
+    autodiff(Reverse, vr_dynamic, Active, Duplicated(x, dx))
+    @test dx == [2.0, 0.0]
+end


### PR DESCRIPTION
Stacked on #3514. Part of the cache redesign towards session-local state and relocatable, cross-session cacheable compilation.

Refer to Julia values from generated code through named globals

`unsafe_to_llvm`, the one place where Enzyme's generated code takes a
reference to a Julia object (rule configurations, types, error payloads, the
function objects of runtime rules, folded global constants), emitted the
object's address as an `inttoptr` constant unless the object was one of the
fixed entries of `JuliaGlobalNameMap`/`JuliaEnzymeNameMap`. Folded constants
went through a variant that registered the value in `JuliaEnzymeNameMap` at
compile time under a name that spelled out the address, which `JIT.prepare!`
parsed back. Either way the module carried addresses of this session, and the
values were kept alive by boxing them and pushing the boxes into a global set
that only ever grew.

Every such reference is now a global `ejl_v_<id>` whose address is the object,
the form the name-map entries already had. `compiler/relocation.jl` keeps the
registry from name to object (`RELOC_TARGETS`): the object is rooted for the
lifetime of the process with `jl_as_global_root`, which also canonicalizes
egal immutables so that equal values share one name, and a `Core.Binding`
target stands for the binding's value. `absint` and `abs_typeof` read the
object back through the registry, `manifest(mod)` lists the values a module
refers to (`persistable` says whether they could be reconstructed in another
process), and `JIT.prepare!` binds each name to the object's address when the
module is linked. `unsafe_to_ptr` roots the same way, and `captured_constants`
and the compile-time mutation of `JuliaEnzymeNameMap` are gone. A folded
global constant keeps its forced-inactive marking through the new
`force_inactive` keyword.

References Julia's own codegen emits (baked by GPUCompiler's `:bake` strategy,
or by Julia's JIT mode on GPUCompiler 1.x) are unchanged here; making the
primal module symbolic is a separate change.

Test: `test/julia_value_refs.jl` differentiates a dynamic call and a function
reading a global constant, and checks that the thunks refer to their values
only by name, that the manifest covers exactly those names and is persistable,
that `absint`/`abs_typeof`/`relocation_pointer` recover value, type and
address, that equal immutables share a name while distinct mutables do not,
that `unsafe_to_llvm` emits no `inttoptr`, and that the derivatives are
unchanged. Passes with `relocation`, `symbolic_lookups`, `basic`, `tests`,
`typeunstable`, `rules/rules`, `absint`, `advanced`, `mixed`, `core/deferred`,
`applyiter`, `usermixed` on Julia 1.12 with GPUCompiler 2.5 and 1.23, and on
Julia 1.10.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT