### PR TITLE
Upgrade Oceananigans integration test to v0.112

### DIFF
--- a/test/integration/Oceananigans/Project.toml
+++ b/test/integration/Oceananigans/Project.toml
@@ -6,7 +6,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 GPUArraysCore = "=0.2.0"
-Oceananigans = "=0.101.0"
+Oceananigans = "=0.112.0"
 
 [sources]
 Enzyme = { path = "../../.." }

--- a/test/integration/Oceananigans/runtests.jl
+++ b/test/integration/Oceananigans/runtests.jl
@@ -25,7 +25,8 @@ end
     grid = RectilinearGrid(size=128, z=(-64, 64), topology=(Flat, Flat, Bounded))
     vitd = VerticallyImplicitTimeDiscretization()
     closure = ScalarDiffusivity(vitd; ν)
-    m = HydrostaticFreeSurfaceModel(grid; closure, coriolis=FPlane(f=1e-4),
+    m = HydrostaticFreeSurfaceModel(
+        grid; closure, coriolis = FPlane(f = 1.0e-4),
         tracers=:b, buoyancy=BuoyancyTracer())
 
     N² = 1e-6

--- a/test/integration/Oceananigans/runtests.jl
+++ b/test/integration/Oceananigans/runtests.jl
@@ -25,7 +25,7 @@ end
     grid = RectilinearGrid(size=128, z=(-64, 64), topology=(Flat, Flat, Bounded))
     vitd = VerticallyImplicitTimeDiscretization()
     closure = ScalarDiffusivity(vitd; ν)
-    m = HydrostaticFreeSurfaceModel(; grid, closure, coriolis=FPlane(f=1e-4),
+    m = HydrostaticFreeSurfaceModel(grid; closure, coriolis=FPlane(f=1e-4),
         tracers=:b, buoyancy=BuoyancyTracer())
 
     N² = 1e-6


### PR DESCRIPTION
> The grid is now a positional argument of `HydrostaticFreeSurfaceModel` rather than a keyword; the rest of the test is unchanged.