### PR TITLE
Test what precompilation survives, and stop the workload's caches reaching the image

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7302,6 +7302,65 @@ const cache_lock = ReentrantLock()
 end
 
 """
+    clear_caches!()
+
+Empty every cache Enzyme keeps in a global, dropping what this session compiled, looked up
+and rooted along with them.
+
+Nearly all of it means something only to the session that filled it. A `CompileResult` holds
+the address the JIT gave a thunk, `captured_constants` roots objects because their addresses
+were written into that code, the rule and activity memos are keyed on world ages, and the
+`jl_load_and_lookup` handles are ones this process opened. Anything outliving the session
+must not carry them, which is why Enzyme's precompile workload ends with this call: what it
+left behind would otherwise be serialized into Enzyme's package image and inherited, dead,
+by every session that loads it.
+
+This is meant for the end of precompilation and not for a live session. It hands back the
+thunks the JIT compiled and unroots the objects their code refers to by address, so a thunk
+still held anywhere is left pointing at objects that may now be collected.
+
+Caches filled by `__init__` rather than by compiling are left alone: they are rebuilt per
+session and so never reach an image.
+"""
+function clear_caches!()
+    # Thunks, held as the addresses the JIT gave them, and the objects rooted because those
+    # addresses were written into their code.
+    empty!(cache)
+    empty!(autodiff_cache)
+    empty!(Enzyme.tape_cache)
+    empty!(Enzyme.captured_constants)
+
+    # Which rules apply, memoized against the world the methods were read in.
+    empty!(FRULE_CACHE)
+    empty!(RRULE_CACHE)
+    empty!(INACTIVE_CACHE)
+    empty!(EASY_RULE_CACHE)
+    empty!(NOALIAS_CACHE)
+    empty!(Interpreter.SigCache)
+    Interpreter.LastFwdWorld[] = Base.IdSet{Type}()
+    Interpreter.LastRevWorld[] = Base.IdSet{Type}()
+    Interpreter.LastInaWorld[] = Base.IdSet{Type}()
+
+    # Activity, and the world its `inactive_type` methods were last checked in. Left set, it
+    # tells a later session its own worlds need no check.
+    empty!(ActivityCache)
+    empty!(ActivityMethodCache)
+    ActivityWorldCache[] = 0
+
+    # The library handles `ejlstr$` and `ejlptr$` symbols were resolved through.
+    empty!(JIT.hnd_string_map)
+    empty!(JIT.hnd_int_map)
+
+    @static if VERSION < v"1.11.0-DEV.1552"
+        # Inference results, kept by Enzyme itself on versions where Julia's own cache does
+        # not hold them. The `CodeInstance`s carry `invoke` and `specptr` addresses.
+        empty!(GLOBAL_FWD_CACHE.dict)
+        empty!(GLOBAL_REV_CACHE.dict)
+    end
+    return nothing
+end
+
+"""
     instantiate_annotation(A, rt, width)
 
 Fill in the free parameters of a (possibly partially applied) activity annotation

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,4 +10,10 @@ using PrecompileTools: @setup_workload, @compile_workload
     @compile_workload begin
         Enzyme.autodiff(Reverse, precompile_module.f, Active(2.0))
     end
+
+    # Everything the workload cached belongs to this process: thunks are held as JIT
+    # addresses, the rule and activity memos are keyed on worlds that mean nothing once the
+    # image is loaded elsewhere. Serializing them hands every session that loads Enzyme a
+    # cache it must not use, so drop them and leave the image with none.
+    Compiler.clear_caches!()
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -28,18 +28,50 @@ function precompile_test_harness(f)
     return nothing
 end
 
+# Options under which Julia ignores the package images it has and compiles from source
+# instead. The test process may well be running under them, `--check-bounds=yes` and coverage
+# being what CI tests with, and `Base.julia_cmd` would pass them on to the children, where
+# they would leave nothing here testing what it says it does.
+function ignores_pkgimages(arg::AbstractString)
+    return startswith(arg, "--check-bounds") || startswith(arg, "--code-coverage") ||
+        startswith(arg, "--track-allocation") || startswith(arg, "--inline") ||
+        startswith(arg, "--pkgimages")
+end
+
+function child_julia_cmd()
+    exec = String[arg for arg in Base.julia_cmd().exec if !ignores_pkgimages(arg)]
+    push!(exec, "--pkgimages=yes")
+    return Cmd(exec)
+end
+
+# Each child reports first whether it does have package images, so that a child which never
+# loaded one cannot quietly stand in for one that did.
+const CHILD_PREAMBLE = """
+print(Int(Base.JLOptions().use_pkgimages), " ", Int(Base.JLOptions().code_coverage), " ")
+flush(stdout)
+"""
+
 function child_command(load_path, code)
     return addenv(
-        `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $code`,
+        `$(child_julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $code`,
         "JULIA_LOAD_PATH" => join([load_path, "@", "@v#.#", "@stdlib"], Sys.iswindows() ? ";" : ":"),
     )
 end
 
-# Run a child, and give back whether it exited cleanly along with what it printed.
+# Run a child, and give back whether it exited cleanly along with the fields it printed. The
+# preamble is flushed before anything else runs, so those two come back even from a child
+# that dies partway.
 function run_child(load_path, code)
     out = IOBuffer()
-    ok = success(pipeline(child_command(load_path, code); stdout = out, stderr = devnull))
-    return ok, String(take!(out))
+    ok = success(
+        pipeline(
+            child_command(load_path, CHILD_PREAMBLE * code);
+            stdout = out, stderr = devnull,
+        )
+    )
+    fields = split(String(take!(out)))
+    @test length(fields) >= 2 && fields[1] == "1" && fields[2] == "0"
+    return ok, fields[3:end]
 end
 
 const USES_AD = """
