### PR TITLE
Cache the pre-post-optimization module as bitcode, not text

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -7248,7 +7248,12 @@ function _thunk(job, postopt::Bool = true)::Tuple{LLVM.Module, Vector{Any}, Stri
                     end
                 end
             end
-            string(mod)
+            # Kept for nested differentiation (see autodiff_cache); bitcode
+            # is far cheaper to write than textual IR and parses faster.
+            buf = convert(MemoryBuffer, mod)
+            bytes = convert(Vector{UInt8}, buf)
+            dispose(buf)
+            String(bytes)
         end
         if job.config.params.ABI <: FFIABI || job.config.params.ABI <: NonGenABI
             if DumpPrePostOpt[]
@@ -7274,6 +7279,7 @@ end
 
 const cache = Dict{UInt,CompileResult}()
 
+# adjoint/primal pointer => (function name, bitcode of the pre-post-optimization module)
 const autodiff_cache = Dict{Ptr{Cvoid},Tuple{String, String}}()
 
 const cache_lock = ReentrantLock()

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -1444,7 +1444,7 @@ function check_ir!(interp, @nospecialize(job::CompilerJob), errors::Vector{IRErr
 
                 @assert !haskey(functions(mod), pname)
 
-                pmod = parse(LLVM.Module, pmod)
+                pmod = parse(LLVM.Module, unsafe_wrap(Vector{UInt8}, pmod))
 
                 @assert haskey(functions(pmod), pname)
 


### PR DESCRIPTION
`_thunk` kept a textual dump of the whole module for `autodiff_cache`, so that nested differentiation can re-parse the rule declarations of a previously compiled thunk. Writing textual IR builds a slot tracker and formats every instruction; the text is only ever parsed back. Store bitcode instead and parse it with the bitcode reader.

Benchmark: Enzyme.jl reverse mode over 2 time steps of an 80×160×32 Oceananigans `HydrostaticFreeSurfaceModel` (Julia 1.12, LLVM 18), timing the first `autodiff` call. All numbers are from the same machine under `perf record`.

`string(mod)` here was ~10 s of ~860 s sampled. Together with #3533: Enzyme compile time 748 s → 721 s. Forward-over-reverse nested differentiation goes through the cache (2 entries) and matches finite differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>