### PR TITLE
Bind rule-bearing callees to native code instead of emitting their body

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -751,6 +751,74 @@ function handleCustom(state::HandlerState, custom, k_name::String, llvmfn::LLVM.
     nothing
 end
 
+"""
+    delete_body!(f::LLVM.Function)
+
+Turn the definition `f` into a declaration, in place, so that the function
+object and every use of it stay valid.
+"""
+function delete_body!(f::LLVM.Function)
+    bbs = collect(blocks(f))
+    for bb in bbs, inst in collect(instructions(bb))
+        value_type(inst) == LLVM.VoidType() && continue
+        replace_uses!(inst, LLVM.UndefValue(value_type(inst)))
+    end
+    for bb in bbs
+        for inst in reverse(collect(instructions(bb)))
+            LLVM.API.LLVMInstructionEraseFromParent(inst)
+        end
+        LLVM.API.LLVMDeleteBasicBlock(bb)
+    end
+    # A declaration may carry at most one !dbg attachment; the definition's
+    # subprogram attachments are meaningless without a body anyway.
+    LLVM.API.LLVMGlobalEraseMetadata(f, LLVM.MD_dbg)
+    return nothing
+end
+
+"""
+    bind_rule_callee_to_native!(mod, llvmfn, mi, world, edges) -> Bool
+
+`llvmfn` carries a custom rule, so the differentiated code calls the rule and
+never the function itself. Its body, and the whole callee tree GPUCompiler
+emitted for it, reach the module only as dead code that `check_ir`,
+`set_module_types!`, type analysis and `optimize!` still walk. When Julia has
+native code for `mi` with the same specsig, drop the body and bind the
+declaration to that code, as `invoke_codegen!` does for `:call`-convention
+rules: any call Enzyme leaves as a plain primal call (all-constant arguments,
+the rule calling the primal) then goes to Julia's native code.
+"""
+const BIND_RULE_CALLEES = Ref(true)
+
+function bind_rule_callee_to_native!(mod::LLVM.Module, llvmfn::LLVM.Function, mi::Core.MethodInstance, world::UInt, edges::Vector)::Bool
+    BIND_RULE_CALLEES[] || return false
+    isempty(blocks(llvmfn)) && return false
+    native = try
+        native_codeinst(mod, mi, world)
+    catch err
+        err isa CallingConventionMismatchError || rethrow()
+        nothing
+    end
+    native === nothing && return false
+    ci, specptr = native
+    # The emitted signature comes from EnzymeInterpreter's inference; only bind
+    # when it agrees with the signature Julia's native code was compiled for.
+    try
+        check_specsig(llvmfn, mi, ci.rettype)
+    catch err
+        err isa AssertionError || rethrow()
+        return false
+    end
+    delete_body!(llvmfn)
+    attrs = function_attributes(llvmfn)
+    delete!(attrs, EnumAttribute("alwaysinline"))
+    push!(attrs, StringAttribute("enzymejl_needs_restoration", string(convert(UInt, specptr))))
+    push!(attrs, StringAttribute("enzymejl_native_invoke"))
+    # The native code stays valid as long as its CodeInstance does.
+    push!(edges, mi)
+    push!(edges, ci)
+    return true
+end
+
 function handle_compiled(state::HandlerState, edges::Vector, run_enzyme::Bool, mode::API.CDerivativeMode, world::UInt, method_table, custom::Dict{String, LLVM.API.LLVMLinkage}, mod::LLVM.Module, mi::Core.MethodInstance, k_name::String, @nospecialize(rettype::Type))::Nothing
     has_custom_rule = false
 
@@ -820,6 +888,11 @@ end
             "enzyme_custom",
             LLVM.Attribute[StringAttribute(PRESERVEPRIMAL_ATTR_KIND, "*")],
         )
+        if run_enzyme && llvmfn != state.primalf && bind_rule_callee_to_native!(mod, llvmfn, mi, world, edges)
+            # A declaration must keep external linkage when the original
+            # linkages are restored after the Enzyme pass.
+            custom[k_name] = LLVM.API.LLVMExternalLinkage
+        end
         return
     end
 
@@ -2464,6 +2537,7 @@ for (k, v) in (
 end
 
 function __init__()
+    BIND_RULE_CALLEES[] = get(ENV, "ENZYME_BIND_RULE_CALLEES", "1") != "0"
     API.memmove_warning!(false)
     API.typeWarning!(false)
     API.EnzymeNonPower2Cache!(false)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1231,6 +1231,11 @@ end
 end
 
 function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLVM.Function}, job, edges, run_enzyme, mode::API.CDerivativeMode)::Tuple{Dict{String,LLVM.API.LLVMLinkage}, HandlerState}
+    # One memo table for the whole module: the argument and return types of
+    # its functions overlap heavily (the same model / array types recur in
+    # every kernel), and building a TypeTree walks the type's fields through
+    # the C API each time.
+    seen = TypeTreeTable()
 
     for f in functions(mod)
         if startswith(LLVM.name(f), "japi3") || startswith(LLVM.name(f), "japi1") || startswith(LLVM.name(f), "jlcapi")
@@ -1305,7 +1310,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
 
                 byref = arg.cc
 
-                rest = copy(typetree(arg.typ, ctx, dl))
+                rest = copy(typetree(arg.typ, ctx, dl, seen))
 
                 if byref == GPUCompiler.BITS_REF || byref == GPUCompiler.MUT_REF
                     # adjust first path to size of type since if arg.typ is {[-1]:Int}, that doesn't mean the broader
@@ -1332,7 +1337,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
                 if !in(0, parmsRemoved)
                     @assert sret <: Ptr
                     sret_et = eltype(sret)
-                    rest = copy(typetree(sret_et, ctx, dl))
+                    rest = copy(typetree(sret_et, ctx, dl, seen))
                     shift!(rest, dl, 0, LLVM.sizeof(LLVM.DataLayout(dl), sret_ty(f, 1)), 0)
                     merge!(rest, TypeTree(API.DT_Pointer, ctx))
                     only!(rest, -1)
@@ -1357,7 +1362,7 @@ function set_module_types!(interp, mod::LLVM.Module, primalf::Union{Nothing, LLV
                LLVM.return_type(LLVM.function_type(f)) != LLVM.VoidType()
                 @assert !retRemoved
                 rest = if llRT == Ptr{RT}
-                    typeTree = copy(typetree(RT, ctx, dl))
+                    typeTree = copy(typetree(RT, ctx, dl, seen))
                     merge!(typeTree, TypeTree(API.DT_Pointer, ctx))
                     only!(typeTree, -1)
                     typeTree


### PR DESCRIPTION
Stacked on #3538 (first commit is that PR).

A function with a custom rule reaches the differentiated module as a full definition together with everything it calls, but the derivative never calls it: Enzyme replaces the call site with the rule. The body is dead code that `check_ir`, `set_module_types!`, type analysis and `optimize!` still walk (the mechanism isolated by #3455 / corpus case 01).

When Julia has native code for the callee with the same specsig (`native_codeinst`, `:call` convention, `check_specsig` agrees), drop the body in place (`delete_body!`, keeping the function object and its uses valid) and bind the declaration to that code with `enzymejl_needs_restoration` / `enzymejl_native_invoke`, the way `invoke_codegen!` (#3479) binds `:call`-convention rules. Calls Enzyme leaves as plain primal calls (all-constant arguments, or the rule calling the primal) go to Julia's native code through `restore_lookups`. The declaration keeps external linkage when the recorded linkages are restored after the Enzyme pass. `ENZYME_BIND_RULE_CALLEES=0` disables it.

**Measured**

| case | binding off | binding on |
| --- | --- | --- |
| microbenchmark: 4000-statement rule-bearing callee, static call (`scripts/enzyme_rule_body_cost.jl` in the corpus) | 15.8 s | 11.0 s |
| same callee reached through the runtime-generic fallback | 25.7 s | 25.8 s |
| Oceananigans channel model, 2 time steps, first `autodiff` (Julia 1.12, LLVM 18) | 680 s | 690 s |

So it helps exactly the case it targets, a static call to a callee that Julia has already compiled, and does nothing for the runtime-generic path, which is where the Oceananigans workload spends its time (53 `KernelAbstractions.Kernel` launches through type-unstable `_launch!`); the 10 s there is within run-to-run noise but I would not call it a win. Opened as a draft for that reason.

Correctness: a rule-bearing callee whose remaining call is inactive resolves through the native address (`g2` in the test script), a rule with no matching method still raises the same `MethodError` (the first version turned that into an LLVM verifier error because the restored linkage made the declaration private), nested forward-over-reverse still works, and `test/callconv.jl`, `test/mixedrrule.jl`, `test/usermixed.jl`, `test/errors.jl`, `test/typetree.jl` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxrYVEwRvZrx16j7ZYWyyG