@@ -84,10 +116,10 @@ const fwd_at_3 = (cos(3.0) * 3.0 - sin(3.0)) / 3.0^2
 
         # The first child writes the image, the second loads it.
         for _ in 1:2
-            ok, out = run_child(load_path, code)
+            ok, fields = run_child(load_path, code)
             @test ok
             if ok
-                rev3, fwd3 = split(out)
+                rev3, fwd3 = fields
                 @test parse(Float64, rev3) ≈ rev_at_3
                 @test parse(Float64, fwd3) ≈ fwd_at_3
             end
@@ -106,10 +138,10 @@ end
         print(EnzymePrecompileAtBuild.PRECOMPILED[1], " ", EnzymePrecompileAtBuild.PRECOMPILED[2])
         """
         for _ in 1:2
-            ok, out = run_child(load_path, values_code)
+            ok, fields = run_child(load_path, values_code)
             @test ok
             if ok
-                rev2, fwd2 = split(out)
+                rev2, fwd2 = fields
                 @test parse(Float64, rev2) ≈ 3 * 2.0^2
                 @test parse(Float64, fwd2) ≈ (cos(2.0) * 2.0 - sin(2.0)) / 2.0^2
             end
@@ -122,10 +154,10 @@ end
         using Enzyme, EnzymePrecompileAtBuild
         print(EnzymePrecompileAtBuild.rev(3.0), " ", EnzymePrecompileAtBuild.fwd(3.0))
         """
-        ok, out = run_child(load_path, call_code)
+        ok, fields = run_child(load_path, call_code)
         @test_broken ok
         if ok
-            rev3, fwd3 = split(out)
+            rev3, fwd3 = fields
             @test parse(Float64, rev3) ≈ rev_at_3
             @test parse(Float64, fwd3) ≈ fwd_at_3
         end
@@ -149,10 +181,10 @@ end
                  length(C.JIT.hnd_string_map), length(C.JIT.hnd_int_map))
         print(sum(sizes), " ", Enzyme.autodiff(Reverse, x -> x * x, Active(4.0))[1][1])
         """
-        ok, out = run_child(load_path, code)
+        ok, fields = run_child(load_path, code)
         @test ok
         if ok
-            cached, grad = split(out)
+            cached, grad = fields
             # Nothing the session that built the image compiled or looked up is left.
             @test parse(Int, cached) == 0
             # And a session that starts from nothing differentiates.
@@ -170,13 +202,13 @@ end
                 getfield(Enzyme, n) isa Module]
         fns = [m.f for m in mods if isdefined(m, :f)]
         if isempty(fns)
-            print("no workload function")   # the workload stopped leaving one behind
+            print("none")   # the workload stopped leaving a function behind
         else
             print(Enzyme.autodiff(Reverse, first(fns), Active(2.0))[1][1])
         end
         """
