### PR TITLE
Keep parameter types in a side table keyed by an opaque id

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -138,12 +138,19 @@ mutable struct EnzymeContext
     edges::Vector{Any}
     nested_cache::Dict{Core.MethodInstance, String}
     mi_cache::Dict{String, Tuple{Core.MethodInstance, Any}}
+    # The Julia type, calling convention and rooted type of each parameter of an emitted
+    # function, by the id in its `enzymejl_parm_id` attribute: what the `enzymejl_parmtype*`
+    # attributes encode as addresses, kept as values so they need no address of this
+    # process. The id travels with the parameter through renames, argument removal and
+    # module links, where a name-and-index key would not.
+    param_types::Dict{UInt64, Tuple{Any, UInt, Any}}
     EnzymeContext(world::Integer) = new(
         world,
         LLVM.Module[],
         Any[],
         Dict{Core.MethodInstance, String}(),
-        Dict{String, Tuple{Core.MethodInstance, Any}}()
+        Dict{String, Tuple{Core.MethodInstance, Any}}(),
+        Dict{UInt64, Tuple{Any, UInt, Any}}(),
     )
 end
 

--- a/src/absint.jl
+++ b/src/absint.jl
@@ -1034,7 +1034,8 @@ function abs_typeof(
     if isa(arg, LLVM.Argument)
         f = LLVM.Function(LLVM.API.LLVMGetParamParent(arg))
         idx = only([i for (i, v) in enumerate(LLVM.parameters(f)) if v == arg])
-        typ, byref = enzyme_extract_parm_type(f, idx, false) #=error=#
+        typ, byref = enzyme_context === nothing ? enzyme_extract_parm_type(f, idx, false) :
+            enzyme_extract_parm_type(enzyme_context, f, idx, false) #=error=#
         if typ !== nothing
             return (true, typ, byref)
         end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1304,6 +1304,7 @@ function set_module_types!(enzyme_context::EnzymeContext, interp, mod::LLVM.Modu
                     parameter_attributes(f, arg.codegen.i),
                     StringAttribute("enzymejl_parmtype_ref", string(UInt(arg.cc))),
                 )
+                record_param_type!(enzyme_context, f, arg.codegen.i, arg.typ, arg.cc, arg.rooted_typ)
 		if arg.rooted_typ !== nothing
 			push!(
 			    parameter_attributes(f, arg.codegen.i),
@@ -2677,6 +2678,44 @@ function enzyme_custom_extract_mi(orig::LLVM.Function, error::Bool = true)
         GPUCompiler.@safe_error "Enzyme: Custom handler, could not find mi", orig
     end
     return mi, RT
+end
+
+# Record what the `enzymejl_parmtype*` attributes of parameter `idx` of `fn` say, as values
+# in the context's side table (see `EnzymeContext.param_types`).
+# Parameter ids are process-unique so a table entry can never be claimed by a parameter
+# emitted in another context.
+const PARM_ID = Threads.Atomic{UInt64}(0)
+
+parm_attributes(fn::LLVM.Function, idx::Int) = idx == 0 ? return_attributes(fn) : parameter_attributes(fn, idx)
+
+# Record the Julia type, calling convention and rooted type of parameter `idx` of `fn`
+# (0 for the return value) in the context's side table, and tag the parameter with the
+# table key.
+function record_param_type!(enzyme_context::EnzymeContext, fn::LLVM.Function, idx::Int, @nospecialize(typ), cc, @nospecialize(rooted))
+    id = Threads.atomic_add!(PARM_ID, UInt64(1)) + 1
+    enzyme_context.param_types[id] = (typ, UInt(cc), rooted)
+    push!(parm_attributes(fn, idx), StringAttribute("enzymejl_parm_id", string(id)))
+    return nothing
+end
+
+function enzyme_parm_id(fn::LLVM.Function, idx::Int)::Union{UInt64, Nothing}
+    for attr in collect(parm_attributes(fn, idx))
+        if isa(attr, LLVM.StringAttribute) && kind(attr) == "enzymejl_parm_id"
+            return parse(UInt64, LLVM.value(attr))
+        end
+    end
+    return nothing
+end
+
+# The Julia type and calling convention of parameter `idx` of `fn`, from the context's side
+# table when the parameter was recorded there, else from its address-valued attributes.
+function enzyme_extract_parm_type(enzyme_context::EnzymeContext, fn::LLVM.Function, idx::Int, error::Bool = true)
+    id = enzyme_parm_id(fn, idx)
+    if id !== nothing
+        entry = get(enzyme_context.param_types, id, nothing)
+        entry === nothing || return (entry[1], GPUCompiler.ArgumentCC(entry[2]))
+    end
+    return enzyme_extract_parm_type(fn, idx, error)
 end
 
 function enzyme_extract_parm_type(fn::LLVM.Function, idx::Int, error::Bool = true)
@@ -4963,6 +5002,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_VALUE)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, wrapper_idx - 1, arg.typ, GPUCompiler.BITS_VALUE, arg.rooted_typ)
 		if arg.rooted_typ !== nothing
                 push!(
 		    parameter_attributes(wrapper_f, wrapper_idx - 1),
@@ -5000,6 +5040,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_REF)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, wrapper_idx - 1, arg.typ, GPUCompiler.BITS_REF, arg.rooted_typ)
 		if arg.rooted_typ !== nothing
                 push!(
                     parameter_attributes(wrapper_f, wrapper_idx - 1),
@@ -5133,6 +5174,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_REF)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, 0, actualRetType, GPUCompiler.BITS_REF, nothing)
             end
         elseif sret
             if sretPtr === nothing
