### PR TITLE
Share one TypeTree memo table across set_module_types!

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1231,6 +1231,11 @@ end
 end
 
 function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLVM.Function}, job, edges, run_enzyme, mode::API.CDerivativeMode)::Tuple{Dict{String,LLVM.API.LLVMLinkage}, HandlerState}
+    # One memo table for the whole module: the argument and return types of
+    # its functions overlap heavily (the same model / array types recur in
+    # every kernel), and building a TypeTree walks the type's fields through
+    # the C API each time.
+    seen = TypeTreeTable()
 
     for f in functions(mod)
         if startswith(LLVM.name(f), "japi3") || startswith(LLVM.name(f), "japi1") || startswith(LLVM.name(f), "jlcapi")
@@ -1305,7 +1310,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
 
                 byref = arg.cc
 
-                rest = copy(typetree(arg.typ, ctx, dl))
+                rest = copy(typetree(arg.typ, ctx, dl, seen))
 
                 if byref == GPUCompiler.BITS_REF || byref == GPUCompiler.MUT_REF
                     # adjust first path to size of type since if arg.typ is {[-1]:Int}, that doesn't mean the broader
@@ -1332,7 +1337,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
                 if !in(0, parmsRemoved)
                     @assert sret <: Ptr
                     sret_et = eltype(sret)
-                    rest = copy(typetree(sret_et, ctx, dl))
+                    rest = copy(typetree(sret_et, ctx, dl, seen))
                     shift!(rest, dl, 0, LLVM.sizeof(LLVM.DataLayout(dl), sret_ty(f, 1)), 0)
                     merge!(rest, TypeTree(API.DT_Pointer, ctx))
                     only!(rest, -1)
@@ -1357,7 +1362,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
                LLVM.return_type(LLVM.function_type(f)) != LLVM.VoidType()
                 @assert !retRemoved
                 rest = if llRT == Ptr{RT}
-                    typeTree = copy(typetree(RT, ctx, dl))
+                    typeTree = copy(typetree(RT, ctx, dl, seen))
                     merge!(typeTree, TypeTree(API.DT_Pointer, ctx))
                     only!(typeTree, -1)
                     typeTree


### PR DESCRIPTION
`set_module_types!` built the TypeTree of every argument and return type of every function in the module with a fresh memo table (`typetree(T, ctx, dl)` with the default `seen`), so the same model, grid and array types were walked through the C API again for every function that takes them. Use one table for the whole module; `typetree` already documents that a shared table is fine as long as callers copy the returned tree before mutating it, which all three call sites do.

Measured on Enzyme.jl reverse mode over 2 time steps of an 80×160×32 Oceananigans `HydrostaticFreeSurfaceModel` (Julia 1.12, LLVM 18, first `autodiff` call), where `typetree_inner` was ~15 s of a ~730 s Julia-profiler run: Enzyme compile time 721 s → 709 s (perf-wrapped) / 714 s (plain), both with another benchmark running concurrently. The slow-compile corpus cases (`2 .* x` thunk, `@nif` evaluator) are unaffected within noise, as expected: their argument types don't repeat.

`test/typetree.jl`, `test/callconv.jl`, `test/mixedrrule.jl`, `test/errors.jl`, `test/usermixed.jl` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxrYVEwRvZrx16j7ZYWyyG