-        ok, out = run_child(load_path, workload_code)
-        if ok && out == "no workload function"
+        ok, fields = run_child(load_path, workload_code)
+        if ok && fields == ["none"]
             @test_skip ok
         else
             @test_broken ok

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1,0 +1,173 @@
+using Enzyme, Test
+
+# Enzyme keeps what it compiles in globals of its own, and a thunk is held as the address of
+# the code the JIT emitted for it. Neither survives the process that produced it, so a
+# package that differentiates while it precompiles writes an image that refers to a dead
+# session (EnzymeAD/Enzyme.jl#1549). What follows pins down which parts of that already work
+# and which do not: the `@test_broken` cases are what precompilation support has to fix, and
+# the plain `@test` cases are what it must not regress.
+
+# Write the packages into a directory of their own and put it first on the child's load
+# path. The depot is the one this test runs under, so the packages precompile next to the
+# Enzyme the parent is testing instead of rebuilding the world in a fresh depot.
+function precompile_test_harness(f)
+    load_path = mktempdir()
+    try
+        f(load_path)
+    finally
+        try
+            rm(load_path; recursive = true, force = true)
+        catch  # Windows may still hold the image files open
+        end
+    end
+    return nothing
+end
+
+function child_command(load_path, code)
+    return addenv(
+        `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $code`,
+        "JULIA_LOAD_PATH" => join([load_path, "@", "@v#.#", "@stdlib"], Sys.iswindows() ? ";" : ":"),
+    )
+end
+
+# Run a child, and give back whether it exited cleanly along with what it printed.
+function run_child(load_path, code)
+    out = IOBuffer()
+    ok = success(pipeline(child_command(load_path, code); stdout = out, stderr = devnull))
+    return ok, String(take!(out))
+end
+
+const USES_AD = """
+module EnzymePrecompileUsesAD
+using Enzyme
+
+scalar(x) = x * x * x
+harmonic(x) = sin(x) / x
+
+# Only differentiated once the package is loaded, never while it precompiles.
+rev(x) = Enzyme.autodiff(Reverse, scalar, Active(x))[1][1]
+fwd(x) = Enzyme.autodiff(Forward, harmonic, Duplicated(x, 1.0))[1]
+end
+"""
+
+const AD_WHILE_PRECOMPILING = """
+module EnzymePrecompileAtBuild
+using Enzyme
+
+scalar(x) = x * x * x
+harmonic(x) = sin(x) / x
+
+rev(x) = Enzyme.autodiff(Reverse, scalar, Active(x))[1][1]
+fwd(x) = Enzyme.autodiff(Forward, harmonic, Duplicated(x, 1.0))[1]
+
+# Differentiate as the package precompiles, so the thunks are compiled in the process that
+# writes the image and whatever refers to them is what the image carries.
+const PRECOMPILED = (rev(2.0), fwd(2.0))
+end
+"""
+
+const rev_at_3 = 3 * 3.0^2
+const fwd_at_3 = (cos(3.0) * 3.0 - sin(3.0)) / 3.0^2
+
+@testset "a package that differentiates only once it is loaded" begin
+    precompile_test_harness() do load_path
+        write(joinpath(load_path, "EnzymePrecompileUsesAD.jl"), USES_AD)
+        code = """
+        using Enzyme, EnzymePrecompileUsesAD
+        print(EnzymePrecompileUsesAD.rev(3.0), " ", EnzymePrecompileUsesAD.fwd(3.0))
+        """
+
+        # The first child writes the image, the second loads it.
+        for _ in 1:2
+            ok, out = run_child(load_path, code)
+            @test ok
+            if ok
+                rev3, fwd3 = split(out)
+                @test parse(Float64, rev3) ≈ rev_at_3
+                @test parse(Float64, fwd3) ≈ fwd_at_3
+            end
+        end
+    end
+end
+
+@testset "a package that differentiates while it precompiles" begin
+    precompile_test_harness() do load_path
+        write(joinpath(load_path, "EnzymePrecompileAtBuild.jl"), AD_WHILE_PRECOMPILING)
+
+        # Differentiating during precompilation itself works, and the values it computed are
+        # in the image: the first child precompiles the package, the second only loads it.
+        values_code = """
+        using Enzyme, EnzymePrecompileAtBuild
+        print(EnzymePrecompileAtBuild.PRECOMPILED[1], " ", EnzymePrecompileAtBuild.PRECOMPILED[2])
+        """
+        for _ in 1:2
+            ok, out = run_child(load_path, values_code)
+            @test ok
+            if ok
+                rev2, fwd2 = split(out)
+                @test parse(Float64, rev2) ≈ 3 * 2.0^2
+                @test parse(Float64, fwd2) ≈ (cos(2.0) * 2.0 - sin(2.0)) / 2.0^2
+            end
+        end
+
+        # Differentiating again from a loaded image is what does not work yet. The thunk the
+        # package image refers to was compiled by the process that precompiled it, so the
+        # call goes to an address that means nothing here and the child dies on it.
+        call_code = """
+        using Enzyme, EnzymePrecompileAtBuild
+        print(EnzymePrecompileAtBuild.rev(3.0), " ", EnzymePrecompileAtBuild.fwd(3.0))
+        """
+        ok, out = run_child(load_path, call_code)
+        @test_broken ok
+        if ok
+            rev3, fwd3 = split(out)
+            @test parse(Float64, rev3) ≈ rev_at_3
+            @test parse(Float64, fwd3) ≈ fwd_at_3
+        end
+    end
+end
+
+@testset "Enzyme's own precompilation" begin
+    precompile_test_harness() do load_path
+        # Enzyme differentiates in its `@compile_workload`, and the cache that fills is a
+        # global of Enzyme's, so it is serialized into Enzyme's image along with the
+        # addresses that session's JIT handed out. Every session that loads Enzyme inherits
+        # them.
+        code = """
+        using Enzyme
+        print(length(Enzyme.Compiler.cache), " ",
+              Enzyme.autodiff(Reverse, x -> x * x, Active(4.0))[1][1])
+        """
+        ok, out = run_child(load_path, code)
+        @test ok
+        if ok
+            cached, grad = split(out)
+            # Differentiating something new is unaffected by what the cache was left holding.
+            @test parse(Float64, grad) ≈ 8.0
+            # Nothing of the session that built the image should still be in the cache.
+            @test_broken parse(Int, cached) == 0
+        end
+
+        # And they are reachable. The workload differentiates a function that stays in
+        # Enzyme, so asking for that same derivative in a fresh session finds the entry the
+        # image carries and calls where that code used to be.
+        workload_code = """
+        using Enzyme
+        mods = [getfield(Enzyme, n) for n in names(Enzyme; all = true) if
+                startswith(string(n), "#") && isdefined(Enzyme, n) &&
+                getfield(Enzyme, n) isa Module]
+        fns = [m.f for m in mods if isdefined(m, :f)]
+        if isempty(fns)
+            print("no workload function")   # the workload stopped leaving one behind
+        else
+            print(Enzyme.autodiff(Reverse, first(fns), Active(2.0))[1][1])
+        end
+        """
+        ok, out = run_child(load_path, workload_code)
+        if ok && out == "no workload function"
+            @test_skip ok
+        else
+            @test_broken ok
+        end
+    end
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -6,6 +6,11 @@ using Enzyme, Test
 # session (EnzymeAD/Enzyme.jl#1549). What follows pins down which parts of that already work
 # and which do not: the `@test_broken` cases are what precompilation support has to fix, and
 # the plain `@test` cases are what it must not regress.