@@ -5166,6 +5208,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_REF)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, 0, actualRetType, GPUCompiler.BITS_REF, nothing)
 		res = load!(builder, RT, sretPtr)
 		@static if VERSION >= v"1.12"
             	   if returnRoots
@@ -5208,6 +5251,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_VALUE)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, 0, expected_RT, GPUCompiler.BITS_VALUE, nothing)
                 ty = emit_jltypeof!(builder, res, world)
                 cmp = icmp!(builder, LLVM.API.LLVMIntEQ, ty, unsafe_to_llvm(builder, expected_RT, world))
                 cmpret = BasicBlock(wrapper_f, "ret")
@@ -5257,6 +5301,7 @@ function lower_convention(
                         string(UInt(GPUCompiler.BITS_REF)),
                     ),
                 )
+                record_param_type!(enzyme_context, wrapper_f, 0, actualRetType, GPUCompiler.BITS_REF, nothing)
                 ret!(builder, res)
             end
         end

--- a/src/compiler/callconv.jl
+++ b/src/compiler/callconv.jl
@@ -250,7 +250,7 @@ end
     # every compiled function (`enzymejl_parmtype*`, `enzymejl_rooted_typ`,
     # `enzymejl_returnRoots`). `fix_decayaddr!` recognizes root-carrying
     # arguments by those markers.
-    function specsig_function!(mod::LLVM.Module, mi::Core.MethodInstance, @nospecialize(RT::Type), name::String, world::UInt)::LLVM.Function
+    function specsig_function!(enzyme_context::EnzymeContext, mod::LLVM.Module, mi::Core.MethodInstance, @nospecialize(RT::Type), name::String, world::UInt)::LLVM.Function
         retty, params, param_attrs = specsig(mi, RT)
         fn = LLVM.Function(mod, name, LLVM.FunctionType(retty, params))
         # Julia's codegen uses the swift calling convention only when the
@@ -262,6 +262,7 @@ end
         fattrs = function_attributes(fn)
         push!(fattrs, StringAttribute("enzymejl_mi", string(convert(UInt, pointer_from_objref(mi)))))
         push!(fattrs, StringAttribute("enzymejl_rt", string(convert(UInt, unsafe_to_pointer(RT)))))
