### PR TITLE
EnzymeTestUtils: guard `Test.eval_test` import for Julia 1.13

### DIFF
--- a/lib/EnzymeTestUtils/Project.toml
+++ b/lib/EnzymeTestUtils/Project.toml
@@ -1,7 +1,7 @@
 name = "EnzymeTestUtils"
 uuid = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 authors = ["Seth Axen <seth@sethaxen.com>", "William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/lib/EnzymeTestUtils/src/output_control.jl
+++ b/lib/EnzymeTestUtils/src/output_control.jl
@@ -3,7 +3,10 @@
 # Copyright (c) 2020 JuliaDiff
 
 # Test.get_test_result generates code that uses the following so we must import them
-using Test: Returned, Threw, eval_test
+using Test: Returned, Threw
+@static if isdefined(Test, :eval_test)
+    using Test: eval_test
+end
 @static if isdefined(Test, :eval_test_function)
     using Test: eval_test_function
 end


### PR DESCRIPTION
Split out of #3545 so it can land (and be registered) independently of the 1.13 CI work.

Julia 1.13 removed `Test.eval_test` in favour of `Test.eval_test_function`, so `using Test: Returned, Threw, eval_test` makes EnzymeTestUtils fail to load there. Guard the import with `isdefined`, mirroring the guard that already exists for `eval_test_function`.

Verified locally:

| Julia | `Test.eval_test` | `Test.eval_test_function` |
| --- | --- | --- |
| 1.12.7 | ✅ | ❌ |
| 1.13.0-rc4 | ❌ | ✅ |

Also bumps EnzymeTestUtils to 0.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SmPcnuzF294EUYoGXpCHQ