+#
+# One of them Enzyme can already keep out of an image, and does: the caches its own workload
+# fills are emptied before the image is written. What no cache can help with is an address
+# baked into code that was compiled during precompilation, which is what the remaining broken
+# cases are.
 
 # Write the packages into a directory of their own and put it first on the child's load
 # path. The depot is the one this test runs under, so the packages precompile next to the
@@ -129,28 +134,35 @@ end
 
 @testset "Enzyme's own precompilation" begin
     precompile_test_harness() do load_path
-        # Enzyme differentiates in its `@compile_workload`, and the cache that fills is a
-        # global of Enzyme's, so it is serialized into Enzyme's image along with the
-        # addresses that session's JIT handed out. Every session that loads Enzyme inherits
-        # them.
+        # Enzyme differentiates in its `@compile_workload`, and the caches that fills are
+        # globals of Enzyme's, so whatever is left in them is serialized into Enzyme's image
+        # along with the addresses that session's JIT handed out. `clear_caches!` at the end
+        # of the workload is what keeps them out of it.
         code = """
         using Enzyme
-        print(length(Enzyme.Compiler.cache), " ",
-              Enzyme.autodiff(Reverse, x -> x * x, Active(4.0))[1][1])
+        C = Enzyme.Compiler
+        sizes = (length(C.cache), length(C.autodiff_cache), length(Enzyme.tape_cache),
+                 length(C.FRULE_CACHE), length(C.RRULE_CACHE), length(C.INACTIVE_CACHE),
+                 length(C.EASY_RULE_CACHE), length(C.NOALIAS_CACHE),
+                 length(C.Interpreter.SigCache), length(C.ActivityCache),
+                 length(C.ActivityMethodCache), Int(C.ActivityWorldCache[]),
+                 length(C.JIT.hnd_string_map), length(C.JIT.hnd_int_map))
+        print(sum(sizes), " ", Enzyme.autodiff(Reverse, x -> x * x, Active(4.0))[1][1])
         """
         ok, out = run_child(load_path, code)
         @test ok
         if ok
             cached, grad = split(out)