+        enzyme_context.mi_cache[name] = (mi, RT)
         if RT === Union{}
             push!(fattrs, EnumAttribute("noreturn"))
         end
@@ -286,6 +287,7 @@ end
             push!(pattrs, StringAttribute("enzymejl_parmtype", string(convert(UInt, unsafe_to_pointer(arg.typ)))))
             push!(pattrs, StringAttribute("enzymejl_parmtype_str", string(arg.typ)))
             push!(pattrs, StringAttribute("enzymejl_parmtype_ref", string(UInt(arg.cc))))
+            record_param_type!(enzyme_context, fn, arg.codegen.i, arg.typ, arg.cc, arg.rooted_typ)
             if arg.rooted_typ !== nothing
                 push!(pattrs, StringAttribute("enzymejl_rooted_typ", string(convert(UInt, unsafe_to_pointer(arg.rooted_typ)))))
             end
@@ -351,15 +353,15 @@ end
     end
 
     """
-        declare_native!(mod, mi, RT, specptr, name, world)
+                declare_native!(enzyme_context, mod, mi, RT, specptr, name, world)
 
     Declare the natively compiled function `mi`, with return type `RT`, in `mod`,
     with the signature [`specsig`](@ref) derives. Store the entry point
     `specptr` in the `enzymejl_needs_restoration` attribute. `restore_lookups`
     turns that attribute into the address once the calling module is final.
     """
-    function declare_native!(mod::LLVM.Module, mi::Core.MethodInstance, @nospecialize(RT::Type), specptr::Ptr{Cvoid}, name::String, world::UInt)::LLVM.Function
-        fn = specsig_function!(mod, mi, RT, name, world)
+    function declare_native!(enzyme_context::EnzymeContext, mod::LLVM.Module, mi::Core.MethodInstance, @nospecialize(RT::Type), specptr::Ptr{Cvoid}, name::String, world::UInt)::LLVM.Function
+        fn = specsig_function!(enzyme_context, mod, mi, RT, name, world)
         push!(function_attributes(fn), StringAttribute("enzymejl_needs_restoration", string(convert(UInt, specptr))))
         # `restore_lookups` leaves the declaration symbolic until the module
         # is compiled, and `materialize_native_invokes!` finds it by this marker.
@@ -571,7 +573,7 @@ end
         ci, specptr = native
 
         name = "ejl_enzyme_" * GPUCompiler.safe_name(string(funcspec.def.name)) * "_" * string(convert(UInt, pointer_from_objref(funcspec)))
-        fn = declare_native!(mod, funcspec, ci.rettype, specptr, name, world)
+        fn = declare_native!(enzyme_context, mod, funcspec, ci.rettype, specptr, name, world)
 
         # The native code stays valid as long as its CodeInstance does.
         push!(enzyme_context.edges, funcspec)

