### PR TITLE
Forward mode: return the shadow of the stored value from `jl_f_setfield`

### DIFF
--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1954,20 +1954,6 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
     origops = @view operands(orig)[offset:end]
     width = get_width(gutils)
 
-    normal =
-        (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
-    if shadowR != C_NULL && normal !== nothing
-        shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
-            if width == 1
-                shadowres = normal
-            else
-                shadowres = insert_value!(B, shadowres, normal, idx - 1)
-            end
-        end
-        unsafe_store!(shadowR, shadowres.ref)
-    end
-
     if !is_constant_value(gutils, origops[2])
 
         shadowstruct = invert_pointer(gutils, origops[2], B)
@@ -1999,6 +1985,27 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
         end
     end
 
+    if unsafe_load(shadowR) != C_NULL
+        shadowres = if !is_constant_value(gutils, origops[4])
+            invert_pointer(gutils, origops[4], B)
+        else
+            normal = new_from_original(gutils, orig)
+            if width == 1
+                normal
+            else
+                res = UndefValue(
+                    LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
+                )
+                position!(B, LLVM.Instruction(LLVM.API.LLVMGetNextInstruction(normal)))
+                for idx in 1:width
+                    res = insert_value!(B, res, normal, idx - 1)
+                end
+                res
+            end
+        end
+        unsafe_store!(shadowR, shadowres.ref)
+    end
+
     return false
 end
 
@@ -2007,33 +2014,28 @@ function common_setfield_rev(offset, B, orig, gutils, tape)
     if !is_constant_value(gutils, origops[2])
         width = get_width(gutils)
 
-        shadowstruct = invert_pointer(gutils, origops[2], B)
+        shadowstruct = lookup_value(gutils, invert_pointer(gutils, origops[2], B), B)
 
         shadowval = if !is_constant_value(gutils, origops[4])
-            invert_pointer(gutils, origops[4], B)
+            lookup_value(gutils, invert_pointer(gutils, origops[4], B), B)
         else
             nothing
         end
+
+        symval = lookup_value(gutils, new_from_original(gutils, origops[3]), B)
+        primalval = lookup_value(gutils, new_from_original(gutils, origops[4]), B)
 
         mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
 
         # TODO handle runtime activity
         for idx = 1:width
             vals = LLVM.Value[
-                lookup_value(
-                    gutils,
-                    (width == 1) ? shadowstruct : extract_value!(B, shadowstruct, idx - 1),
-                    B,
-                ),
-                lookup_value(gutils, new_from_original(gutils, origops[3]), B),
+                (width == 1) ? shadowstruct : extract_value!(B, shadowstruct, idx - 1),
+                symval,
                 unsafe_to_llvm(B, Val(is_constant_value(gutils, origops[4]))),
-                lookup_value(gutils, new_from_original(gutils, origops[4]), B),
+                primalval,
                 is_constant_value(gutils, origops[4]) ? unsafe_to_llvm(B, nothing) :
-                lookup_value(
-                    gutils,
                     ((width == 1) ? shadowval : extract_value!(B, shadowval, idx - 1)),
-                    B,
-                ),
             ]
 
             pushfirst!(vals, unsafe_to_llvm(B, rt_jl_setfield_rev))

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1840,25 +1840,10 @@ end
 end
 
 function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
-    normal =
-        (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
-    if shadowR != C_NULL && normal !== nothing
-        width = get_width(gutils)
-        shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
-        for idx = 1:width
-            if width == 1
-                shadowres = normal
-            else
-                shadowres = insert_value!(B, shadowres, normal, idx - 1)
-            end
-        end
-        unsafe_store!(shadowR, shadowres.ref)
-    end
-
     origops = @view operands(orig)[offset:end]
-    if !is_constant_value(gutils, origops[4])
-        width = get_width(gutils)
+    width = get_width(gutils)
 
+    if !is_constant_value(gutils, origops[4])
         shadowout = invert_pointer(gutils, origops[4], B)
 
         shadowin = if !is_constant_value(gutils, origops[2])
@@ -1896,9 +1881,53 @@ function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
             need_result = false
         ) #=lookup=#
     end
+
+    # `setfield!(obj, fld, val)` returns `val`, so the shadow of the result is
+    # the shadow of the stored value -- not the primal result.
+    if shadowR != C_NULL && !is_constant_value(gutils, orig)
+        shadowres = if !is_constant_value(gutils, origops[4])
+            invert_pointer(gutils, origops[4], B)
+        elseif !get_runtime_activity(gutils)
+            estr =
+                "Mismatched activity for: " *
+                string(orig) *
+                " const stored value " *
+                string(origops[4]) *
+                ", differentiable return"
+            eres = julia_error(
+                estr,
+                orig.ref,
+                API.ET_MixedActivityError,
+                gutils.ref,
+                origops[4].ref,
+                B.ref,
+            )
+            if eres != C_NULL
+                LLVM.Value(eres)
+            else
+                invert_pointer(gutils, origops[4], B)
+            end
+        else
+            # Under runtime activity a constant stored value has the primal as
+            # its own shadow.
+            normal = new_from_original(gutils, orig)
+            if width == 1
+                normal
+            else
+                res = UndefValue(
+                    LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
+                )
+                position!(B, LLVM.Instruction(LLVM.API.LLVMGetNextInstruction(normal)))
+                for idx in 1:width
+                    res = insert_value!(B, res, normal, idx - 1)
+                end
+                res
+            end
+        end
+        unsafe_store!(shadowR, shadowres.ref)
+    end
     return false
 end
-
 
 function rt_jl_setfield_aug(dptr::T, idx, ::Val{isconst}, val, dval) where {T,isconst}
     RT = Core.Typeof(val)
@@ -1926,11 +1955,19 @@ function rt_jl_setfield_rev(dptr::T, idx, ::Val{isconst}, val, dval) where {T,is
 end
 
 function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR)
+    origops = @view operands(orig)[offset:end]
+    width = get_width(gutils)
 
+    # TODO: `setfield!(obj, fld, val)` returns `val`, so the shadow of the result
+    # ought to be the shadow of the stored value rather than the primal result
+    # (this is what makes reverse mode drop the derivative flowing through a used
+    # `setproperty!` return, cf. https://github.com/EnzymeAD/Enzyme.jl/issues/3555).
+    # Returning the shadow of `val` here additionally requires Enzyme's
+    # `cacheForReverse` to accept a shadow return that is not an `Instruction`
+    # (the shadow of `val` may be a shadow argument), so it is left as-is for now.
     normal =
         (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
     if shadowR != C_NULL && normal !== nothing
-        width = get_width(gutils)
         shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
         for idx = 1:width
             if width == 1
@@ -1942,13 +1979,11 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
         unsafe_store!(shadowR, shadowres.ref)
     end
 
-    origops = @view operands(orig)[offset:end]
     if !is_constant_value(gutils, origops[2])
-        width = get_width(gutils)
 
         shadowstruct = invert_pointer(gutils, origops[2], B)
 
-        shadowval = if !is_constant_value(gutils, origops[2])
+        shadowval = if !is_constant_value(gutils, origops[4])
             invert_pointer(gutils, origops[4], B)
         else
             nothing
@@ -1985,7 +2020,7 @@ function common_setfield_rev(offset, B, orig, gutils, tape)
 
         shadowstruct = invert_pointer(gutils, origops[2], B)
 
-        shadowval = if !is_constant_value(gutils, origops[2])
+        shadowval = if !is_constant_value(gutils, origops[4])
             invert_pointer(gutils, origops[4], B)
         else
             nothing

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1954,6 +1954,20 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
     origops = @view operands(orig)[offset:end]
     width = get_width(gutils)
 
+    normal =
+        (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
+    if shadowR != C_NULL && normal !== nothing
+        shadowres = UndefValue(LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(orig))))
+        for idx = 1:width
+            if width == 1
+                shadowres = normal
+            else
+                shadowres = insert_value!(B, shadowres, normal, idx - 1)
+            end
+        end
+        unsafe_store!(shadowR, shadowres.ref)
+    end
+
     if !is_constant_value(gutils, origops[2])
 
         shadowstruct = invert_pointer(gutils, origops[2], B)
@@ -1985,27 +1999,6 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
         end
     end
 
-    if unsafe_load(shadowR) != C_NULL
-        shadowres = if !is_constant_value(gutils, origops[4])
-            invert_pointer(gutils, origops[4], B)
-        else
-            normal = new_from_original(gutils, orig)
-            if width == 1
-                normal
-            else
-                res = UndefValue(
-                    LLVM.LLVMType(API.EnzymeGetShadowType(width, value_type(normal))),
-                )
-                position!(B, LLVM.Instruction(LLVM.API.LLVMGetNextInstruction(normal)))
-                for idx in 1:width
-                    res = insert_value!(B, res, normal, idx - 1)
-                end
-                res
-            end
-        end
-        unsafe_store!(shadowR, shadowres.ref)
-    end
-
     return false
 end
 
@@ -2014,28 +2007,33 @@ function common_setfield_rev(offset, B, orig, gutils, tape)
     if !is_constant_value(gutils, origops[2])
         width = get_width(gutils)
 
-        shadowstruct = lookup_value(gutils, invert_pointer(gutils, origops[2], B), B)
+        shadowstruct = invert_pointer(gutils, origops[2], B)
 
         shadowval = if !is_constant_value(gutils, origops[4])
-            lookup_value(gutils, invert_pointer(gutils, origops[4], B), B)
+            invert_pointer(gutils, origops[4], B)
         else
             nothing
         end
-
-        symval = lookup_value(gutils, new_from_original(gutils, origops[3]), B)
-        primalval = lookup_value(gutils, new_from_original(gutils, origops[4]), B)
 
         mod = LLVM.parent(LLVM.parent(LLVM.parent(orig)))
 
         # TODO handle runtime activity
         for idx = 1:width
             vals = LLVM.Value[
-                (width == 1) ? shadowstruct : extract_value!(B, shadowstruct, idx - 1),
-                symval,
+                lookup_value(
+                    gutils,
+                    (width == 1) ? shadowstruct : extract_value!(B, shadowstruct, idx - 1),
+                    B,
+                ),
+                lookup_value(gutils, new_from_original(gutils, origops[3]), B),
                 unsafe_to_llvm(B, Val(is_constant_value(gutils, origops[4]))),
-                primalval,
+                lookup_value(gutils, new_from_original(gutils, origops[4]), B),
                 is_constant_value(gutils, origops[4]) ? unsafe_to_llvm(B, nothing) :
+                lookup_value(
+                    gutils,
                     ((width == 1) ? shadowval : extract_value!(B, shadowval, idx - 1)),
+                    B,
+                ),
             ]
 
             pushfirst!(vals, unsafe_to_llvm(B, rt_jl_setfield_rev))

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1882,8 +1882,6 @@ function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
         ) #=lookup=#
     end
 
