### PR TITLE
Build the LLVM rule trampolines in a module with optimization off

### DIFF
--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -1,3 +1,31 @@
+# Home of the C-callable trampolines that enzyme-core calls back into.
+#
+# `@register_aug` and friends pair every rule with a `<rule>_cfunc` shim, and
+# `register_llvm_rules` hands enzyme-core a `@cfunction` pointer to each of the
+# 115 shims. A `@cfunction` target must be compiled eagerly, and the shims call
+# their rule through an `@inline` boundary, so building them in `Compiler` drags
+# every rule body through inference and codegen while the package precompiles.
+# That is roughly 22 of the 33 seconds Enzyme spends precompiling its module
+# body, and it buys very little: the rules are ordinary Julia functions that
+# would be compiled on demand anyway, the first time a differentiation reaches
+# one.
+#
+# Defining the shims here instead leaves the `@inline` unresolved, so only the
+# shim itself is compiled ahead of time and each rule is compiled on first use,
+# at full optimization, in `Compiler` where it is defined. The shims themselves
+# are pure argument forwarding, so `optimize = 0` costs nothing measurable, and
+# the extra dynamic dispatch is one per call enzyme-core hands to a rule.
+module RuleTrampolines
+
+    Base.Experimental.@compiler_options compile = min optimize = 0 infer = false
+
+    import ...Compiler
+    import ..LLVM
+    import ..API
+    import ..GradientUtils
+
+end # module RuleTrampolines
+
 macro register_aug(expr)
     decl = string(expr.args[1])
     name = decl[1:prevind(decl, findfirst('(', decl))]
@@ -7,7 +35,7 @@ macro register_aug(expr)
 
     expr2 = :(@inline $expr)
     res = quote
