### PR TITLE
Test uuid4 through the i128 mask fix

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -28,6 +28,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [sources]
 Enzyme = {path = ".."}

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,6 +1,7 @@
 using Enzyme
 using Statistics
 using Random
+using UUIDs
 using Test
 
 include("common.jl")
@@ -892,4 +893,19 @@ end
         @test Enzyme.autodiff(Forward, rand_device, Duplicated(2.0, 1.0), Const(out)) == (2.0,)
         @test Enzyme.autodiff(Reverse, rand_device, Active(2.0), Const(out)) == ((2.0, nothing),)
     end
+end
+
+# Issue #2464: `uuid4()` masks a `UInt128` with the RFC 4122 version/variant
+# constant, which does not fit in 64 bits. Type analysis used to sign-extend it
+# and abort the process (fixed in EnzymeAD/Enzyme#3205, Enzyme_jll 0.0.293).
+function make_uuid4(x::Float64, out::Vector{UUIDs.UUID})
+    out[1] = UUIDs.uuid4()
+    return x * 2.0
+end
+
+@testset "uuid4 i128 mask" begin
+    out = [UUIDs.UUID(0)]
+    @test Enzyme.autodiff(Forward, make_uuid4, Duplicated(2.0, 1.0), Const(out)) == (2.0,)
+    @test out[1] != UUIDs.UUID(0)
+    @test Enzyme.autodiff(Reverse, make_uuid4, Active(2.0), Const(out)) == ((2.0, nothing),)
 end


### PR DESCRIPTION
Follow-up to #3557, part of #2464.

`uuid4()` masks a `UInt128` with the RFC 4122 version/variant constant `0xffffffffffff0fff3fffffffffffffff`. Type analysis sign-extended that constant and tripped the `APInt::getSExtValue` assertion, aborting the Julia process rather than raising an error. EnzymeAD/Enzyme#3205 fixed it and Enzyme_jll 0.0.293 ships the fix, which main already requires, so the test deferred from #3557 can land now.

Verified against Enzyme_jll 0.0.293 on Julia 1.12: both testsets pass, and the `uuid4` one aborted the process on 0.0.292.

This closes out the crash reported in #2464. The remaining failure there is not an Enzyme crash: `AbstractMCMC.mcmcsample` rebinds its `progress::Union{Bool,<:AbstractProgressKwarg}` keyword and the logger closure captures it, so Julia boxes a Union and Enzyme reports the documented `IllegalTypeAnalysisException`. That needs an upstream change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcTbLNBXz7VEHFHMXHcFdp