### PR TITLE
Keep addresses of this process out of persisted artifacts

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -138,6 +138,27 @@ struct PrimalCompilerParams <: AbstractEnzymeCompilerParams
     mode::API.CDerivativeMode
 end
 
+"""
+    SYMBOLIC_PRIMAL
+
+Whether the primal module refers to Julia objects by name instead of by address.
+
+With this set (the default), GPUCompiler leaves Julia's value references as empty slots plus
+a manifest (`:patch`) and `adopt_relocations!` replaces every load of a slot by the object's
+name, so the module carries no address of this process and its artifact can be reused by
+another session. Off, the primal keeps Julia's baked addresses (`:bake`) and
+`bakes_addresses` keeps the resulting artifacts out of the cross-session cache; kept as a
+switch for bisecting.
+"""
+const SYMBOLIC_PRIMAL = Ref(true)
+
+@static if isdefined(GPUCompiler, :Relocations)
+    GPUCompiler.relocation_lowering(
+        @nospecialize(job::CompilerJob{<:GPUCompiler.NativeCompilerTarget, <:PrimalCompilerParams})
+    ) = SYMBOLIC_PRIMAL[] ? :patch : :bake
+end
+
+
 function EnzymeCompilerParams(TT, mode, width, rt, run_enzyme, abiwrap,
                               modifiedBetween, returnPrimal, shadowInit,
                               expectedTapeType, ABI,
@@ -1546,7 +1567,10 @@ function nested_codegen!(
 
     GPUCompiler.prepare_job!(job)
     otherMod, meta = GPUCompiler.emit_llvm(job)
-    
+    # As in `compile_unhooked`: the module Julia hands back refers to objects through
+    # relocation slots, which must be pointed at their objects by name before it is used.
+    adopt_relocations!(otherMod::LLVM.Module, hasproperty(meta, :relocations) ? meta.relocations : nothing)
+
     interp = GPUCompiler.get_interpreter(job)
     prepare_llvm(interp, otherMod, job, meta)
 
@@ -5656,6 +5680,9 @@ function GPUCompiler.compile_unhooked(output::Symbol, job::CompilerJob{<:EnzymeT
     @safe_debug "Emit LLVM with" primal_job
     GPUCompiler.prepare_job!(primal_job)
     mod, meta = GPUCompiler.emit_llvm(primal_job)
+    # Julia's codegen refers to objects through relocation slots; turn them into Enzyme's
+    # symbolic references before anything else looks at the module.
+    adopt_relocations!(mod::LLVM.Module, hasproperty(meta, :relocations) ? meta.relocations : nothing)
     # `emit_llvm` is not concretely inferred, so without this assertion every
     # subsequent use of `mod` (e.g. `LLVM.context(mod)`) is a dynamic dispatch
     # through jl_apply_generic, which forces boxing and GC-rooting across it.
@@ -7752,7 +7779,7 @@ const DumpPrePostOpt = Ref(false)
 const DumpPostOpt = Ref(false)
 
 # actual compilation
-function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, String, Union{String, Nothing}, Type, String}
+function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, String, Union{String, Nothing}, Type, String, Bool}
     config = CompilerConfig(job.config; optimize=false)
     job = CompilerJob(job.source, config, job.world)
     mod, meta = compile(:llvm, job)
@@ -7771,6 +7798,11 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
         add!(pm, FunctionPass("ReinsertGCMarker", reinsert_gcmarker_pass!))
         LLVM.run!(pm, mod)
     end
+
+    # Whether the module refers to anything by an address of this process, judged before
+    # the module string nested differentiation splices is taken: optimization may fold such
+    # an address away from the compiled code while the string still holds it.
+    relocatable = !bakes_addresses(mod)
 
     # Run post optimization pipeline
     prepost = if postopt
@@ -7811,7 +7843,7 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
         bind_native_invokes!(mod)
         ""
     end
-    return (mod, meta.edges, adjoint_name, primal_name, meta.TapeType, prepost)
+    return (mod, meta.edges, adjoint_name, primal_name, meta.TapeType, prepost, relocatable)
 end
 
 # Link an artifact into this session's JIT, no compiler involved; `entries` are the
@@ -7864,7 +7896,10 @@ const HAS_CI_RESULTS = HAS_CI_THUNKS
                 EMIT_COUNT[] += 1
                 mod = asm[1]
                 man = manifest(mod)
-                persist = persistable(man) && !haskey(LLVM.flags(mod), NONRELOCATABLE_FLAG)
+                # An address of this process anywhere in the module makes the artifact
+                # unusable by another session, whoever put it there.
+                persist = asm[7] && persistable(man) && !haskey(LLVM.flags(mod), NONRELOCATABLE_FLAG) &&
+                    !bakes_addresses(mod)
                 art = ThunkArtifact(
                     convert(Vector{UInt8}, convert(MemoryBuffer, mod)),
                     asm[3], asm[4], asm[5], asm[2], asm[6], man, persist,

--- a/src/compiler/relocation.jl
+++ b/src/compiler/relocation.jl
@@ -6,7 +6,15 @@
 # name to the object's address only when the module is linked (`JIT.prepare!`), so the module
 # Enzyme emits carries no address of this session. Targets are rooted for the lifetime of the
 # process by `jl_as_global_root`, which also canonicalizes egal immutables, so equal values
-# share one name. A `Core.Binding` target stands for the value of the binding.
+# share one name. A `Core.Binding` target stands for the value of the binding; a
+# `BindingObject` target for the binding itself.
+
+# A `Core.Binding` as an object: what Julia's codegen refers to when the code reads a
+# global through the runtime (`jl_get_binding_value_seqcst` takes the binding, not its
+# value). Serializable, since bindings are.
+struct BindingObject
+    binding::Core.Binding
+end
 
 const RELOC_LOCK = ReentrantLock()
 const RELOC_TARGETS = Dict{String, Any}()
@@ -51,7 +59,7 @@ end
 # Register `target` under a name computed elsewhere (e.g. from an artifact's manifest, in a
 # session that did not emit the module). Idempotent for an equal target.
 function register_relocation!(name::String, @nospecialize(target))
-    target = target isa Core.Binding ? target : root_value(unbind(target))
+    target = (target isa Core.Binding || target isa BindingObject) ? target : root_value(unbind(target))
     lock(RELOC_LOCK)
     try
         prev = get(RELOC_TARGETS, name, nothing)
@@ -84,6 +92,7 @@ end
 function relocation_value(gname::AbstractString)::Tuple{Bool, Any}
     found, target = relocation_target(gname)
     found || return (false, nothing)
+    target isa BindingObject && return (true, target.binding)
     return (true, unbind(target))
 end
 
@@ -91,6 +100,7 @@ end
 function relocation_pointer(gname::AbstractString)::Ptr{Cvoid}
     found, target = relocation_target(gname)
     found || error("$gname is not a registered Julia value reference")
+    target isa BindingObject && return value_pointer(target.binding)
     return value_pointer(root_value(unbind(target)))
 end
 
@@ -109,15 +119,280 @@ function manifest(mod::LLVM.Module)
     return m
 end
 
+# An address baked into the code as an integer constant. Anything at or above this is taken
+# to be a pointer of this process rather than a genuine small integer.
+const MIN_BAKED_ADDRESS = UInt(1) << 16
+
+# Whether `v` is (or contains) an `inttoptr` of a process address.
+function has_baked_address(@nospecialize(v::LLVM.Value), seen::Base.IdSet{LLVM.Value})::Bool
+    isa(v, LLVM.ConstantExpr) || return false
+    v in seen && return false
+    push!(seen, v)
+    if opcode(v) == LLVM.API.LLVMIntToPtr
+        arg = operands(v)[1]
+        if isa(arg, LLVM.ConstantInt) && convert(UInt, arg) >= MIN_BAKED_ADDRESS
+            return true
+        end
+    end
+    for op in operands(v)
+        has_baked_address(op, seen) && return true
+    end
+    return false
+end
+
+"""
+    bakes_addresses(mod::LLVM.Module) -> Bool
+
+Whether `mod` refers to anything by an address of this process. Such a module cannot be
+reused by another session: the addresses are of Julia objects Julia's own codegen embedded
+(the `:bake` relocation strategy), of C functions no name could be found for, or of values
+folded from a constant. They are frequently on paths a happy-path test never runs, so this
+is checked rather than inferred.
+"""
+function bakes_addresses(mod::LLVM.Module)::Bool
+    seen = Base.IdSet{LLVM.Value}()
+    for g in globals(mod)
+        init = LLVM.initializer(g)
+        init === nothing || has_baked_address(init, seen) && return true
+    end
+    for f in functions(mod), bb in blocks(f), inst in instructions(bb)
+        for op in operands(inst)
+            has_baked_address(op, seen) && return true
+        end
+    end
+    return false
+end
+
+# Whether a single value can be reconstructed in another process from its serialized form.
+function persistable_value(@nospecialize(v))::Bool
+    v isa BindingObject && return true
+    v = unbind(v)
+    return v isa Type || v isa Symbol || v isa String || v isa Module ||
+        v isa Core.MethodInstance || v isa Core.CodeInstance || v isa Method ||
+        (isbits(v) && !(v isa Ptr))
+end
+
 # Whether every target can be reconstructed in another process from its serialized form.
 function persistable(m::AbstractVector{<:Pair{String}})::Bool
     for (_, target) in m
-        v = unbind(target)
-        (
-            v isa Type || v isa Symbol || v isa String || v isa Module || v isa Core.MethodInstance ||
-                v isa Core.CodeInstance ||
-                v isa Method || (isbits(v) && !(v isa Ptr))
-        ) || return false
+        persistable_value(target) || return false
     end
     return true
+end
+
+# Adopting GPUCompiler's relocation metadata for the primal module.
+#
+# Julia's codegen refers to a Julia object through a word-sized slot global. GPUCompiler's
+# default `:bake` strategy fills that slot with the object's address, which puts an address
+# of this process into everything Enzyme emits. Enzyme asks for `:patch` instead
+# (`relocation_lowering`), which leaves the slots empty and hands back a manifest, and then
+# gives each slot an initializer that names the object (the `ejl_v_*` form of
+# `unsafe_to_llvm`) rather than an address. The slot and the loads through it are untouched,
+# so the shape Enzyme's activity and type analyses see is exactly the one they saw before;
+# only the address is gone. `JIT.prepare!` binds the name when the module is linked, and
+# `absint`/`try_replace_constant_load!` read the object back out of the registry so that
+# constant folding still works (see `relocation_slot_value`).
+@static if isdefined(GPUCompiler, :Relocations)
+
+    # The global whose *address* is the Julia object `val`, as `unsafe_to_llvm` emits it.
+    function relocation_global!(mod::LLVM.Module, @nospecialize(val))::LLVM.GlobalVariable
+        name = relocation_name(val)
+        globs = globals(mod)
+        haskey(globs, name) && return globs[name]
+        gv = LLVM.GlobalVariable(mod, LLVM.StructType(LLVM.LLVMType[]), name, Tracked)
+        API.SetMD(gv, "enzyme_ta_norecur", LLVM.MDNode(LLVM.Metadata[]))
+        # Julia emits these slots only for compile-time-constant objects, which Enzyme has
+        # always treated as constants: the folded form in `try_replace_constant_load!` marks
+        # them inactive too. Without it a reference by name would ask for a shadow global
+        # that the primal has none of, where the address form asked for nothing.
+        API.SetMD(gv, "enzyme_inactive", LLVM.MDNode(LLVM.Metadata[]))
+        return gv
+    end
+
+    # `gv` (the named global whose address is a Julia object) as a constant of type `T`. An
+    # integer word goes through the generic address space: the tracked one is non-integral,
+    # and the word was a plain address before GPUCompiler recorded the site.
+    function relocation_constant(gv::LLVM.GlobalVariable, T::LLVM.LLVMType)
+        if !(T isa LLVM.PointerType)
+            generic = LLVM.const_addrspacecast(gv, LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[])))
+            return LLVM.const_ptrtoint(generic, T)
+        end
+        LLVM.addrspace(T) == LLVM.addrspace(value_type(gv)) && return LLVM.const_pointercast(gv, T)
+        return LLVM.const_addrspacecast(gv, T)
+    end
+
+    # Replace every load through `v` (the slot, or a constant cast of it) by what
+    # `produce(builder, T)` gives for the type `T` the loaded word is used as, positioned
+    # at the load. GPUCompiler records a site by loading the slot as an integer word and
+    # converting it back to the pointer the original code loaded (`inttoptr`); each such
+    # conversion is replaced as the pointer it produces, so what the module sees is the
+    # form Julia's codegen emitted, never an integer image of an object's address.
+    function replace_slot_loads!(produce, @nospecialize(v::LLVM.Value), name::String)::Nothing
+        for use in collect(LLVM.uses(v))
+            u = LLVM.user(use)
+            if u isa LLVM.LoadInst
+                b = IRBuilder()
+                position!(b, u)
+                for luse in collect(LLVM.uses(u))
+                    conv = LLVM.user(luse)
+                    conv isa LLVM.IntToPtrInst || continue
+                    replace_uses!(conv, produce(b, value_type(conv)))
+                    LLVM.API.LLVMInstructionEraseFromParent(conv)
+                end
+                isempty(LLVM.uses(u)) || replace_uses!(u, produce(b, value_type(u)))
+                dispose(b)
+                LLVM.API.LLVMInstructionEraseFromParent(u)
+            elseif u isa LLVM.ConstantExpr && opcode(u) in (LLVM.API.LLVMBitCast, LLVM.API.LLVMAddrSpaceCast)
+                replace_slot_loads!(produce, u, name)
+            elseif u isa LLVM.StoreInst
+                error("Enzyme: relocation slot $name is written to")
+            end
+        end
+        return nothing
+    end
+
+    # Produces, for a slot holding a Julia object, that object by name.
+    struct SlotObject
+        gv::LLVM.GlobalVariable
+    end
+    (p::SlotObject)(b::IRBuilder, T::LLVM.LLVMType) = relocation_constant(p.gv, T)
+
+    # Produces, for a slot holding the word at `offset` from a C data global, a load of that
+    # word from the global itself, which the JIT resolves by name in any session (the form
+    # Julia's codegen emitted before GPUCompiler recorded the site).
+    struct SlotCGlobal
+        g::LLVM.Value
+        offset::Int
+    end
+    function (p::SlotCGlobal)(b::IRBuilder, T::LLVM.LLVMType)
+        T_i8 = LLVM.Int8Type()
+        addr = LLVM.const_pointercast(p.g, LLVM.PointerType(T_i8, LLVM.addrspace(value_type(p.g))))
+        if p.offset != 0
+            addr = inbounds_gep!(b, T_i8, addr, [LLVM.ConstantInt(Int64(p.offset))])
+        end
+        addr = pointercast!(b, addr, LLVM.PointerType(T, LLVM.addrspace(value_type(addr))))
+        return load!(b, T, addr)
+    end
+
+    # The C data global `sym` as declared in `mod`, declaring it if the module lost it.
+    function cglobal_declaration!(mod::LLVM.Module, sym::String)::LLVM.Value
+        globs = globals(mod)
+        haskey(globs, sym) && return globs[sym]
+        fns = functions(mod)
+        haskey(fns, sym) && return fns[sym]
+        return LLVM.GlobalVariable(mod, LLVM.Int8Type(), sym)
+    end
+
+    # Drop `slot` from the `llvm.compiler.used` and `llvm.used` lists of `mod`, which keep
+    # the slots alive for a loader that never comes.
+    function forget_slot!(mod::LLVM.Module, slot::LLVM.GlobalVariable)
+        globs = globals(mod)
+        for lname in ("llvm.compiler.used", "llvm.used")
+            haskey(globs, lname) || continue
+            used = globs[lname]
+            init = LLVM.initializer(used)
+            init isa LLVM.ConstantArray || continue
+            kept = LLVM.Constant[]
+            for i in 1:length(operands(init))
+                el = operands(init)[i]
+                base, _ = get_base_and_offset(el; offsetAllowed = false, inttoptr = false)
+                base == slot || push!(kept, el)
+            end
+            length(kept) == length(operands(init)) && continue
+            LLVM.API.LLVMDeleteGlobal(used)
+            isempty(kept) && continue
+            T_el = value_type(kept[1])
+            newused = LLVM.GlobalVariable(mod, LLVM.ArrayType(T_el, length(kept)), lname)
+            LLVM.initializer!(newused, LLVM.ConstantArray(T_el, kept))
+            linkage!(newused, LLVM.API.LLVMAppendingLinkage)
+            LLVM.section!(newused, "llvm.metadata")
+        end
+        return nothing
+    end
+
+    # Retire a slot whose loads are gone. A use that is not a load takes the slot's address
+    # (Julia selects between addresses of type-tag words, say, and loads through the
+    # choice); for a C data global that address is the global's own, for a Julia object a
+    # word holding the object is kept: this module's own copy, named for the object, so that
+    # linking modules together never leaves a slot to resolve.
+    function retire_slot!(mod::LLVM.Module, slot::LLVM.GlobalVariable, gv::LLVM.GlobalVariable)
+        forget_slot!(mod, slot)
+        if isempty(LLVM.uses(slot))
+            LLVM.API.LLVMDeleteGlobal(slot)
+            return nothing
+        end
+        name = "ejl_slot\$" * LLVM.name(gv)
+        globs = globals(mod)
+        if haskey(globs, name)
+            replace_uses!(slot, LLVM.const_pointercast(globs[name], value_type(slot)))
+            LLVM.API.LLVMDeleteGlobal(slot)
+            return nothing
+        end
+        LLVM.initializer!(slot, relocation_constant(gv, LLVM.global_value_type(slot)))
+        linkage!(slot, LLVM.API.LLVMInternalLinkage)
+        LLVM.name!(slot, name)
+        return nothing
+    end
+
+    function retire_slot!(mod::LLVM.Module, slot::LLVM.GlobalVariable, addr::LLVM.Value, ::Nothing)
+        forget_slot!(mod, slot)
+        isempty(LLVM.uses(slot)) || replace_uses!(slot, LLVM.const_pointercast(addr, value_type(slot)))
+        LLVM.API.LLVMDeleteGlobal(slot)
+        return nothing
+    end
+
+    """
+        adopt_relocations!(mod, relocations)
+
+    Replace every load through a relocation slot in `mod` by what the slot stands for, and
+    drop the slot: a Julia object becomes a reference to it by name (`ejl_v_*`), the word of
+    a C data global (`jl_nothing`, an entry of `jl_small_typeof`, ...) becomes a load from
+    that global by its own name. GPUCompiler names a slot for the job it was emitted by, so
+    the same object gets differently named slots in the modules Enzyme links together (a
+    differentiated function and the rule bodies or runtime functions emitted for it); the
+    names used here are the same everywhere, so nothing is left for a later link to resolve.
+    """
+    function adopt_relocations!(mod::LLVM.Module, relocations)::Nothing
+        relocations === nothing && return nothing
+        for rec in relocations.records
+            rec.kind === GPUCompiler.SlotSite || continue
+            target = rec.target
+            globs = globals(mod)
+            haskey(globs, rec.name) || continue
+            slot = globs[rec.name]
+            cur = LLVM.initializer(slot)
+            (cur === nothing || LLVM.isnull(cur)) || continue
+            if target isa GPUCompiler.JuliaValueRef
+                val = target.value
+                # The code reads the global through the runtime: it needs the binding itself.
+                val isa Core.Binding && (val = BindingObject(val))
+                gv = relocation_global!(mod, val)
+                replace_slot_loads!(SlotObject(gv), slot, rec.name)
+                retire_slot!(mod, slot, gv)
+            elseif target isa GPUCompiler.CGlobalRef
+                target.library === nothing || continue
+                g = cglobal_declaration!(mod, String(target.symbol))
+                replace_slot_loads!(SlotCGlobal(g, target.offset), slot, rec.name)
+                T_i8 = LLVM.Int8Type()
+                addr = LLVM.const_pointercast(g, LLVM.PointerType(T_i8, LLVM.addrspace(value_type(g))))
+                if target.offset != 0
+                    addr = LLVM.const_inbounds_gep(T_i8, addr, [LLVM.ConstantInt(Int64(target.offset))])
+                end
+                retire_slot!(mod, slot, addr, nothing)
+            end
+        end
+        return nothing
+    end
+
+    # The Julia object a slot initialized by `adopt_relocations!` points at, or
+    # `(false, nothing)`: the initializer names the object instead of giving its address, so
+    # constant folding reads it out of the registry.
+    function relocation_slot_value(@nospecialize(init::LLVM.Value))::Tuple{Bool, Any}
+        gv, _ = get_base_and_offset(init; offsetAllowed = false, inttoptr = true)
+        isa(gv, LLVM.GlobalVariable) || return (false, nothing)
+        return relocation_value(LLVM.name(gv))
+    end
+else
+    adopt_relocations!(mod::LLVM.Module, relocations)::Nothing = nothing
+    relocation_slot_value(@nospecialize(init::LLVM.Value))::Tuple{Bool, Any} = (false, nothing)
 end

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -455,6 +455,25 @@ function try_replace_constant_load!(@nospecialize(inst::LLVM.Instruction); check
     if isa(addr, LLVM.GlobalVariable) && (haskey(metadata(addr), "julia.constgv") || !check_mutability)
         paddr = addr
         addr = LLVM.initializer(paddr)
+        # A slot `adopt_relocations!` made symbolic names its object instead of giving its
+        # address, so the object comes from the registry rather than from memory.
+        if addr !== nothing
+            found, obj = relocation_slot_value(addr)
+            if found
+                if check_mutability && isstructtype(Core.Typeof(obj)) && ismutable(obj) &&
+                        nameof(Core.Typeof(obj)) !== :GenericMemory
+                    return inst
+                end
+                b = IRBuilder()
+                position!(b, inst)
+                newf = unsafe_to_llvm(b, obj)
+                if do_replace
+                    replace_uses!(inst, newf)
+                    LLVM.API.LLVMInstructionEraseFromParent(inst)
+                end
+                return newf
+            end
+        end
         # Folding needs the object's address. A GPUCompiler 2.x job compiled on behalf of a
         # kernel (`toplevel = false`) keeps the slot symbolic until the kernel is linked, so
         # there is none yet; the load stays a load.
@@ -477,6 +496,18 @@ function try_replace_constant_load!(@nospecialize(inst::LLVM.Instruction); check
         end
     elseif isa(addr, LLVM.ConstantInt)
         gname = string(convert(UInt, addr)) * "\$true"
+        load1 = true
+    elseif isa(addr, LLVM.GlobalVariable) && is_relocation_name(LLVM.name(addr))
+        # A load through a Julia object referred to by name (a field of it, the value of a
+        # binding): the same fold as through the object's address.
+        found, target = relocation_target(LLVM.name(addr))
+        found || return inst
+        obj = target isa BindingObject ? target.binding : unbind(target)
+        gname = LLVM.name(addr) * "\$true"
+        addr = LLVM.ConstantInt(reinterpret(UInt, value_pointer(obj)))
+        # As a load through a slot: a field of a mutable object is not folded (its value may
+        # change), the value of a binding is.
+        originally_tracked = true
         load1 = true
     end
 

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -23,7 +23,13 @@ end
 
         GPUCompiler.prepare_job!(job)
         mod, meta = GPUCompiler.emit_llvm(job)
-        
+        # This module is compiled by Julia's own JIT (through `llvmcall`), which cannot fill
+        # the relocation slots a primal job leaves symbolic for Enzyme's linker; bind them
+        # to their addresses here, as Julia's codegen would have.
+        if hasproperty(meta, :relocations) && meta.relocations !== nothing
+            GPUCompiler.bake_relocations!(mod, meta.relocations)
+        end
+
         copysetfn = meta.entry
         blk = first(LLVM.blocks(copysetfn))
         iter = LLVM.API.LLVMGetFirstInstruction(blk)

--- a/test/ci_results.jl
+++ b/test/ci_results.jl
@@ -51,6 +51,9 @@ end
         """
         module $pkg
         using Enzyme
+        # Refer to Julia objects by name, so the compiled thunk carries no address of the
+        # precompiling process and its artifact can be reused (see `SYMBOLIC_PRIMAL`).
+        Enzyme.Compiler.SYMBOLIC_PRIMAL[] = true
         f(x) = sin(x) * x
         grad(x) = Enzyme.autodiff(Reverse, f, Active(x))[1][1]
         const PRECOMPILED = grad(1.5)
@@ -60,6 +63,7 @@ end
     code = """
     pushfirst!(LOAD_PATH, $(repr(load_path)))
     using Enzyme, $pkg
+    Enzyme.Compiler.SYMBOLIC_PRIMAL[] = true
     Enzyme.Compiler.EMIT_COUNT[] = 0
     v = $pkg.grad(2.0)
     print(v, " ", Enzyme.Compiler.EMIT_COUNT[])

--- a/test/julia_value_refs.jl
+++ b/test/julia_value_refs.jl
@@ -12,6 +12,9 @@ const THUNK_CACHE = C.THUNK_CACHE
 # for dynamic callees as the derivative runs, so there can be several), as kept for nested
 # differentiation. Only a first differentiation compiles anything.
 function thunk_irs(f, args...)
+    # A fresh session, and only this function's thunks: another test sharing the worker
+    # would otherwise leave thunks of its own in the cache.
+    Enzyme.Compiler.reset_session!()
     autodiff(Reverse, f, args...)
     irs = String[]
     for e in Enzyme.Compiler.thunk_entries(f)

--- a/test/relocatable_primal.jl
+++ b/test/relocatable_primal.jl
@@ -1,0 +1,91 @@
+using Enzyme, LLVM, Test
+
+# Julia's codegen refers to a Julia object through a word-sized slot. Enzyme asks
+# GPUCompiler to leave those slots symbolic (`:patch`) and rewrites each one into a
+# reference to the object by name, so the differentiated module carries no address of this
+# process and its artifact can be reused by another session.
+
+const C = Enzyme.Compiler
+const THUNK_CACHE = C.THUNK_CACHE
+
+rp_plain(x) = sin(x) * x
+rp_alloc(x) = sum(abs2, [x, 2x])
+const RP_GLOBAL = [2.0, 3.0]
+rp_global(x) = RP_GLOBAL[1] * x * RP_GLOBAL[2]
+
+function rp_artifact(f)
+    # A fresh session, so that differentiating `f` compiles a thunk rather than reusing the
+    # one the generated method already holds.
+    C.reset_session!()
+    grad = autodiff(Reverse, f, Active(3.0))[1][1]
+    e = only(C.thunk_entries(f))
+    res = e isa Core.CodeInstance ? C.enzyme_ci_results(C.thunk_job(e)[1]) : nothing
+    art = res === nothing ? nothing : res.artifact
+    return grad, art
+end
+
+baked_addresses(ir) = unique([m.captures[1] for m in eachmatch(r"inttoptr \(i64 (\d{9,})", ir)])
+
+@testset "derivatives are unchanged" begin
+    @test rp_artifact(rp_plain)[1] ≈ cos(3.0) * 3.0 + sin(3.0)
+    @test rp_artifact(rp_alloc)[1] ≈ 2 * 3.0 + 8 * 3.0
+    @test rp_artifact(rp_global)[1] ≈ 6.0
+end
+
+# The symbolic primal is off by default (see `SYMBOLIC_PRIMAL`); these run it explicitly.
+function with_symbolic_primal(f)
+    old = C.SYMBOLIC_PRIMAL[]
+    C.SYMBOLIC_PRIMAL[] = true
+    return try
+        f()
+    finally
+        C.SYMBOLIC_PRIMAL[] = old
+        C.reset_session!()
+    end
+end
+
+@static if C.HAS_CI_RESULTS && isdefined(Enzyme.Compiler.GPUCompiler, :Relocations)
+    @testset "the module carries no address of this process" begin
+        with_symbolic_primal() do
+            for f in (rp_plain, rp_alloc)
+                _, art = rp_artifact(f)
+                @test art !== nothing
+                @test art.persistable
+                LLVM.Context() do ctx
+                    mod = parse(LLVM.Module, LLVM.MemoryBuffer(art.bitcode))
+                    ir = string(mod)
+                    @test isempty(baked_addresses(ir))
+                    # Whatever Julia objects it refers to are named instead of addressed.
+                    @test f !== rp_plain || occursin("ejl_v_", ir)
+                end
+            end
+        end
+    end
+
+    @testset "mutable data is named, not bound, but is not persisted" begin
+        with_symbolic_primal() do
+            # The reference is symbolic like any other, so the module holds no address; the
+            # object itself cannot be reconstructed in another process, so the artifact is kept
+            # out of the CodeInstance rather than silently reused.
+            _, art = rp_artifact(rp_global)
+            @test art === nothing
+            ir = C.thunk_link(only(C.thunk_entries(rp_global))).modstr
+            @test isempty(baked_addresses(ir))
+            @test occursin("ejl_v_", ir)
+        end
+    end
+
+    @testset "baked addresses are detected" begin
+        LLVM.Context() do ctx
+            mod = LLVM.Module("baked")
+            @test !C.bakes_addresses(mod)
+            gv = LLVM.GlobalVariable(mod, LLVM.Int64Type(), "g")
+            LLVM.initializer!(gv, LLVM.ConstantInt(Int64(7)))
+            @test !C.bakes_addresses(mod)
+            T_ptr = LLVM.PointerType(LLVM.Int8Type())
+            pv = LLVM.GlobalVariable(mod, T_ptr, "p")
+            LLVM.initializer!(pv, LLVM.const_inttoptr(LLVM.ConstantInt(UInt64(0x00007f0000000000)), T_ptr))
+            @test C.bakes_addresses(mod)
+        end
+    end
+end


### PR DESCRIPTION
Stacked on #3520. Part of the cache redesign. Contains a soundness fix to #3518 (artifacts were reused across sessions while holding addresses of the process that compiled them) plus the symbolic-primal work behind an off-by-default flag.

Keep addresses of this process out of persisted artifacts

An artifact was attached to a CodeInstance, and so reused by another session,
whenever its manifest of Julia values was reconstructible. That is not enough:
Julia's own codegen refers to an object through a word-sized slot that
GPUCompiler's default `:bake` strategy fills with the object's address, so a
module could be reused while holding addresses of the process that compiled it.
Measured, a reverse-mode thunk for `GLOB[1] * x * GLOB[2]` bakes the addresses
of the global `Vector`, of a `MethodInstance` and of an interior field, and was
marked persistable; even `sin(x) * x` bakes a `String` and a `MethodInstance`
and passed its reload test only because nothing runs the paths that read them.

`bakes_addresses` now walks a module for `inttoptr` of a process address, and an
artifact holding one is kept out of the CodeInstance. Fewer artifacts are
persisted than before, but each one that is can actually be reused.

Recovering the lost ground is what `SYMBOLIC_PRIMAL` is for. With it set, the
primal is compiled with GPUCompiler's `:patch` strategy, which leaves the slots
empty and hands back a manifest, and `adopt_relocations!` gives each slot an
initializer that names its object (the `ejl_v_*` form of `unsafe_to_llvm`)
rather than an address. The slot and the loads through it are untouched, so the
shape Enzyme's analyses see is the one they saw before; only the address is
gone. Reading a value back out of a named slot is taught to
`try_replace_constant_load!` and `abs_typeof`, so constant folding still works
without an address to dereference, and the named globals are marked inactive,
following the folded-constant path, so that naming a value does not ask for a
shadow global the primal has none of.

It is off by default. GPUCompiler's `:patch` renames the slots to
content-derived names, and enzyme-core emits helper functions whose names embed
those names; the helpers are then undefined when the module is linked, which
ends in a "Symbols not found" JIT error and a segfault across most of the suite.
The flag keeps the work available, and testable, while that is resolved.

Test: `test/relocatable_primal.jl` turns the flag on and checks that the
differentiated modules for a plain function, an allocating one, and one reading
a mutable global contain no address of this process and name their values
instead, that an artifact referring to a mutable global is not persisted, and
that `bakes_addresses` recognizes a baked address and ignores a plain integer.
`test/ci_results.jl`'s package-image test now differentiates with the flag set,
so it still reloads in a fresh process with no `enzyme!` run. Passes with
`ci_results`, `thunk_handle`, `session_cache`, `julia_value_refs`,
`symbolic_lookups`, `basic`, `tests`, `advanced`, `core/deferred`, `core/abi`,
`rules/rules`, `rules/rule_inlining`, `mixed`, `typeunstable`, `absint`,
`ext/jlarrays` on Julia 1.12 and on Julia 1.10.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVAXqghGYwHGrnzaFchPT

### Update (2026-09-07): the symbolic primal is on

`adopt_relocations!` kept GPUCompiler's relocation slots and only pointed their initializers at
the object by name. GPUCompiler names a slot for the job it was emitted by, so the same object
had differently named slots in the modules Enzyme links together, and `splice_thunk!` strips
the initializers of external globals, which turned such a slot into an undefined symbol at link
(the `Symbols not found: [_Z9zerosetfn...]` failure that kept `SYMBOLIC_PRIMAL` off). Loads of
libjulia globals (`jl_nothing`, entries of `jl_small_typeof`, the exception objects) had the
same fate: GPUCompiler records them as slots too, and nothing defined them.

Every load of a slot now becomes what the slot stands for, and the slot goes: a Julia object
becomes the `ejl_v_*` reference to it (a `Core.Binding` the code reads through the runtime
becomes a `BindingObject`, the binding itself rather than its value), the word of a C data
global becomes a load from that global by its own name, the form Julia's codegen emitted
before GPUCompiler recorded the site. The `onehot` module, which Julia's own JIT compiles
through `llvmcall`, bakes its relocations instead. Whether an artifact is session-portable is
judged before the module string nested differentiation splices is taken as well as after
optimization. `SYMBOLIC_PRIMAL` defaults to on and stays as a switch for bisecting.

Test: `basic`, `mixed`, `mixedapplyiter`, `rules/rules`, `relocatable_primal`,
`julia_value_refs`, `symbolic_lookups`, `thunk_handle`, `ci_results`, `precompile` on Julia
1.12 with the flag on.