### PR TITLE
Tell the use analysis that the getfield rules need their object shadow

### DIFF
--- a/src/rules/llvmrules.jl
+++ b/src/rules/llvmrules.jl
@@ -244,6 +244,16 @@ include("parallelrules.jl")
     return false
 end
 
+@register_diffuse function jlcall_diffuse(orig::LLVM.CallInst, gutils::GradientUtils, @nospecialize(val::LLVM.Value), isshadow::Bool, mode::API.CDerivativeMode)
+    F = operands(orig)[1]
+    if isa(F, LLVM.Function)
+        if in(LLVM.name(F), ("ijl_f_getfield", "jl_f_getfield"))
+            return common_jl_getfield_diffuse(2, orig, gutils, val, isshadow, mode)
+        end
+    end
+    return (false, true)
+end
+
 @register_aug function jlcall_augfwd(B, orig, gutils, normalR, shadowR, tapeR)
     F = operands(orig)[1]
     if isa(F, LLVM.Function)
@@ -2286,6 +2296,12 @@ end
         "enzyme_custom",
         @diffusefunc(enzyme_custom_diffuse)
     )
+    for nm in ("julia.call", "julia.call2")
+        API.EnzymeRegisterDiffUseCallHandler(nm, @diffusefunc(jlcall_diffuse))
+    end
+    for nm in ("jl_f_getfield", "ijl_f_getfield")
+        API.EnzymeRegisterDiffUseCallHandler(nm, @diffusefunc(jl_getfield_diffuse))
+    end
     register_handler!(
         ("julia.call",),
         @augfunc(jlcall_augfwd),

--- a/src/rules/typeunstablerules.jl
+++ b/src/rules/typeunstablerules.jl
@@ -1839,6 +1839,38 @@ end
     common_jl_getfield_rev(1, B, orig, gutils, tape)
 end
 
+"""
+    common_jl_getfield_diffuse(offset, orig, gutils, val, isshadow, mode)
+
+`common_jl_getfield_rev` calls `invert_pointer` on the object it reads from and
+then `lookup_value` on the result, so that shadow is consumed by the reverse
+pass. Enzyme's differential use analysis cannot see inside an LLVM rule, so
+without this handler it can conclude that the shadow is dead, erase the
+placeholder the rule already consumed, and fail with "Erased value with a use".
+"""
+function common_jl_getfield_diffuse(
+        offset,
+        @nospecialize(orig::LLVM.CallInst),
+        gutils::GradientUtils,
+        @nospecialize(val::LLVM.Value),
+        isshadow::Bool,
+        mode::API.CDerivativeMode,
+    )
+    # Only the shadow query is affected; let the default logic answer the rest.
+    if !isshadow || is_constant_value(gutils, orig)
+        return (false, true)
+    end
+    ops = @view operands(orig)[offset:end]
+    if length(ops) >= 2 && val == ops[2] && !is_constant_value(gutils, ops[2])
+        return (true, false)
+    end
+    return (false, true)
+end
+
+@register_diffuse function jl_getfield_diffuse(orig::LLVM.CallInst, gutils::GradientUtils, @nospecialize(val::LLVM.Value), isshadow::Bool, mode::API.CDerivativeMode)
+    return common_jl_getfield_diffuse(1, orig, gutils, val, isshadow, mode)
+end
+
 function common_setfield_fwd(offset, B, orig, gutils, normalR, shadowR)
     normal =
         (unsafe_load(normalR) != C_NULL) ? LLVM.Instruction(unsafe_load(normalR)) : nothing


### PR DESCRIPTION
Part of #2464.

`common_jl_getfield_rev` calls `invert_pointer` on the object it reads a field from, then `lookup_value` on the result. That materializes the object's shadow and builds a scope cache for it, so the shadow is genuinely consumed by the reverse pass.

Enzyme's differential use analysis cannot see inside an LLVM rule. We register exactly one DiffUse handler, `enzyme_custom`; every other rule has augmented/reverse/forward handlers and no DiffUse handler, so enzyme-core falls back to its default reasoning. For this shape it concludes the object's shadow is dead, and `visitLoadLike` erases the placeholder the rule has already consumed:

```
Erased value with a use
```

This registers a DiffUse handler for `jl_f_getfield` / `ijl_f_getfield`, and for `julia.call` / `julia.call2` wrapping them, reporting the object operand's shadow as needed whenever the rule would invert it. Everything else returns `useDefault`, so the default logic is unchanged.

One detail worth knowing for future handlers: enzyme-core looks DiffUse handlers up via `getFuncNameFromCall`, which returns the *called operand* — `julia.call` — and not the inner callee. A handler registered only under `jl_f_getfield` never fires for the wrapped form, which is the form Julia actually emits here.

### Effect

This is what blocked differentiating a Turing model that calls `sample` internally, through the chain indexing in `chn[:prob]`. Reverse mode on the reproducer from #2464 now completes.

### Testing

Verified against released Enzyme_jll 0.0.293, no enzyme-core change needed:

- the reduced reproducer returns the exact analytic gradient in both forward and reverse
- the full #2464 reproducer completes in reverse and matches central finite differences to 0.2% (the Metropolis-Hastings accept/reject makes it slightly non-smooth, so the RNG has to be seeded per evaluation)
- `test/typeunstable.jl`, `test/basic.jl`, `test/sugar.jl`, `test/mixed.jl`, `test/applyiter.jl`, `test/runtime_calls.jl` and `test/usermixed.jl` all pass

No regression test, and I would rather say so than bury it. Twelve synthetic variants all pass on an unpatched build: plain vectors, `OrderedDict` keysets, loop-carried phis, `Any`-typed getfield results, `Const` and `Duplicated` containers. Whether the object's shadow is materialized at all depends on the surrounding shadow ordering, which is what makes it hard to provoke in a small function. I also considered `test/integration/Turing`, but it pins `Turing = "=0.42.1"`, which predates the chain type whose indexing triggers this, so a test added there probably would not exercise the path. Happy to keep trying, or to bump that pin separately, if you would rather this not land untested.

Forward mode on the full #2464 reproducer additionally needs EnzymeAD/Enzyme#3213; reverse mode needs only this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcTbLNBXz7VEHFHMXHcFdp