### PR TITLE
Call native custom rules through their CodeInstance, not a baked address

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7791,6 +7791,9 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
             end
             string(mod)
         end
+        # The string above keeps the rule declarations symbolic for nested differentiation;
+        # the compiled module calls them through their CodeInstances.
+        bind_native_invokes!(mod)
         if job.config.params.ABI <: FFIABI || job.config.params.ABI <: NonGenABI
             if DumpPrePostOpt[]
                 API.EnzymeDumpModuleRef(mod.ref)
@@ -7805,11 +7808,9 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
         end
         mstr
     else
+        bind_native_invokes!(mod)
         ""
     end
-    # The module string above keeps the rule declarations symbolic for nested
-    # differentiation; the compiled module binds them to their addresses.
-    restore_native_invokes!(mod)
     return (mod, meta.edges, adjoint_name, primal_name, meta.TapeType, prepost)
 end
 
@@ -7824,6 +7825,9 @@ function link_artifact!(@nospecialize(job::CompilerJob), art::ThunkArtifact, @no
         # have emitted the module), then link as usual.
         for (name, target) in art.manifest
             register_relocation!(name, target)
+            # A natively called rule loads its entry point from its CodeInstance at run time;
+            # make sure the instance is compiled in this session before that happens.
+            target isa Core.CodeInstance && ensure_native_compiled!(target)
         end
         mod = parse(LLVM.Module, MemoryBuffer(art.bitcode))
         return _link(job, mod, art.edges, art.adjoint_name, art.primal_name, art.tape_type, art.prepost, entries)

--- a/src/compiler/callconv.jl
+++ b/src/compiler/callconv.jl
@@ -356,14 +356,14 @@ end
 
     Declare the natively compiled function `mi`, with return type `RT`, in `mod`,
     with the signature [`specsig`](@ref) derives. Store the entry point
-    `specptr` in the `enzymejl_needs_restoration` attribute. `restore_lookups`
-    turns that attribute into the address once the calling module is final.
+            `bind_native_invokes!` later gives the declaration a body that calls the
+            function through its `CodeInstance`.
     """
     function declare_native!(mod::LLVM.Module, mi::Core.MethodInstance, @nospecialize(RT::Type), specptr::Ptr{Cvoid}, name::String, world::UInt)::LLVM.Function
         fn = specsig_function!(mod, mi, RT, name, world)
-        push!(function_attributes(fn), StringAttribute("enzymejl_needs_restoration", string(convert(UInt, specptr))))
-        # `restore_lookups` leaves the declaration symbolic until the module
-        # is compiled, and `materialize_native_invokes!` finds it by this marker.
+        # The declaration stays symbolic until `bind_native_invokes!` gives it a body (after
+        # the module string for nested differentiation is taken), and
+        # `materialize_native_invokes!` finds it by this marker.
         push!(function_attributes(fn), StringAttribute("enzymejl_native_invoke"))
         return fn
     end
@@ -480,6 +480,78 @@ end
         return (ci, specptr)
     end
 
+    # The declaration of a natively called function is named after the relocation name of the
+    # `CodeInstance` it calls, which registers that instance as a Julia-value reference like any
+    # other (`compiler/relocation.jl`); `bind_native_invokes!` reads it back from the name.
+    native_symbol_name(ci::Core.CodeInstance)::String = "ejlnative\$" * relocation_name(ci)
+
+    const SPECPTR_OFFSET = fieldoffset(Core.CodeInstance, Base.fieldindex(Core.CodeInstance, :specptr))
+
+    # Compile `ci` (waiting for it) so that its `specptr` is set before code that loads it runs.
+    function ensure_native_compiled!(ci::Core.CodeInstance)::Nothing
+        specptr, _ = Interpreter.codeinst_entry(ci)
+        specptr == C_NULL && error("Enzyme: CodeInstance $(ci) has no specialized entry point")
+        return nothing
+    end
+
+    """
+        bind_native_invokes!(mod)
+
+    Give every natively called declaration (`declare_native!`) a body that calls the
+    function through its `CodeInstance`: the instance is referenced as a Julia value
+    (an `ejl_v_*` global, so the module carries no address and Julia's serialization of
+    the instance is what makes the reference valid in another session), and its specialized
+    entry point is loaded from the instance's `specptr` field at run time, the shape Julia's
+    own image-mode codegen gives an `invoke`. The body is always inlined, so each call site
+    becomes a load and an indirect call with the declaration's calling convention and
+    parameter attributes. Runs after the module string for nested differentiation is taken,
+    which must still see declarations (`materialize_native_invokes!`).
+    """
+    function bind_native_invokes!(mod::LLVM.Module)::Nothing
+        marker = StringAttribute("enzymejl_native_invoke")
+        prefix = "ejlnative\$"
+        for fn in collect(functions(mod))
+            isdeclaration(fn) || continue
+            has_fn_attr(fn, marker) || continue
+            fname = LLVM.name(fn)
+            startswith(fname, prefix) || continue
+            found, ci = relocation_value(fname[(ncodeunits(prefix) + 1):end])
+            (found && ci isa Core.CodeInstance) || error("Enzyme: native invoke $fname has no CodeInstance")
+            ft = LLVM.function_type(fn)
+            entry = BasicBlock(fn, "entry")
+            b = IRBuilder()
+            position!(b, entry)
+            civ = unsafe_to_llvm(b, ci)
+            T_i8 = LLVM.Int8Type()
+            T_fnptr = LLVM.PointerType(ft)
+            p0 = addrspacecast!(b, civ, LLVM.PointerType(T_i8))
+            slot = inbounds_gep!(b, T_i8, p0, [ConstantInt(Int64(SPECPTR_OFFSET))])
+            slot = bitcast!(b, slot, LLVM.PointerType(T_fnptr))
+            fp = load!(b, T_fnptr, slot)
+            ordering!(fp, LLVM.API.LLVMAtomicOrderingMonotonic)
+            alignment!(fp, 8)
+            args = collect(LLVM.Value, parameters(fn))
+            call = call!(b, ft, fp, args)
+            callconv!(call, callconv(fn))
+            for i in 1:length(args)
+                for attr in collect(parameter_attributes(fn, i))
+                    LLVM.API.LLVMAddCallSiteAttribute(call, LLVM.API.LLVMAttributeIndex(i), attr)
+                end
+            end
+            if has_fn_attr(fn, EnumAttribute("noreturn"))
+                unreachable!(b)
+            elseif LLVM.return_type(ft) == LLVM.VoidType()
+                ret!(b)
+            else
+                ret!(b, call)
+            end
+            dispose(b)
+            push!(function_attributes(fn), EnumAttribute("alwaysinline"))
+            linkage!(fn, LLVM.API.LLVMInternalLinkage)
+        end
+        return nothing
+    end
+
     """
         native_return_type(mod::LLVM.Module, mi::MethodInstance, world::UInt) -> Union{Nothing, Type}
 
@@ -571,7 +643,7 @@ end
         end
         ci, specptr = native
 
-        name = "ejl_enzyme_" * GPUCompiler.safe_name(string(funcspec.def.name)) * "_" * string(convert(UInt, pointer_from_objref(funcspec)))
+        name = native_symbol_name(ci)
         fn = declare_native!(mod, funcspec, ci.rettype, specptr, name, world)
 
         # The native code stays valid as long as its CodeInstance does.
@@ -667,5 +739,8 @@ else
     check_emitted_specsig(mod::LLVM.Module, llvmf::LLVM.Function, mi::Core.MethodInstance, @nospecialize(RT::Type)) = nothing
 
     materialize_native_invokes!(enzyme_context::EnzymeContext, mode::API.CDerivativeMode, mod::LLVM.Module, world::UInt) = nothing
+
+    bind_native_invokes!(mod::LLVM.Module)::Nothing = nothing
+    ensure_native_compiled!(ci::Core.CodeInstance)::Nothing = nothing
 
 end

--- a/src/compiler/relocation.jl
+++ b/src/compiler/relocation.jl
@@ -115,6 +115,7 @@ function persistable(m::AbstractVector{<:Pair{String}})::Bool
         v = unbind(target)
         (
             v isa Type || v isa Symbol || v isa String || v isa Module || v isa Core.MethodInstance ||
+                v isa Core.CodeInstance ||
                 v isa Method || (isbits(v) && !(v isa Ptr))
         ) || return false
     end

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -280,34 +280,11 @@ function symbolize_call_target!(mod::LLVM.Module, inst::LLVM.CallInst, fn::Strin
 end
 
 """
-    restore_native_invokes!(mod::LLVM.Module)
 
 Bind the declarations of natively called functions in `mod` to their entry
 addresses. `restore_lookups(mod; native_invokes = false)` skips them, so that
 the module can still be differentiated again while they are symbolic.
 """
-function restore_native_invokes!(mod::LLVM.Module)::Nothing
-    T_size_t = convert(LLVM.LLVMType, Int)
-    marker = StringAttribute("enzymejl_native_invoke")
-    for f in functions(mod)
-        has_fn_attr(f, marker) || continue
-        for fattr in collect(function_attributes(f))
-            if isa(fattr, LLVM.StringAttribute) && kind(fattr) == "enzymejl_needs_restoration"
-                v = parse(UInt, LLVM.value(fattr))
-                replace_uses!(
-                    f,
-                    LLVM.Value(
-                        LLVM.API.LLVMConstIntToPtr(
-                            ConstantInt(T_size_t, convert(UInt, v)),
-                            value_type(f),
-                        ),
-                    ),
-                )
-            end
-        end
-    end
-    return nothing
-end
 
 # Marks a module in which `restore_lookups` bound a callee to an address of this session.
 const NONRELOCATABLE_FLAG = "enzyme.nonrelocatable"

--- a/test/ci_results.jl
+++ b/test/ci_results.jl
@@ -1,4 +1,4 @@
-using Enzyme, Test
+using Enzyme, LLVM, Test
 
 # A compiled thunk's session-portable artifact (bitcode plus entry names) is attached to its
 # primal-partition CodeInstance on Julia 1.11+. A fresh session, or one that dropped its
@@ -76,4 +76,81 @@ end
     # Persistable artifacts need the symbolic primal, which comes next; what this guards
     # is that loading the image and differentiating works at all (#1549).
     @test parse(Int, emit) >= 0
+end
+
+# A natively called custom rule (a `@noinline` rule, Julia 1.12+) is reached through its
+# CodeInstance, referenced as a Julia value and read for its entry point at run time, so a
+# thunk calling it is persistable too, and a fresh process starts it without an emit.
+@static if Enzyme.Compiler.Interpreter.HAS_INVOKE_RULES
+    import Enzyme.EnzymeRules: forward, FwdConfig
+
+    @noinline cir_native(x) = x * x
+    @noinline function forward(config::FwdConfig, ::Const{typeof(cir_native)}, ::Type{RT}, x::Duplicated) where {RT <: Annotation}
+        dv = 2 * x.val * x.dval
+        return RT <: Const ? cir_native(x.val) : (RT <: DuplicatedNoNeed ? dv : Duplicated(cir_native(x.val), dv))
+    end
+    cir_calls_native(x) = cir_native(x) + x
+
+    @testset "native rules keep the artifact persistable" begin
+        C.reset_session!()
+        @test autodiff(Forward, cir_calls_native, Duplicated(3.0, 1.0))[1] == 7.0
+        if C.HAS_CI_RESULTS
+            e = only(C.thunk_entries(cir_calls_native))
+            art = C.enzyme_ci_results(C.thunk_job(e)[1]).artifact
+            @test art !== nothing
+            @test art.persistable
+            @test any(t -> last(t) isa Core.CodeInstance, art.manifest)
+            # No address of this session in the bitcode: the rule is called through its CI.
+            LLVM.Context() do ctx
+                mod = parse(LLVM.Module, LLVM.MemoryBuffer(art.bitcode))
+                ir = string(mod)
+                @test !occursin(r"call[^\n]*inttoptr \(i64 \d{9,}", ir)
+            end
+            C.reset_session!()
+            before = C.EMIT_COUNT[]
+            @test autodiff(Forward, cir_calls_native, Duplicated(4.0, 1.0))[1] == 9.0
+            @test C.EMIT_COUNT[] == before
+        end
+        # Differentiating through the rule (nested) still sees its code.
+        cir_grad(x) = autodiff(Forward, cir_calls_native, Duplicated(x, 1.0))[1]
+        @test autodiff(Forward, cir_grad, Duplicated(3.0, 1.0))[1] == 2.0
+    end
+
+    @testset "native rules ride into a package image" begin
+        C.HAS_CI_RESULTS || return
+        load_path = mktempdir()
+        depot = mktempdir()
+        pkg = "EnzymeCINativeRuleTest"
+        write(
+            joinpath(load_path, "$pkg.jl"),
+            """
+            module $pkg
+            using Enzyme
+            import Enzyme.EnzymeRules: forward, FwdConfig
+            @noinline inner(x) = x * x
+            @noinline function forward(config::FwdConfig, ::Const{typeof(inner)}, ::Type{RT}, x::Duplicated) where {RT <: Annotation}
+                dv = 2 * x.val * x.dval
+                return RT <: Const ? inner(x.val) : (RT <: DuplicatedNoNeed ? dv : Duplicated(inner(x.val), dv))
+            end
+            outer(x) = inner(x) + x
+            grad(x) = Enzyme.autodiff(Forward, outer, Duplicated(x, 1.0))[1]
+            const PRECOMPILED = grad(3.0)
+            end
+            """,
+        )
+        code = """
+        pushfirst!(LOAD_PATH, $(repr(load_path)))
+        using Enzyme, $pkg
+        Enzyme.Compiler.EMIT_COUNT[] = 0
+        print($pkg.grad(4.0), " ", Enzyme.Compiler.EMIT_COUNT[])
+        """
+        cmd = addenv(
+            `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $code`,
+            "JULIA_DEPOT_PATH" => join([depot; DEPOT_PATH], Sys.iswindows() ? ";" : ":"),
+        )
+        read(cmd, String)
+        val, emit = split(read(cmd, String))
+        @test parse(Float64, val) == 9.0
+        @test parse(Int, emit) == 0
+    end
 end


### PR DESCRIPTION
Stacked on #3518, and removes its one caveat: thunks that call natively compiled custom rules are now persistable too. Part of the cache redesign towards session-local state and relocatable, cross-session cacheable compilation; this shape (a CodeInstance referenced as a Julia value, entry point read from it at run time, no Enzyme symbol table) is also what a juliac build needs.

Call native custom rules through their CodeInstance, not a baked address

A natively called custom rule (a `@noinline` rule on Julia 1.12+, #3479) was
declared in the differentiated module and, once the module was final,
`restore_native_invokes!` replaced the declaration with the rule's entry
address as an `inttoptr` constant. The compiled module therefore carried an
address of this session, and an artifact of it (#3518) could not be reused by
another process; worse, nothing marked it as such, so a reloaded artifact
would have called a dead address.

The declaration is now bound the way Julia's own image-mode codegen binds an
`invoke`: `bind_native_invokes!` gives it an always-inline body that refers to
the rule's `CodeInstance` as a Julia value (an `ejl_v_*` global, so the
instance is one more entry of the module's manifest and is rooted, serialized
and re-registered like any other value) and loads the specialized entry point
from the instance's `specptr` field at run time, calling through it with the
declaration's calling convention and parameter attributes. The declaration is
named after the instance's relocation name so the binding step can find the
instance; there is no Enzyme-side symbol table and nothing to define in the
JIT, which also keeps the shape viable without an ORC JIT (juliac).
`link_artifact!` compiles the instance (`ensure_native_compiled!`) before code
that loads its entry point can run in a new session. The binding runs after the
module string for nested differentiation is taken, which must still see
declarations (`materialize_native_invokes!`), and before post-optimization, so
each call site becomes a load and an indirect call. `restore_native_invokes!`
and the `enzymejl_needs_restoration` attribute on rule declarations are gone;
`persistable` accepts `CodeInstance` targets.

Test: `test/ci_results.jl` gains, on Julia 1.12+, a `@noinline` forward rule
whose caller's artifact is persistable, carries a `CodeInstance`, contains no
`inttoptr` call target, relinks after a session reset with no emit, and is
differentiable through (forward over forward); and a package defining such a
rule and differentiating in its own precompilation, loaded in a fresh process,
computing the right derivative with zero emits. Reverse-mode `@noinline`
rules and forward-over-reverse were checked by hand. Passes with `rules/rules`,
`rules/rule_inlining`, `thunk_handle`, `session_cache`, `julia_value_refs`,
`symbolic_lookups`, `basic`, `tests`, `advanced`, `core/deferred`, `mixed`,
`core/abi`, `ext/jlarrays`, `typeunstable` on Julia 1.12 with GPUCompiler 2.5
and 1.23, and on Julia 1.10.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT