### PR TITLE
Keep julia.get_pgcstack_or_new first in @cfunction wrappers

### DIFF
--- a/src/compiler/utils.jl
+++ b/src/compiler/utils.jl
@@ -333,7 +333,22 @@ end
 
 function get_pgcstack(func::LLVM.Function)
     entry_bb = first(blocks(func))
-    pgcstack_func = declare_pgcstack!(LLVM.parent(func))
+    mod = LLVM.parent(func)
+    pgcstack_func, _ = declare_pgcstack!(mod)
+
+    # A @cfunction wrapper fetches its pgcstack with julia.get_pgcstack_or_new,
+    # which adopts the calling thread when it is not a Julia thread yet. It has
+    # to stay the first getter of the entry block: FinalLowerGC roots the GC
+    # frame in whichever getter comes first, and a plain getter placed ahead of
+    # the adopting one dereferences a NULL pgcstack on a foreign thread.
+    if haskey(functions(mod), "julia.get_pgcstack_or_new")
+        or_new = functions(mod)["julia.get_pgcstack_or_new"]
+        for I in instructions(entry_bb)
+            if I isa LLVM.CallInst && called_operand(I) == or_new
+                return I
+            end
+        end
+    end
 
     for I in instructions(entry_bb)
         if I isa LLVM.CallInst && called_operand(I) == pgcstack_func
@@ -497,7 +512,7 @@ end
 
 function unique_gcmarker!(func::LLVM.Function)
     entry_bb = first(blocks(func))
-    pgcstack_func = declare_pgcstack!(LLVM.parent(func))
+    pgcstack_func, _ = declare_pgcstack!(LLVM.parent(func))
 
     found = LLVM.CallInst[]
     for I in instructions(entry_bb)


### PR DESCRIPTION
Fixes the flaky Buildkite CUDA failure that dies with a bare `signal (11.1): Segmentation fault` at `test/cuda.jl:6` and no Julia backtrace (11 of the 80 builds on 2026-09-07, Julia 1.10 and 1.11, unrelated branches; e.g. build 8006 on #3534).

## Root cause

`Compiler.get_pgcstack` compared a call's callee against the `(Function, FunctionType)` tuple returned by `declare_pgcstack!`, so it never matched. `reinsert_gcmarker!` therefore inserted a fresh `julia.get_pgcstack` at the top of every function that passes through `ReinsertGCMarkerPass` (post-optimization, right before GC lowering). `unique_gcmarker!` had the same comparison and never deduplicated anything. Both date back to 2023.

For ordinary functions the duplicate getter is harmless. A `@cfunction` wrapper, however, fetches its pgcstack via `julia.get_pgcstack_or_new`, which adopts the calling thread when it is not a Julia thread yet. With the plain getter placed ahead of it, `FinalLowerGC` rooted the GC frame in the plain getter, and the wrapper pushed its GC frame through a NULL pgcstack whenever it ran on a foreign thread:

```
mov    %fs:0x0,%rax
mov    -0x8(%rax),%r15        ; plain TLS pgcstack load (NULL on a foreign thread)
movq   $0x4,-0x40(%rbp)
mov    (%r15),%rax            ; <- SIGSEGV, GC frame push
...
mov    -0x8(%rax),%rbx
test   %rbx,%rbx
je     <call jl_adopt_thread> ; the or_new null check, too late
```

CUDACore 6.2.2 starts its synchronization worker with `uv_thread_create` and exactly such a `@cfunction`, and Enzyme compiles that wrapper into its module whenever the differentiated code copies to or from the device. The worker is only spawned when CUDA's spin-wait gives up, which is why CI only failed intermittently.

## Fix

`get_pgcstack` now prefers the `julia.get_pgcstack_or_new` call when the entry block has one, and both helpers destructure the tuple. The adopting getter stays first, so `FinalLowerGC` roots the frame in it.

## Verification

On a machine where the crash reproduced deterministically (Quadro RTX 4000, Julia 1.10.12, CUDA 6.2.2), unpatched main crashed on every run of `test/cuda.jl`; with this change the whole file passes (CUDA memory copies 39/39, Reverse Kernel 3/3, GPUArrays linalg rules 8/8).

An `EnzymeRules.inactive` rule on the CUDA synchronize path was considered as an alternative and does not help: inactive only adds attributes to the callee that is already compiled into Enzyme's module, so the wrapper would still be emitted and executed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUbM5JBzMLEcnnbjY925gf