-        function $cname(
+        @eval RuleTrampolines function $cname(
                 B::LLVM.API.LLVMBuilderRef,
                 OrigCI::LLVM.API.LLVMValueRef,
                 gutils::API.EnzymeGradientUtilsRef,
@@ -16,7 +44,7 @@ macro register_aug(expr)
                 tapeR::Ptr{LLVM.API.LLVMValueRef},
             )::UInt8
             return UInt8(
-                $name(
+                Compiler.$name(
                     LLVM.IRBuilder(B),
                     LLVM.CallInst(OrigCI),
                     GradientUtils(gutils),
@@ -39,13 +67,13 @@ macro register_rev(expr)
     cname = Symbol(cname)
     expr2 = :(@inline $expr)
     res = quote
-        function $cname(
+        @eval RuleTrampolines function $cname(
                 B::LLVM.API.LLVMBuilderRef,
                 OrigCI::LLVM.API.LLVMValueRef,
                 gutils::API.EnzymeGradientUtilsRef,
                 tape::LLVM.API.LLVMValueRef,
             )::Cvoid
-            $name(
+            Compiler.$name(
                 LLVM.IRBuilder(B),
                 LLVM.CallInst(OrigCI),
                 GradientUtils(gutils),
@@ -65,7 +93,7 @@ macro register_fwd(expr)
     cname = Symbol(cname)
     expr2 = :(@inline $expr)
     res = quote
-        function $cname(
+        @eval RuleTrampolines function $cname(
                 B::LLVM.API.LLVMBuilderRef,
                 OrigCI::LLVM.API.LLVMValueRef,
                 gutils::API.EnzymeGradientUtilsRef,
@@ -73,7 +101,7 @@ macro register_fwd(expr)
                 shadowR::Ptr{LLVM.API.LLVMValueRef},
             )::UInt8
             return UInt8(
-                $name(
+                Compiler.$name(
                     LLVM.IRBuilder(B),
                     LLVM.CallInst(OrigCI),
                     GradientUtils(gutils),
@@ -94,7 +122,7 @@ macro register_diffuse(expr)
     cname = Symbol(cname)
     expr2 = :(@inline $expr)
     res = quote
-        function $cname(
+        @eval RuleTrampolines function $cname(
                 OrigCI::LLVM.API.LLVMValueRef,
                 gutils::API.EnzymeGradientUtilsRef,
                 val::LLVM.API.LLVMValueRef,
@@ -102,7 +130,7 @@ macro register_diffuse(expr)
                 mode::API.CDerivativeMode,
                 useDefault::Ptr{UInt8},
             )::UInt8
-            res = $name(
+            res = Compiler.$name(
                 LLVM.CallInst(OrigCI),
                 GradientUtils(gutils),
                 LLVM.Value(val),
@@ -2188,7 +2216,7 @@ macro augfunc(f)
     cname = Symbol(string(f) * "_cfunc")
     return :(
         @cfunction(
-            $cname,
+            RuleTrampolines.$cname,
             UInt8,
             (
                 LLVM.API.LLVMBuilderRef,
@@ -2206,7 +2234,7 @@ macro revfunc(f)
     cname = Symbol(string(f) * "_cfunc")
     return :(
         @cfunction(
-            $cname,
+            RuleTrampolines.$cname,
             Cvoid,
             (
                 LLVM.API.LLVMBuilderRef,
@@ -2222,7 +2250,7 @@ macro fwdfunc(f)
     cname = Symbol(string(f) * "_cfunc")
     return :(
         @cfunction(
-            $cname,
+            RuleTrampolines.$cname,
             UInt8,
             (
                 LLVM.API.LLVMBuilderRef,
@@ -2239,7 +2267,7 @@ macro diffusefunc(f)
     cname = Symbol(string(f) * "_cfunc")
     return :(
         @cfunction(
-            Compiler.$cname,
+            RuleTrampolines.$cname,
             UInt8,
             (
                 LLVM.API.LLVMValueRef,


### PR DESCRIPTION
Supersedes #1305. Refs #776.

`@register_aug`/`_rev`/`_fwd`/`_diffuse` pair every LLVM rule with a
`<rule>_cfunc` shim, and `register_llvm_rules` hands enzyme-core a
`@cfunction` pointer to each of the 115 shims. A `@cfunction` target has to be
compiled eagerly, and the shims reach their rule through an `@inline`
boundary, so defining them in `Compiler` drags all 115 rule bodies through
inference and codegen every time the package precompiles.

This moves only the shims into a module carrying
`@compiler_options compile=min optimize=0 infer=false`. The `@inline` is then
left unresolved, so each rule is compiled on first use, at full optimization,
in `Compiler` where it is defined.

## Why not #1305 as written

#1305 took this approach in 2023, when `@augfunc` built an anonymous closure
*inside* the low-optimization module, so `@compiler_options` covered the actual
`@cfunction` target. The shims are now named top-level functions in `Compiler`
and stay fully optimized, so moving only the `@cfunction` call site recovers 5s
of the 22s available. The shim definitions have to move too.

## Numbers

Julia 1.12.7, deps already precompiled, interleaved A/B, min of 3.

| precompile | before | after |
| --- | --- | --- |
| `@compile_workload` disabled | 33.3s | **11.1s** |
| `@compile_workload` enabled (what ships) | 47.9s | **37.8s** |

Stubbing `register_llvm_rules` to `return nothing` gives 11.4s, so this
recovers essentially all of the available time. The `@compile_workload` claws
back about half the win by re-compiling some rules on demand while it runs;
the two are not additive.

## Cost

@wsmoses' concern on #1305 was that these functions are a non-negligible part of
adjoint generation. That is real but small. Adjoint generation pays one dynamic
dispatch per call enzyme-core routes to a rule:

| | before | after |
| --- | --- | --- |
| deliberately generic-dispatch-heavy differentiation | 5.18s | 5.42s |
| scalar / array first gradient | 0.44s / 0.95s | 0.44s / 0.93s |
| 100k runs of an already-compiled gradient | 0.007s | 0.007s |
| `using Enzyme` | 1.00s | 0.93s |

Rules execute while differentiating, not while a gradient runs, so
already-compiled gradients are untouched. The generic-heavy case is an `Any[]`
loop plus a `Dict{Symbol,Any}`, written to hammer exactly the shims this
deoptimizes; ordinary code does not move.

## Tests

- `runtime_calls`, `typeunstable`, `mixed`, `mixedrrule`, `mixedapplyiter`,
  `applyiter`, `basic`: 669 pass, 0 fail
- `basic`, `rules`, `array`, `absint`, `sugar`, `make_zero`, `errors`,
  `callconv`: 172136 pass, 46 pre-existing broken, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BG7Q1n5G3JPPgb9zcCQ5wV