### PR TITLE
Rewrap Vararg into a Tuple binding environment in absint

### DIFF
--- a/src/absint.jl
+++ b/src/absint.jl
@@ -139,9 +139,16 @@ function absint(@nospecialize(arg::LLVM.Value), partial::Bool = false, istracked
 
                 if legal
                     res = Ty{found...}
+                    # A `Vararg` must not be wrapped in a `UnionAll` directly (deprecated),
+                    # so build the binding environment around a `Tuple` and rewrap `res`
+                    # into it. `rewrap_unionall` dispatches on `Core.TypeofVararg` and
+                    # pushes the bindings into the element type, leaving the `Vararg`
+                    # itself unwrapped; for every other `Ty` it is the plain loop.
+                    env = Tuple{res}
                     for u in unionalls
-                        res = UnionAll(u, res)
+                        env = UnionAll(u, env)
                     end
+                    res = Base.rewrap_unionall(res, env)
                     return (true, res)
                 end
             end


### PR DESCRIPTION
Replaces #3358, applying the `rewrap_unionall` approach from [that review thread](https://github.com/EnzymeAD/Enzyme.jl/pull/3358#issuecomment-5023809948).

`absint`'s `jl_f_apply_type` handler binds arguments it could not deduce by wrapping the result in a `UnionAll`. When the deduced type is a `Vararg`, that is the deprecated `Vararg{T} where T` form, so 1.11+ prints

```
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
```

22 times in `rules/internal_rules/sparsearrays_rules` alone, and downstream CIs are flooded with it (#3358 comments).

This builds the binding environment around `Tuple{res}` and rewraps `res` into it. `Base.rewrap_unionall` has a [`Core.TypeofVararg` method](https://github.com/JuliaLang/julia/blob/e9fc2544ac66c6b9fcf9689113601f8f80060562/base/essentials.jl#L560) that pushes the bindings into the element type and leaves the `Vararg` itself unwrapped, so a single code path covers both the `Vararg` and the ordinary case.

### Why not the `Tuple{res}` round trip in #3358

#3358 wraps in `Tuple`, binds, then takes `Base.unwrap_unionall(res).parameters[1]` back out. `Tuple{...}` normalizes a `Vararg` with a concrete length, so that does not round-trip: `Tuple{Vararg{Int,2}}.parameters` is `svec(Int64, Int64)`, and `Tuple{Vararg{Int,0}}` is `Tuple{}` with no parameters at all. Comparing all three versions over the reachable inputs:

| `apply_type` args | before | #3358 | this PR |
|---|---|---|---|
| `Vararg, Int, 2` | `Vararg{Int64, 2}` | **`Int64`** | `Vararg{Int64, 2}` |
| `Vararg, Int, 0` | `Vararg{Int64, 0}` | **`BoundsError`** | `Vararg{Int64, 0}` |
| `Vararg, Int` | `Vararg{Int64}` | `Vararg{Int64}` | `Vararg{Int64}` |
| `Vararg, <unknown>` | `Vararg{Any}` | `Vararg{sarg1}` (free tyvar) | `Vararg{Any}` |
| `Vararg, Int, <unknown>` | `Vararg{Int64}` | `Vararg{Int64, sarg2}` (free tyvar) | `Vararg{Int64}` |
| `Vararg, <unknown>, <unknown>` | `Vararg{Any}` | `Vararg{sarg1, sarg2}` (free tyvar) | `Vararg{Any}` |
| `Array, <unknown>, 1` | `Vector` | `Vector` | `Vector` |

So this PR reproduces the previous result exactly on every input while emitting no warning, whereas #3358 corrupts or throws on a `Vararg` with a concrete length and leaks unbound `TypeVar`s into the caller's `Ty{found...}` splice.

### Testing

`rules/internal_rules/sparsearrays_rules` on Julia 1.12.7 with `--depwarn=yes`: 22 warnings before, 0 after, all 5714 tests passing. Identical results verified on 1.10.12 and 1.11 for the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SmhTf2kXQTFts7EwDqMRb