-    # `setfield!(obj, fld, val)` returns `val`, so the shadow of the result is
-    # the shadow of the stored value -- not the primal result.
     if shadowR != C_NULL && !is_constant_value(gutils, orig)
         shadowres = if !is_constant_value(gutils, origops[4])
             invert_pointer(gutils, origops[4], B)
@@ -1908,8 +1906,6 @@ function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
                 invert_pointer(gutils, origops[4], B)
             end
         else
-            # Under runtime activity a constant stored value has the primal as
-            # its own shadow.
             normal = new_from_original(gutils, orig)
             if width == 1
                 normal
@@ -1958,13 +1954,6 @@ function common_setfield_augfwd(offset, B, orig, gutils, normalR, shadowR, tapeR
     origops = @view operands(orig)[offset:end]
     width = get_width(gutils)
 
-    # TODO: `setfield!(obj, fld, val)` returns `val`, so the shadow of the result
-    # ought to be the shadow of the stored value rather than the primal result
-    # (this is what makes reverse mode drop the derivative flowing through a used
-    # `setproperty!` return, cf. https://github.com/EnzymeAD/Enzyme.jl/issues/3555).
-    # Returning the shadow of `val` here additionally requires Enzyme's
-    # `cacheForReverse` to accept a shadow return that is not an `Instruction`
-    # (the shadow of `val` may be a shadow argument), so it is left as-is for now.
     normal =
         (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
     if shadowR != C_NULL && normal !== nothing

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -346,6 +346,40 @@ end
     )[1]
     @test res[1] ≈ 2.0
     @test res[2] ≈ 2.0
+
+    dv = zeros(2)
+    Enzyme.autodiff(Reverse, Enzyme.Const(loss_3555), Active, Duplicated(copy(v), dv))
+    @test dv ≈ [2.0, 2.0]
+
+    dv1 = zeros(2)
+    dv2 = zeros(2)
+    Enzyme.autodiff(
+        Reverse, Enzyme.Const(loss_3555), Active, BatchDuplicated(copy(v), (dv1, dv2))
+    )
+    @test dv1 ≈ [2.0, 2.0]
+    @test dv2 ≈ [2.0, 2.0]
+end
+
+function loss_3555_retonly(v::Vector{Float64})
+    b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
+    r = setit_3555!(b, :u, v)
+    return sum(r)
+end
+
+@testset "Issue 3555 reverse type-unstable setproperty! with used return" begin
+    v = [1.0, 2.0]
+
+    @test Enzyme.autodiff(
+        Enzyme.Forward,
+        Enzyme.Const(loss_3555_retonly),
+        Enzyme.Duplicated(copy(v), [1.0, 0.0]),
+    )[1] ≈ 1.0
+
+    dv = zeros(2)
+    Enzyme.autodiff(
+        Reverse, Enzyme.Const(loss_3555_retonly), Active, Duplicated(copy(v), dv)
+    )
+    @test dv ≈ [1.0, 1.0]
 end
 
 # Issue 3425: an `Active` return whose inferred type is abstract routes combined

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -311,6 +311,48 @@ end
     ) == (1.0,)
 end
 
+# Issue 3555: `setfield!(obj, fld, val)` returns `val`, so the shadow of a
+# type-unstable `setproperty!` whose return value is used must be the shadow of
+# `val`, not the primal result.  Returning the primal made width 1 silently
+# wrong and, at width >= 2, built the `[N x ptr]` shadow out of the primal call
+# before that call was emitted ("Instruction does not dominate all uses").
+mutable struct SetpropertyRetBox3555
+    u::Vector{Float64}
+    t::Float64
+end
+
+@noinline setit_3555!(b::SetpropertyRetBox3555, name::Symbol, v) = setproperty!(b, name, v)
+
+function loss_3555(v::Vector{Float64})
+    b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
+    r = setit_3555!(b, :u, v)  # r === v
+    return sum(r) + sum(b.u)   # == 2 * sum(v)
+end
+
+@testset "Issue 3555 forward type-unstable setproperty! with used return" begin
+    v = [1.0, 2.0]
+
+    @test Enzyme.autodiff(
+        Enzyme.Forward,
+        Enzyme.Const(loss_3555),
+        Enzyme.Duplicated(copy(v), [1.0, 0.0]),
+    )[1] ≈ 2.0
+
+    @test Enzyme.autodiff(
+        Enzyme.set_runtime_activity(Enzyme.Forward),
+        Enzyme.Const(loss_3555),
+        Enzyme.Duplicated(copy(v), [1.0, 0.0]),
+    )[1] ≈ 2.0
+
+    res = Enzyme.autodiff(
+        Enzyme.Forward,
+        Enzyme.Const(loss_3555),
+        Enzyme.BatchDuplicated(copy(v), ([1.0, 0.0], [0.0, 1.0])),
+    )[1]
+    @test res[1] ≈ 2.0
+    @test res[2] ≈ 2.0
+end
+
 # Issue 3425: an `Active` return whose inferred type is abstract routes combined
 # reverse mode through the split (augmented forward + adjoint) path.  For a batched
 # call the return annotation handed to that path must carry the batch width,

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -311,11 +311,6 @@ end
     ) == (1.0,)
 end
 
-# Issue 3555: `setfield!(obj, fld, val)` returns `val`, so the shadow of a
-# type-unstable `setproperty!` whose return value is used must be the shadow of
-# `val`, not the primal result.  Returning the primal made width 1 silently
-# wrong and, at width >= 2, built the `[N x ptr]` shadow out of the primal call
-# before that call was emitted ("Instruction does not dominate all uses").
 mutable struct SetpropertyRetBox3555
     u::Vector{Float64}
     t::Float64
@@ -325,8 +320,8 @@ end
 
 function loss_3555(v::Vector{Float64})
     b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
-    r = setit_3555!(b, :u, v)  # r === v
-    return sum(r) + sum(b.u)   # == 2 * sum(v)
+    r = setit_3555!(b, :u, v)
+    return sum(r) + sum(b.u)
 end
 
 @testset "Issue 3555 forward type-unstable setproperty! with used return" begin

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -346,40 +346,6 @@ end
     )[1]
     @test res[1] ≈ 2.0
     @test res[2] ≈ 2.0
-
-    dv = zeros(2)
-    Enzyme.autodiff(Reverse, Enzyme.Const(loss_3555), Active, Duplicated(copy(v), dv))
-    @test dv ≈ [2.0, 2.0]
-
-    dv1 = zeros(2)
-    dv2 = zeros(2)
-    Enzyme.autodiff(
-        Reverse, Enzyme.Const(loss_3555), Active, BatchDuplicated(copy(v), (dv1, dv2))
-    )
-    @test dv1 ≈ [2.0, 2.0]
-    @test dv2 ≈ [2.0, 2.0]
-end
-
-function loss_3555_retonly(v::Vector{Float64})
-    b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
-    r = setit_3555!(b, :u, v)
-    return sum(r)
-end
-
-@testset "Issue 3555 reverse type-unstable setproperty! with used return" begin
-    v = [1.0, 2.0]
-
-    @test Enzyme.autodiff(
-        Enzyme.Forward,
-        Enzyme.Const(loss_3555_retonly),
-        Enzyme.Duplicated(copy(v), [1.0, 0.0]),
-    )[1] ≈ 1.0
-
-    dv = zeros(2)
-    Enzyme.autodiff(
-        Reverse, Enzyme.Const(loss_3555_retonly), Active, Duplicated(copy(v), dv)
-    )
-    @test dv ≈ [1.0, 1.0]
 end
 
 # Issue 3425: an `Active` return whose inferred type is abstract routes combined

--- a/test/typeunstable.jl
+++ b/test/typeunstable.jl
@@ -346,6 +346,56 @@ end
     )[1]
     @test res[1] ≈ 2.0
     @test res[2] ≈ 2.0
+
+    dv = zeros(2)
+    Enzyme.autodiff(Reverse, Enzyme.Const(loss_3555), Active, Duplicated(copy(v), dv))
+    @test dv ≈ [2.0, 2.0]
+
+    dv1 = zeros(2)
+    dv2 = zeros(2)
+    Enzyme.autodiff(
+        Reverse, Enzyme.Const(loss_3555), Active, BatchDuplicated(copy(v), (dv1, dv2))
+    )
+    @test dv1 ≈ [2.0, 2.0]
+    @test dv2 ≈ [2.0, 2.0]
+end
+
+function loss_3555_retonly(v::Vector{Float64})
+    b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
+    r = setit_3555!(b, :u, v)
+    return sum(r)
+end
+
+@noinline function setit_3555_inner!(b::SetpropertyRetBox3555, name::Symbol, v)
+    r = setproperty!(b, name, v)
+    return sum(r)::Float64
+end
+
+function loss_3555_inner(v::Vector{Float64})
+    b = SetpropertyRetBox3555(zeros(length(v)), 0.0)
+    return setit_3555_inner!(b, :u, v)
+end
+
+@testset "Issue 3555 reverse type-unstable setproperty! with used return" begin
+    v = [1.0, 2.0]
+
+    @test Enzyme.autodiff(
+        Enzyme.Forward,
+        Enzyme.Const(loss_3555_retonly),
+        Enzyme.Duplicated(copy(v), [1.0, 0.0]),
+    )[1] ≈ 1.0
+
+    dv = zeros(2)
+    Enzyme.autodiff(
+        Reverse, Enzyme.Const(loss_3555_retonly), Active, Duplicated(copy(v), dv)
+    )
+    @test dv ≈ [1.0, 1.0]
+
+    dv = zeros(2)
+    Enzyme.autodiff(
+        Reverse, Enzyme.Const(loss_3555_inner), Active, Duplicated(copy(v), dv)
+    )
+    @test dv ≈ [1.0, 1.0]
 end
 
 # Issue 3425: an `Active` return whose inferred type is abstract routes combined


### PR DESCRIPTION
Fixes #3555. Reverse-mode half needs EnzymeAD/Enzyme#3206.

## Problem

`jl_f_setfield(obj, fld, val)` returns `val`, but `common_setfield_fwd` and `common_setfield_augfwd` both handed back the **primal** call result as the return shadow:

