### PR TITLE
Add Julia 1.13 to the release CI matrix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ steps:
           - "1.10"
           - "1.11"
           - "1.12"
+          - "1.13"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -59,6 +60,7 @@ steps:
           - "1.10"
           - "1.11"
           - "1.12"
+          - "1.13"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
           - '1.10'
           - '1.11'
           - '1.12'
+          - '1.13'
         os:
           - ubuntu-24.04
           - macOS-latest
@@ -96,6 +97,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          include-all-prereleases: true
       - uses: actions/checkout@v7
         if: ${{ matrix.assertions }}
         with:
@@ -179,6 +181,7 @@ jobs:
           - '1.10'
           - '1.11'
           - '1.12'
+          - '1.13'
         os:
           - ubuntu-latest
         arch:
@@ -190,6 +193,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          include-all-prereleases: true
       - uses: julia-actions/cache@v3.2.0
         with:
           gcp-bucket: ${{ (contains(matrix.os, 'linux') && 'enzyme-ci-transient' ) || '' }}
@@ -231,6 +235,7 @@ jobs:
           - '1.10'
           - '1.11'
           - '1.12'
+          - '1.13'
         os:
           - ubuntu-latest
         arch:
@@ -242,6 +247,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          include-all-prereleases: true
       - uses: julia-actions/cache@v3.2.0
         with:
           gcp-bucket: ${{ (contains(matrix.os, 'linux') && 'enzyme-ci-transient' ) || '' }}

--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -43,6 +43,7 @@ jobs:
           - '1.10'
           - '1.11'
           - '1.12'
+          - '1.13'
         os:
           - linux-x86-n2-32
         package:
@@ -67,6 +68,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
+          include-all-prereleases: true
 
       - name: Load Julia packages from cache
         uses: julia-actions/cache@v3.2.0

--- a/lib/EnzymeTestUtils/src/output_control.jl
+++ b/lib/EnzymeTestUtils/src/output_control.jl
@@ -3,7 +3,10 @@
 # Copyright (c) 2020 JuliaDiff
 
 # Test.get_test_result generates code that uses the following so we must import them
-using Test: Returned, Threw, eval_test
+using Test: Returned, Threw
+@static if isdefined(Test, :eval_test)
+    using Test: eval_test
+end
 @static if isdefined(Test, :eval_test_function)
     using Test: eval_test_function
 end


### PR DESCRIPTION
Supersedes #3070 and #3222, rebased onto current main (which no longer has `nightly` in the matrix and already has the 1.13 assertions job).

What is covered, matching what #2957 / #2862 did for 1.12:

- **CI.yml**: `test`, `enzymetestutils` and `enzymecore` jobs run on 1.13 (packaged + local libEnzyme on Linux, packaged on macOS/Windows). `setup-julia` gets `include-all-prereleases: true` so `'1.13'` resolves to the current rc until 1.13.0 is out.
- **Integration.yml**: 1.13 added next to 1.10–1.12 (#3222 had replaced the list as an experiment).
- **Buildkite**: CUDA and Metal jobs on 1.13. CUDA.jl and Metal.jl both declare `julia = "1.10 - 1"`, and the `julia-1.13-latest` tarball the Buildkite plugin downloads already exists.
- **EnzymeTestUtils**: `Test.eval_test` is gone on 1.13, so it is now imported under `isdefined`. #3070 dropped the import unconditionally, which is why all of its 1.10–1.12 jobs failed with `UndefVarError: eval_test not defined in EnzymeTestUtils` (the generated `@test_msg` code resolves it inside the module via hygiene). Verified locally that `test_approx` works on 1.10.12 and 1.13.0-rc4 with the conditional import.

Left out on purpose: #3070's bump of Documentation.yml / scripts_deploy.yml from `'1.11'` to `'1'`. On 1.12 the `docs/src/faq.md` doctest at line 737 fails because the error message now prints `EnzymeCore.Duplicated{Val{1.0}}` with the module prefix. That doctest needs updating first, and `'1'` would silently move the docs build to 1.13 on release day.

Known 1.13 state from the earlier runs (July): the 1.13 unit-test jobs on #3070 were green; on #3222 the Comrade, Lux, Molly, Oceananigans and SciML integration jobs failed (inference `InferenceState` typeassert, Lux test-utils not loading Enzyme, two `EnzymeInternalError`s, one runtime-activity error). Those are the things to look at on this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ggwnn7AEg7YdTaeHdDo71
