### PR TITLE
Fix heap corruption for custom rules with mixed sret returns in split mode (#3528)

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -737,6 +737,62 @@ mutable struct HandlerState
 end
 
 
+# Enzyme's allocation forwarding analysis (`GradientUtils::computeForwardingProperties`)
+# classifies a caller-side buffer that is only ever passed as a `writeonly` sret /
+# return-roots argument as having a "backwards-only" shadow: the shadow buffer is
+# then not materialized in the augmented forward pass (its uses are replaced by
+# `jl_nothing`) and is instead re-created from scratch in the reverse pass.
+# That is sound for Enzyme-generated code, which never writes shadow data into
+# such a buffer during the forward pass, but not for custom rules: the augmented
+# forward pass of a rule returning by sret (see `enzyme_custom_augfwd`) stores the
+# rule-provided shadow into the shadow of that buffer. Drop the write-only
+# markers from these parameters so that the shadow buffer is kept alive in the
+# forward pass and cached for the reverse pass.
+function strip_writeonly_from_sret!(llvmfn::LLVM.Function)
+    sretkind = LLVM.kind(LLVM.TypeAttribute("sret", LLVM.Int32Type()))
+    writeonlykind = LLVM.kind(LLVM.EnumAttribute("writeonly"))
+    readnonekind = LLVM.kind(LLVM.EnumAttribute("readnone"))
+    for i in 1:length(LLVM.parameters(llvmfn))
+        is_ret_ptr = false
+        for attr in collect(LLVM.parameter_attributes(llvmfn, i))
+            ekind = LLVM.kind(attr)
+            if ekind == sretkind ||
+                    ekind == "enzymejl_returnRoots" ||
+                    ekind == "enzymejl_sret_union_bytes"
+                is_ret_ptr = true
+                break
+            end
+        end
+        if !is_ret_ptr
+            continue
+        end
+        idx = LLVM.API.LLVMAttributeIndex(i)
+        for k in (writeonlykind, readnonekind)
+            LLVM.API.LLVMRemoveEnumAttributeAtIndex(llvmfn, idx, k)
+            for u in LLVM.uses(llvmfn)
+                c = LLVM.user(u)
+                if !isa(c, LLVM.CallInst)
+                    continue
+                end
+                if LLVM.called_operand(c) != llvmfn
+                    continue
+                end
+                LLVM.API.LLVMRemoveCallSiteEnumAttribute(c, idx, k)
+            end
+        end
+    end
+    return nothing
+end
+
+function strip_writeonly_from_sret!(mod::LLVM.Module)
+    for f in functions(mod)
+        if has_fn_attr(f, StringAttribute("enzyme_math", "enzyme_custom"))
+            strip_writeonly_from_sret!(f)
+        end
+    end
+    return nothing
+end
+
 function handleCustom(state::HandlerState, custom, k_name::String, llvmfn::LLVM.Function, name::String, attrs::Vector{LLVM.Attribute} = LLVM.Attribute[], setlink::Bool = true, noinl::Bool = true)
     attributes = function_attributes(llvmfn)
     custom[k_name] = linkage(llvmfn)
@@ -6269,6 +6325,7 @@ end
         memcpy_alloca_to_loadstore(mod)
         force_recompute!(mod)
         API.EnzymeDetectReadonlyOrThrow(mod)
+        strip_writeonly_from_sret!(mod)
 
         adjointf, augmented_primalf, TapeType = enzyme!(
             job,

--- a/src/internal_rules/core.jl
+++ b/src/internal_rules/core.jl
@@ -352,10 +352,20 @@ function EnzymeRules.reverse(
     rtact = EnzymeRules.runtime_activity(config)
     if EnzymeRules.needs_shadow(config)
         if EnzymeRules.width(config) == 1
-            accumulate_into(x.dval, IdDict(), shadow, x.val, Val(rtact))
+            if x isa MixedDuplicated
+                # The shadow of a mixed argument is boxed; accumulate into the
+                # boxed value and write the (possibly re-created) result back.
+                x.dval[] = accumulate_into(x.dval[], IdDict(), shadow, x.val, Val(rtact))[1]
+            else
+                accumulate_into(x.dval, IdDict(), shadow, x.val, Val(rtact))
+            end
         else
-            for i = 1:EnzymeRules.width(config)
-                accumulate_into(x.dval[i], IdDict(), shadow[i], x.val, Val(rtact))
+            for i in 1:EnzymeRules.width(config)
+                if x isa BatchMixedDuplicated
+                    x.dval[i][] = accumulate_into(x.dval[i][], IdDict(), shadow[i], x.val, Val(rtact))[1]
+                else
+                    accumulate_into(x.dval[i], IdDict(), shadow[i], x.val, Val(rtact))
+                end
             end
         end
     end

--- a/test/rules/internal_rules/deepcopy.jl
+++ b/test/rules/internal_rules/deepcopy.jl
@@ -158,3 +158,50 @@ const U0_test = [2.0]
         @test U0_test ≈ [2.0]
     end
 end
+
+# https://github.com/EnzymeAD/Enzyme.jl/issues/3528
+struct Foo3528{T}
+    foo2::T
+end
+struct Bar3528{V, S}
+    bar1::V
+    nested_foo::S
+end
+
+@testset "deepcopy of mixed-activity structs (#3528)" begin
+    # Return type Bar3528{Vector{Float64}, Foo3528{Float64}} holds both a GC
+    # pointer and an active float and is returned through the type-unstable
+    # (runtime activity) path in split reverse mode.
+    function f3528(x, b)
+        b = deepcopy(b)
+        return sum(b.nested_foo.foo2 * x .+ b.bar1)
+    end
+    b = Bar3528(zeros(3), Foo3528(1.0))
+    @test f3528(ones(3), b) ≈ 3.0
+    @static if VERSION < v"1.12"
+        @test_throws Enzyme.Compiler.MixedReturnException Enzyme.gradient(
+            set_runtime_activity(Reverse), f3528, ones(3), Const(b)
+        )
+    else
+        grad = Enzyme.gradient(set_runtime_activity(Reverse), f3528, ones(3), Const(b))
+        @test grad[1] ≈ ones(3)
+        @test grad[2] === nothing
+
+        g3528(x, b) = (deepcopy(b); sum(x))
+        grad = Enzyme.gradient(set_runtime_activity(Reverse), g3528, ones(3), Const((zeros(3), 1.0)))
+        @test grad[1] ≈ ones(3)
+
+        # Shadow accumulation into a MixedDuplicated argument.
+        h3528(x, b) = sum(deepcopy(b).bar1 .* x)
+        x = [1.0, 2.0, 3.0]
+        dx = zeros(3)
+        b2 = Bar3528([4.0, 5.0, 6.0], Foo3528(1.0))
+        db2 = Enzyme.make_zero(b2)
+        autodiff(set_runtime_activity(Reverse), h3528, Duplicated(x, dx), MixedDuplicated(b2, Ref(db2)))
+        @test dx ≈ [4.0, 5.0, 6.0]
+        @test db2.bar1 ≈ [1.0, 2.0, 3.0]
+    end
+    # Generated functions and the REPL must still work afterwards (the original
+    # failure corrupted the symbol table).
+    @test ccall(:jl_symbol, Any, (Cstring,), "lambda") === :lambda
+end


### PR DESCRIPTION
Fixes #3528.

## Symptom

On Julia 1.12, differentiating through `deepcopy` of a struct that holds both a GC pointer and an active float (e.g. `Bar{Vector{Float64}, Foo1{Float64}}`) via the runtime-activity path first raises "The function body AST defined by this @generated function is not pure" and then leaves the REPL permanently broken (`FieldError: type Expr has no field code`).

Both are downstream symptoms of heap corruption: the corrupting write clobbers Julia's symbol table, after which `jl_symbol("lambda") !== :lambda`, `jl_expand` stops recognising `lambda`/`list`/`core`, and every subsequent lowering fails.

## Root cause

The augmented forward IR of the split-mode thunk for the `deepcopy` custom rule contains

```llvm
store double %32, ptr addrspace(11) getelementptr ({ptr addrspace(10), double}, addrspacecast(@ejl_jl_nothing), i64 0, i32 1)
```

i.e. the rule-provided float shadow is written 8 bytes past the `nothing` singleton. The chain:

1. Enzyme C++ `GradientUtils::computeForwardingProperties` sees the caller's sret buffer used only by a `nocapture writeonly` call plus float loads and classifies its shadow as *backwards-only* (`backwardsOnlyShadows`): it is not materialized in the augmented forward pass and is rebuilt from scratch in the reverse pass.
2. In `ReverseModePrimal` the forward-pass shadow placeholder is replaced with `getUndefinedValueForType`, which Enzyme.jl's callback (`julia_undef_value_for_type`) maps to `jl_nothing`.
3. That is sound for Enzyme-generated code, whose shadow stores are replayed in the reverse pass, but `enzyme_custom_augfwd` stores the shadow returned by the rule into the shadow of the sret buffer during the forward pass (`extract_nonjlvalues_into!`). That store now targets `jl_nothing`.

This only triggers for custom rules returning a mixed-activity aggregate through the 1.12 sret + return-roots ABI in split reverse mode. Combined mode always materializes the shadow, and Julia ≤ 1.11 raises `MixedReturnException` before reaching the write-back (this path was opened up by #2915).

Minimal reproducers (no `Base.deepcopy` needed for the second):

```julia
using Enzyme
g(x, b) = (deepcopy(b); sum(x))
Enzyme.gradient(set_runtime_activity(Reverse), g, ones(3), Const((zeros(3), 1.0)))
```

```julia
mydc(x) = Base.deepcopy_internal(x, IdDict())::typeof(x)
# augmented_primal returns AugmentedReturn(primal, make_zero(primal), shadow); reverse returns (nothing,)
fwd, rev = Enzyme.autodiff_thunk(set_runtime_activity(ReverseSplitWithPrimal),
                                 Const{typeof(mydc)}, Duplicated, Const{Tuple{Vector{Float64},Float64}})
fwd(Const(mydc), Const(([1.0,2.0,3.0], 4.0)))   # heap corruption
```

## Fix

- `src/compiler.jl`: `strip_writeonly_from_sret!` drops `writeonly`/`readnone` from the sret / return-roots parameters of every function that has a custom rule (declaration and call sites). The C++ analysis then treats the call as load-like and keeps the shadow buffer alive in the forward pass. This has to run right before `enzyme!`: the early `optimize!` pipeline re-infers `writeonly` if it is stripped earlier.
- `src/internal_rules/core.jl`: the `deepcopy` reverse rule now handles `MixedDuplicated` / `BatchMixedDuplicated` arguments (boxed shadow). Once the crash was gone, the issue's example hit a `MethodError` here.
- `test/rules/internal_rules/deepcopy.jl`: regression tests for the issue's struct, the tuple variant, shadow accumulation into a `MixedDuplicated` argument, and a symbol-table sanity check.

## Verification

| Check | Julia 1.12.7 | Julia 1.11.9 |
|---|---|---|
| Issue reproducer | `([1.0, 1.0, 1.0], nothing)` | `MixedReturnException` (unchanged) |
| `rules/mixedreturn.jl`, `rules/mixederror.jl` | 2/2, 2/2 | 2/2, 2/2 |
| `rules/internal_rules/deepcopy.jl` | 28/28 | 24/24 |
| `rules/{rrules,rules,easyrules,kwrrules,inactive_kwrules,sret_union_test,rule_inlining,rule_return_errors,make_zero}.jl`, `mixedapplyiter.jl`, `rooted_args.jl` | pass, identical to baseline | not run |

## Related problems found but not addressed here

- **Float adjoints of a `Duplicated` mixed-activity return never reach the reverse rule.** `g(x, b) = (c = deepcopy((b, x)); c[2] * sum(c[1]))` gives `0.0` instead of `6.0`. The rule only receives `Type{Duplicated{...}}` and its tape, so the adjoint accumulated in the shadow sret is dropped. Design limitation of #2915; also affects combined mode.
- **The same C++ mechanism affects arguments.** A custom rule on `scale!(r::Ref{Float64})` in split mode receives a bogus `dval` in `augmented_primal` (it reads back as `5.7e-322`); any rule that touches `dval` in its forward pass corrupts memory. The `writeonly` trick does not cover float-only buffers; this needs Enzyme C++ to treat calls with custom derivative handlers as non-promotable in `computeForwardingProperties`.
- `BatchMixedDuplicated` arguments through `deepcopy` fail with `n_shadow_roots == n_primal_roots + 1` in `enzyme_custom_setup_args` (pre-existing, reproduced on an unmodified baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XELWaarsZdSjzHANnWjHMY