-            # Differentiating something new is unaffected by what the cache was left holding.
+            # Nothing the session that built the image compiled or looked up is left.
+            @test parse(Int, cached) == 0
+            # And a session that starts from nothing differentiates.
             @test parse(Float64, grad) ≈ 8.0
-            # Nothing of the session that built the image should still be in the cache.
-            @test_broken parse(Int, cached) == 0
         end
 
-        # And they are reachable. The workload differentiates a function that stays in
-        # Enzyme, so asking for that same derivative in a fresh session finds the entry the
-        # image carries and calls where that code used to be.
+        # An emptied cache is not the whole of it. The workload differentiates a function
+        # that stays in Enzyme, and the thunk that call goes through was compiled while
+        # Enzyme precompiled, so Enzyme's own image bakes in an address of that session just
+        # as a package image does. Asking for that derivative again calls it.
         workload_code = """
         using Enzyme
         mods = [getfield(Enzyme, n) for n in names(Enzyme; all = true) if


### PR DESCRIPTION
Three commits. The first adds `test/precompile.jl`, which pins down how far a package that
uses Enzyme gets through precompilation today. The second fixes the part of what it found that
is fixable without changing how thunks are held. The third makes the children the tests spawn
actually use package images, which CI's own flags otherwise take away.

### What the tests found

Precompilation gets further than #1549 suggests. A package that differentiates while it
precompiles *precompiles fine*, and the values it computed are in its image and read back
correctly. What breaks is differentiating again from the loaded image: Enzyme holds a thunk
as the address its just-in-time compiler handed out, the image refers to an address from the
process that wrote it, and the call lands in a dead session.

Enzyme's own image had the same problem twice over. Its `@compile_workload` differentiates,
and everything that fills while it does is an Enzyme global, so it is serialized. On Julia
1.12 every session that loads Enzyme inherited fourteen entries:

| Cache | Entries | What they are |
|---|---|---|
| `Compiler.cache` | 1 | a `CompileResult` holding a dead just-in-time address |
| `Compiler.autodiff_cache` | 1 | keyed by that address |
| rule memos (`RRULE`, `INACTIVE`, `EASY_RULE`, `NOALIAS`) | 13 | keyed on the precompiling world |
| `Interpreter.SigCache` | 2 | keyed on the precompiling world |
| `ActivityCache`, `ActivityMethodCache` | 14 | activity results and the methods they were read from |
| `ActivityWorldCache` | 43630 | a world age from the precompiling session |
| `GLOBAL_REV_CACHE` (1.10 only) | 4 | `CodeInstance`s carrying `invoke` and `specptr` addresses |

`ActivityWorldCache` is the nastiest of them. `check_activity_cache_invalidations` returns
early for any world at or below it, so a session whose worlds start lower than the
precompiling session's skips the check that clears stale activity results.

The `Compiler.cache` entry is reachable, because the function the workload differentiates
stays in Enzyme:

```
signal (11): Segmentation fault
unknown function (ip: 0x7f0f31765960)        # == the serialized CompileResult's adjoint
macro expansion at src/compiler.jl:7144 [inlined]
enzyme_call at src/compiler.jl:6610 [inlined]
CombinedAdjointThunk at src/compiler.jl:6492 [inlined]
```

### The fix

`Compiler.clear_caches!()` empties them, and the workload ends with a call to it, so the
image is written with none. Caches that `__init__` fills rather than compiling does are left
alone: `FFI.ptr_map` is the one that matters, it is rebuilt per session and so never reaches
an image, and clearing it would only break a live one. The docstring says why the function is
for the end of precompilation and not for a live session.

This does not fix an address baked into code compiled *during* precompilation. The thunk the
workload's own `autodiff` call goes through is compiled while Enzyme precompiles, and
Enzyme's image carries that call with the address in it, which is the same reason a package
that differentiates while precompiling cannot call its derivatives after loading. Both stay
`@test_broken`, and they are what precompilation support has to fix.

### The children need their own flags

Worth knowing for any future test of this shape. `Base.julia_cmd()` passes the parent's
`--check-bounds=yes` and `--code-coverage` to a child, CI runs the suite under both, and under
either Julia ignores the package images it has and compiles from source. The first round of CI
caught this the hard way: on 1.12 and 1.13 the children never loaded an image, the bug never
triggered, and both `@test_broken` cases came back as unexpected passes.

The children now drop those options, ask for images explicitly, and report whether they have
them before anything else runs. That is also 15x faster, since a child reuses Enzyme's image
instead of rebuilding it: the testset takes 36 s under CI's flags, where it took over ten
minutes.

### The tests

Three testsets, each running children against small packages written into a load path of
their own, in the depot the test already runs under.

| Testset | Passes | `@test_broken` |
|---|---|---|
| Differentiates only once loaded | precompiles, loads, differentiates correctly, twice over | – |
| Differentiates while precompiling | precompiles; precompile-time values read back correctly | calling its derivatives after loading the image |
| Enzyme's own precompilation | every cache empty on load; differentiating works from empty | calling the workload's own derivative |

### Testing

`test/precompile.jl` gives 22 passed and 2 broken on Julia 1.10, 1.11, 1.12 and 1.13, run
plainly and again under `--check-bounds=yes --code-coverage=user`, which is every version CI
tests. `Pkg.test(; test_args = ["precompile"], coverage = true, julia_args =
["--check-bounds=yes"])` on 1.12 gives the same, in 36 s.
`Pkg.test(; test_args = ["precompile", "cache_token", "rules/rules", "basic"])` passes on 1.12
(350 passed, 2 broken) and on 1.10 (310 passed, 2 broken). Runic clean on the diff.

Latency is unchanged by the eviction. Loading Enzyme and taking a first derivative costs 1.0 s
and 0.16 s on 1.12 with it, against 1.0 s and 0.17 s without.

Two failures in the first CI round are not from this PR. The 1.13 assertions job fails on main
too, in `ext/jlarrays` and `absint`. The MatrixAlgebraKit integration job failed only on 1.10,
on a finite-difference tolerance in a complex `svd_compact` reverse rule, and passed on 1.11
and 1.12.

Related: #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnjGDaotLGjPNWSdXwhd8J