### PR TITLE
Key the 1.12 sret rewrite on the ABI in the IR, not on a version bound

### DIFF
--- a/src/llvm/transforms.jl
+++ b/src/llvm/transforms.jl
@@ -253,6 +253,25 @@ function rewrite_ccalls!(mod::LLVM.Module)
     end
 end
 
+"""
+    fixup_1p12_sret!(f::LLVM.Function)
+
+Rewrite the untyped store of a return value that needs both an `sret` buffer and a
+`returnRoots` array into field-wise stores that skip the GC-tracked slots.
+
+Julia 1.12 changed the convention for such a return: the callee writes the tracked
+pointers only into `returnRoots` and leaves the corresponding slots of the `sret`
+buffer undefined, so a caller has to recombine the two halves (which is what
+[`recombine_value!`](@ref) does). Codegen spells the write of the remaining, inline
+data as a single untyped `llvm.memcpy` out of an `[N x i64]` alloca, which also
+drags the undefined bytes into the tracked slots -- and Enzyme would then take those
+for live `jlvalue`s. Replacing the memcpy with stores of just the untracked fields
+keeps the tracked slots alone, matching what the convention promises the caller.
+
+The rewrite is keyed on the ABI actually present in the IR rather than on a version
+bound: it only fires for a `memcpy` whose destination parameter carries an `sret`
+attribute for exactly `RT`.
+"""
 function fixup_1p12_sret!(f::LLVM.Function)
     if VERSION < v"1.12"
         return
@@ -268,10 +287,16 @@ function fixup_1p12_sret!(f::LLVM.Function)
         return
     end
 