```julia
normal = (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing
shadowres = normal                                        # width 1
shadowres = insert_value!(B, shadowres, normal, idx - 1)  # width >= 2
```

Three symptoms from that one line:

* **forward, width 1** - the shadow of the `setproperty!` result was the primal `v`, so the reducer in #3555 returned `4.0` (`sum(v) + sum(seed)`) instead of `2.0`, and `1.0` under runtime activity (shadow == primal, so the contribution is dropped).
* **forward, width >= 2** - the `[N x ptr]` shadow was assembled from `normal` at the builder's insert point, which sits *before* the new primal call, giving `Instruction does not dominate all uses!` -> `LLVM ERROR: function failed verification (4)`. Width 1 needed no `insertvalue`, which is why it was only silently wrong there.
* **reverse** - the derivative flowing through a used `setproperty!` return was silently dropped, and batched reverse hit the same dominance crash:

  ```julia
  f(v) = sum(setit!(b, :u, v)) + sum(b.u)   # exact [2, 2],  Enzyme.Reverse gave [1, 1]
  g(v) = sum(setit!(b, :u, v))              # exact [1, 1],  Enzyme.Reverse gave [0, 0]
  ```

This is what makes the width-8 `fwddiffe8julia_setproperty_` on `ODEIntegrator` fail in forward-over-reverse Hessians for the SciMLSensitivity neural-ODE example (SciML/SciMLSensitivity.jl#1427).

## Fix

Return `invert_pointer(gutils, origops[4], B)` - the shadow of the stored value - from both rules, emitted after the shadow store so it always dominates its uses.

In forward mode, when the stored value is `Const` but the result is differentiable, follow the same convention as `jl_nthfield_fwd`: a mismatched-activity error without runtime activity, primal-as-its-own-shadow with it. Previously that case silently returned the wrong number.

Two further bugs fixed along the way:

* `common_setfield_augfwd` / `common_setfield_rev` tested `is_constant_value(gutils, origops[2])` (the struct) instead of `origops[4]` when deciding whether to invert the stored value, so a `Const` stored value into a `Duplicated` struct went through `invert_pointer` on a constant.
* `common_setfield_rev` extracted the per-batch element of a shadow *before* looking it up, so the batched path asserted in `lookupM` on an instruction whose block has no original. Look the whole shadow up first, then extract.

## Requires EnzymeAD/Enzyme#3206

Inside a callee, the shadow of the stored value is that callee's own shadow *argument*. `AdjointGenerator` tapes whatever an augmented handler returns as the call's shadow, unconditionally, and the augmented primal then needs a defining instruction to place the store, so a shadow argument crashed with `cast<Ty>() argument of incompatible type!`. EnzymeAD/Enzyme#3206 stops caching a shadow the reverse pass already has, which is the correct answer here - the argument is available in the reverse pass, so there is nothing to tape.

**Do not merge the reverse-mode commit before an `Enzyme_jll` carrying EnzymeAD/Enzyme#3206 is available.** The forward-mode commit is independent and safe with the current jll.

## Testing

Regression tests in `test/typeunstable.jl`: forward width 1, runtime activity, forward width 2, reverse, batched reverse, a variant where only the return value (not the field) is read, and one where the return value is consumed *inside* the same callee (so its shadow is needed by that callee's own reverse pass). The reducer from the issue now gives `2.0`, `2.0`, `(2.0, 2.0)`; width 3 is also correct.

Verified against Julia 1.11 with a local Enzyme build of `main` + EnzymeAD/Enzyme#3206. Passing: `basic`, `array`, `advanced`, `typeunstable`, `applyiter`, `mixed`, `mixedapplyiter`, `usermixed`, `runtime_calls`, `sugar`, `absint`, `errors`, `make_zero`, `optimize`, `recursive_accumulate`, `rooted_args`, `sparam`, `typetree`, `DiffTests`, `callconv`, `locks`, `cache_token`, `finalizers`, `method_table`, `mixedrrule`, `test_builtin_dynamic`, `threads`, `ignore_derivatives`, `core/*`, `rules/*`, `rules/internal_rules/*`, and the `ext/*` suites. `ext/bfloat16s` fails identically with and without these changes (an LLVM 16 `Cannot select: v8bf16` in the backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RAaewsVwF5wyRBfErBEEr