--- a/src/rules/activityrules.jl
+++ b/src/rules/activityrules.jl
@@ -49,7 +49,7 @@ function julia_activity_rule(enzyme_context::EnzymeContext, f::LLVM.Function, wo
 
             op_idx = arg.codegen.i
 
-            typ, _ = enzyme_extract_parm_type(f, arg.codegen.i)
+            typ, _ = enzyme_extract_parm_type(enzyme_context, f, arg.codegen.i)
             @assert typ == arg.typ
 
 	    if (kwarg_inactive && arg.arg_i == 2) || guaranteed_const_nongen(arg.typ, world) || (arg.rooted_typ !== nothing && guaranteed_const_nongen(arg.rooted_typ, world))

--- a/test/rules/rule_inlining.jl
+++ b/test/rules/rule_inlining.jl
@@ -481,7 +481,7 @@ end
             # either target. `check_specsig` reads the parameter back from that
             # mark, so it accepts the declaration it derived.
             RT = native[1].rettype
-            decl = Enzyme.Compiler.specsig_function!(mod, mi, RT, "test_specsig_gcstack", world)
+            decl = Enzyme.Compiler.specsig_function!(Enzyme.EnzymeContext(world), mod, mi, RT, "test_specsig_gcstack", world)
             @test (Enzyme.Compiler.gcstack_arg_index(decl) != 0) == Enzyme.Compiler.jit_gcstack_arg()
             @test Enzyme.Compiler.has_swiftself(decl) ==
                 (Enzyme.Compiler.jit_gcstack_arg() && Enzyme.Compiler.jit_uses_swiftcc())


### PR DESCRIPTION
Stacked on #3156 (which is stacked on #2643). Draft: the first step of a change that will take a few rounds.

## Why

Every function Enzyme emits carries its Julia signature as *process addresses in string attributes*: `enzymejl_mi` and `enzymejl_rt` on the function, `enzymejl_parmtype` (plus `_ref` and `_rooted_typ`) on each parameter and on the return value. They are read back with `unsafe_pointer_to_objref` at compile time, by `enzyme_custom_extract_mi`, `enzyme_extract_parm_type`, the type-analysis setup in `set_module_types!`, and the error paths.

Inside one session that is fine. It stops being fine once modules outlive the session: the cache stack (#3517, #3521, #3522) keeps a thunk's compiled artifact on its `CodeInstance`, together with the pre-optimization module string that nested differentiation splices, and a package image carries both. `bakes_addresses` only inspects `inttoptr` constants, so a module whose only process addresses live in these attributes is judged session-portable, and nested differentiation through a thunk linked from an image would decode dead addresses. Nothing in the suite exercises that path yet; it is a latent crash, not a failing test.

## Plan

1. **Side table** (this PR): `EnzymeContext` already gained `mi_cache` (function name to method instance and return type) in #3156. It now also carries `param_types`, a table from an opaque id to the Julia type, calling convention and rooted type of one parameter (0 for the return value). Every writer records into it as it writes the address attributes: `prepare_llvm` for compiled functions, the ABI wrappers in `lower_convention`, and the native rule declarations in `callconv.jl` (which now take the context). The parameter is tagged with its id in an `enzymejl_parm_id` attribute, and that id is the key. A name-and-index key was tried first and broke as soon as a pass removed a dead argument (the kwsorter of `stdm` loses its `Bool`, and index 1 becomes the array); an attribute moves with the parameter through renames, argument removal, the attribute copies onto wrappers and module links. Ids come from a process-wide counter, so an entry can never be claimed by a parameter recorded in another context. `enzyme_extract_parm_type(enzyme_context, fn, idx)` prefers the table and falls back to the attributes; `absint` and `julia_activity_rule` use it. Behaviour is unchanged when the table misses.
2. Cover the remaining readers: the `set_module_types!` loop that pairs `enzymejl_mi`/`enzymejl_rt` back into `handle_compiled`, the `enzymejl_rooted_typ` reads, and the `enzymejl_gc_alloc_rt` metadata on allocations.
3. Stop writing addresses. Keep the `_str` attributes for debugging, and have `bakes_addresses` (on the cache stack) reject any surviving address-valued attribute so an artifact can never be marked portable with one.
4. On the cache stack: serialize the table with the artifact (method instances and types are ordinary Julia values, so it rides in `analysis_results` like the rest), and merge it into the context when an artifact is linked or spliced.

`mi_cache` from #3156 is still keyed by function name; it should move to the same id scheme (an `enzymejl_fn_id` attribute) in step 2, since a name key has exactly the fragility the parameter table just lost.

## Test

`typeunstable`, `errors`, `basic`, `rules/rules`, `absint`, `rules/rrules`, `rules/rule_inlining`, `mixed` on Julia 1.12 pass. The `stdm` case above is covered by `basic` (the Statistics tests), which is what exposed the index shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZ9ygd17aLfCESakQx36ot


---

**2026-09-08, later:** rebased onto #3156 after #2643 removed `enzymejl_world` and threaded `world::UInt` explicitly; no design change here. Same test set passes on Julia 1.12.