+    lltype = convert(LLVMType, RT)
+
+    # Bail out if parameter 1 is not the `sret` buffer holding an `RT`, i.e. if the
+    # calling convention is not the one this rewrite knows about.
+    if sret_ty(f, 1, #=btval=# nothing, #=throw_error=# false) != lltype
+        return
+    end
+
     dl = datalayout(LLVM.parent(f))
 
-    @assert VERSION < v"1.13"
-    #TODO for 1.13 fixup this
     torep = LLVM.Instruction[]
     for u in LLVM.uses(parameters(f)[1])
         ci = LLVM.user(u)
@@ -287,7 +312,6 @@ function fixup_1p12_sret!(f::LLVM.Function)
     end
 
     if length(torep) > 0
-	lltype = convert(LLVMType, RT)
         sz = LLVM.sizeof(dl, lltype)
         for ci in torep
             cst = operands(ci)[3]::LLVM.ConstantInt

--- a/test/callconv.jl
+++ b/test/callconv.jl
@@ -132,6 +132,46 @@ end
     @test dx == (1.0, ((0.0, 0.0), (0.0, 0.0)))
 end
 
+struct ResultOk{A <: AbstractArray}
+    x::A
+    ok::Bool
+end
+@noinline scale_ok(v::Vector{Float64}) = ResultOk(v .* 2, true)
+f_sret_roots_struct(v) = sum(scale_ok(v).x)
+
+@noinline scale_sum(v::Vector{Float64}) = (v .* 2, sum(v))
+f_sret_roots_tuple(v) = last(scale_sum(v))
+f_sret_roots_tuple_arr(v) = sum(first(scale_sum(v)))
+
+struct TwoRooted{A, B}
+    a::A
+    b::B
+    n::Int
+    s::Float64
+end
+@noinline two_rooted(v::Vector{Float64}) = TwoRooted(v .* 2, v .* 3, length(v), sum(v))
+f_sret_roots_two(v) = sum(two_rooted(v).a) + sum(two_rooted(v).b)
+
+# A return value that needs both an `sret` buffer and a `returnRoots` array: Julia 1.12+
+# leaves the GC-tracked slots of the buffer undefined and passes those pointers through
+# the roots array only, spelling the write of the remaining inline data as one untyped
+# memcpy. `fixup_1p12_sret!` has to split that memcpy so the undefined bytes never reach
+# the tracked slots (#3566).
+@testset "Sret With ReturnRoots" begin
+    for (f, expected) in (
+            (f_sret_roots_struct, [2.0, 2.0, 2.0]),
+            (f_sret_roots_tuple, [1.0, 1.0, 1.0]),
+            (f_sret_roots_tuple_arr, [2.0, 2.0, 2.0]),
+            (f_sret_roots_two, [5.0, 5.0, 5.0]),
+        )
+        v = [1.0, 2.0, 3.0]
+        dv = zero(v)
+        Enzyme.autodiff(Reverse, f, Active, Duplicated(v, dv))
+        @test dv ≈ expected
+        @test Enzyme.autodiff(Forward, f, Duplicated(v, [1.0, 0.0, 0.0]))[1] ≈ expected[1]
+    end
+end
+
 const M_test = [1.0 0.2 0.0; 0.0 1.0 0.1; 0.3 0.0 1.0]
 inner_test(t) = sum((M_test * t) .^ 2)
 g_test(p) = sum(Enzyme.gradient(Enzyme.set_runtime_activity(Enzyme.Reverse), inner_test, p)[1])


### PR DESCRIPTION
Fixes #3566.

### The problem

`fixup_1p12_sret!` handles a return value that needs both an `sret` buffer and a `returnRoots` array — an ordinary immutable struct or tuple with a GC-tracked field. Julia 1.12 changed the convention for these: the callee writes the tracked pointers *only* into `returnRoots` and leaves the matching slots of the `sret` buffer undefined, so the caller recombines the two halves (`recombine_value!`). Codegen spells the write of the remaining inline data as one untyped `llvm.memcpy` out of an `[N x i64]` alloca, which drags those undefined bytes into the tracked slots as well; the rewrite splits that memcpy into field-wise stores so Enzyme never takes the undefined bytes for live jlvalues.

That rewrite carried an `@assert VERSION < v"1.13"` next to a `#TODO for 1.13 fixup this`, added in #2892 back in January while 1.13 was still nightly-only. Nothing ever exercised it. Now that 1.13 has shipped it fires for every such return, `prepare_llvm` aborts, and reverse mode is unusable for any function returning a struct with a tracked field.

The blast radius is wider than the issue reports — at baseline on 1.13, `test/basic.jl`, `test/usermixed.jl` and `test/callconv.jl` all abort on this one assert.

### The fix

1.13 emits exactly the same shape as 1.12 — an `[N x i64]` alloca whose tracked slots are never stored, one full-size untyped memcpy into the sret parameter, the tracked pointer stored only into `return_roots`. The convention did not move.

So guard on the shape actually present in the IR instead of on a version bound:

```julia
lltype = convert(LLVMType, RT)
# Bail out if parameter 1 is not the `sret` buffer holding an `RT`
if sret_ty(f, 1, #=btval=# nothing, #=throw_error=# false) != lltype
    return
end
```

This unblocks 1.13 and leaves nothing to revisit at the next version bump, while still declining to touch a convention this code does not recognize. A docstring now records what the rewrite is for.

### Verification

- **1.12 equivalence** — the only semantic change on 1.12 is the new guard. Instrumented across `basic`, `applyiter`, `mixedapplyiter`, `usermixed`, `callconv` and `passes`, it accepts all 27 rewrites the assert-guarded version performed and rejects none.
- **1.13** — `basic`, `usermixed`, `callconv`, `applyiter`, `mixedapplyiter`, `rooted_args`, `mixed`, `passes` and `typeunstable` pass. Gradients were checked against hand-computed values for an immutable struct, a tuple, a two-tracked-pointer struct, a nested struct, a `Float32` payload, forward mode and `ReverseWithPrimal` — not just that compilation succeeds.
- The new `Sret With ReturnRoots` testset in `test/callconv.jl` fails on 1.13 without the patch and passes with it; it also passes on 1.10, 1.11 and 1.12.

Two 1.13 failures remain in a full run and are **not** touched by this PR — `advanced.jl` "Copy Broadcast arg" (`IllegalTypeAnalysisException`) and `absint.jl` "Absint load of constantexpr gep HVP" (the subject of #3475). Both reproduce identically with and without the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ5ChmjzPnFgFkRJbDYN8